### PR TITLE
Add AutoResizeTextArea

### DIFF
--- a/src/components/AutoResizeTextArea.tsx
+++ b/src/components/AutoResizeTextArea.tsx
@@ -1,0 +1,24 @@
+import { Textarea, type TextareaProps } from "@chakra-ui/react";
+import ResizeTextarea from "react-textarea-autosize";
+import React from "react";
+
+export const AutoResizeTextarea: React.ForwardRefRenderFunction<
+  HTMLTextAreaElement,
+  TextareaProps
+> = (props, ref) => {
+  return (
+    <Textarea
+      minH="unset"
+      overflow="hidden"
+      w="100%"
+      resize="none"
+      ref={ref}
+      minRows={1}
+      transition="height none"
+      as={ResizeTextarea}
+      {...props}
+    />
+  );
+};
+
+export default React.forwardRef(AutoResizeTextarea);

--- a/src/components/OutputsTable/ScenarioEditor.tsx
+++ b/src/components/OutputsTable/ScenarioEditor.tsx
@@ -4,12 +4,12 @@ import { isEqual } from "lodash";
 import { type Scenario } from "./types";
 import { useExperiment, useHandledAsyncCallback } from "~/utils/hooks";
 import { useState } from "react";
-import ResizeTextarea from "react-textarea-autosize";
 
-import { Box, Button, Flex, HStack, Icon, Stack, Textarea, Tooltip } from "@chakra-ui/react";
+import { Box, Button, Flex, HStack, Icon, Stack, Tooltip } from "@chakra-ui/react";
 import { cellPadding } from "../constants";
 import { BsX } from "react-icons/bs";
 import { RiDraggable } from "react-icons/ri";
+import AutoResizeTextArea from "../AutoResizeTextArea";
 
 export default function ScenarioEditor({
   scenario,
@@ -132,7 +132,7 @@ export default function ScenarioEditor({
                 <Box bgColor="blue.100" color="blue.600" px={2} my="3px" fontSize="xs" fontWeight="bold">
                   {key}
                 </Box>
-                <Textarea
+                <AutoResizeTextArea
                   px={2}
                   py={1}
                   placeholder="empty"
@@ -150,9 +150,6 @@ export default function ScenarioEditor({
                   }}
                   resize="none"
                   overflow="hidden"
-                  minRows={1}
-                  minH="unset"
-                  as={ResizeTextarea}
                   flex={layoutDirection === "row" ? 1 : undefined}
                   borderColor={hasChanged ? "blue.300" : "transparent"}
                   _hover={{ borderColor: "gray.300" }}

--- a/src/components/OutputsTable/VariantHeader.tsx
+++ b/src/components/OutputsTable/VariantHeader.tsx
@@ -2,10 +2,11 @@ import { useState, type DragEvent } from "react";
 import { type PromptVariant } from "./types";
 import { api } from "~/utils/api";
 import { useHandledAsyncCallback } from "~/utils/hooks";
-import { Button, HStack, Input, Icon, Tooltip } from "@chakra-ui/react"; // Changed here
+import { Button, HStack, Icon, Tooltip } from "@chakra-ui/react"; // Changed here
 import { BsX } from "react-icons/bs";
 import { RiDraggable } from "react-icons/ri";
 import { cellPadding, headerMinHeight } from "../constants";
+import AutoResizeTextArea from "../AutoResizeTextArea";
 
 export default function VariantHeader(props: { variant: PromptVariant }) {
   const utils = api.useContext();
@@ -76,11 +77,12 @@ export default function VariantHeader(props: { variant: PromptVariant }) {
         color="gray.400"
         _hover={{ color: "gray.800", cursor: "pointer" }}
       />
-      <Input // Changed to Input
+      <AutoResizeTextArea // Changed to Input
         size="sm"
         value={label}
         onChange={(e) => setLabel(e.target.value)}
         onBlur={onSaveLabel}
+        placeholder="Variant Name"
         borderWidth={1}
         borderColor="transparent"
         fontWeight="bold"


### PR DESCRIPTION
Before, long variant header titles were cut off.

Before:
<img width="740" alt="Screenshot 2023-07-01 at 7 47 08 AM" src="https://github.com/corbt/prompt-lab/assets/41524992/2403be04-cecc-45ac-95e7-1cb2b0343720">

After:
<img width="757" alt="Screenshot 2023-07-01 at 7 47 30 AM" src="https://github.com/corbt/prompt-lab/assets/41524992/75905be0-9e8a-42e6-8eee-546fe6d1bfde">
