### PR TITLE
Maintain spaces and newlines in model output

### DIFF
--- a/src/components/OutputsTable/OutputCell.tsx
+++ b/src/components/OutputsTable/OutputCell.tsx
@@ -92,5 +92,5 @@ export default function OutputCell({
     );
   }
 
-  return <Box>{message?.content ?? JSON.stringify(output.data.output)}</Box>;
+  return <Box whiteSpace="pre-wrap">{message?.content ?? JSON.stringify(output.data.output)}</Box>;
 }


### PR DESCRIPTION
This fixes a bug in which model outputs were stripped of whitespace characters like newlines.

Output before:
![Screenshot 2023-06-30 at 5 44 16 PM](https://github.com/corbt/prompt-lab/assets/41524992/5e4085fe-8c73-4ae3-8ce6-d8a6c5e5ae75)


Output after:
![Screenshot 2023-06-30 at 5 43 53 PM](https://github.com/corbt/prompt-lab/assets/41524992/719ea271-74a4-41a8-9892-351c3e6624c3)
