### PR TITLE
Add request cost to OutputStats

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -9,15 +9,15 @@ export type JSONSerializable =
 // Placeholder for now
 export type OpenAIChatConfig = NonNullable<JSONSerializable>;
 
-export enum OpenAIChatModels {
+export enum OpenAIChatModel {
   "gpt-4" = "gpt-4",
   "gpt-4-0613" = "gpt-4-0613",
   "gpt-4-32k" = "gpt-4-32k",
   "gpt-4-32k-0613" = "gpt-4-32k-0613",
   "gpt-3.5-turbo" = "gpt-3.5-turbo",
-  "gpt-3.5-turbo-16k" = "gpt-3.5-turbo-16k",
   "gpt-3.5-turbo-0613" = "gpt-3.5-turbo-0613",
+  "gpt-3.5-turbo-16k" = "gpt-3.5-turbo-16k",
   "gpt-3.5-turbo-16k-0613" = "gpt-3.5-turbo-16k-0613",
 }
 
-type SupportedModel = keyof typeof OpenAIChatModels;
+export type SupportedModel = keyof typeof OpenAIChatModel;

--- a/src/server/utils/getModelName.ts
+++ b/src/server/utils/getModelName.ts
@@ -1,0 +1,8 @@
+import { isObject } from "lodash";
+import { type JSONSerializable, type SupportedModel } from "../types";
+
+export function getModelName(config: JSONSerializable): SupportedModel | null {
+  if (!isObject(config)) return null;
+  if ("model" in config && typeof config.model === "string") return config.model as SupportedModel;
+  return null
+}

--- a/src/utils/calculateTokenCost.ts
+++ b/src/utils/calculateTokenCost.ts
@@ -1,0 +1,39 @@
+import { type SupportedModel, OpenAIChatModel } from "~/server/types";
+
+const openAIPromptTokensToDollars: { [key in OpenAIChatModel]: number } = {
+  "gpt-4": 0.00003,
+  "gpt-4-0613": 0.00003,
+  "gpt-4-32k": 0.00006,
+  "gpt-4-32k-0613": 0.00006,
+  "gpt-3.5-turbo": 0.0000015,
+  "gpt-3.5-turbo-0613": 0.0000015,
+  "gpt-3.5-turbo-16k": 0.000003,
+  "gpt-3.5-turbo-16k-0613": 0.000003,
+};
+
+const openAICompletionTokensToDollars: { [key in OpenAIChatModel]: number } = {
+  "gpt-4": 0.00006,
+  "gpt-4-0613": 0.00006,
+  "gpt-4-32k": 0.00012,
+  "gpt-4-32k-0613": 0.00012,
+  "gpt-3.5-turbo": 0.000002,
+  "gpt-3.5-turbo-0613": 0.000002,
+  "gpt-3.5-turbo-16k": 0.000004,
+  "gpt-3.5-turbo-16k-0613": 0.000004,
+};
+
+export const calculateTokenCost = (model: SupportedModel, numTokens: number, isCompletion = false) => {
+    if (model in OpenAIChatModel) {
+        return calculateOpenAIChatTokenCost(model as OpenAIChatModel, numTokens, isCompletion);
+    }
+    return 0;
+}
+
+const calculateOpenAIChatTokenCost = (
+  model: OpenAIChatModel,
+  numTokens: number,
+  isCompletion: boolean
+) => {
+    const tokensToDollars = isCompletion ? openAICompletionTokensToDollars[model] : openAIPromptTokensToDollars[model];
+    return tokensToDollars * numTokens;
+};

--- a/src/utils/countTokens.ts
+++ b/src/utils/countTokens.ts
@@ -1,6 +1,6 @@
 import { type ChatCompletion } from "openai/resources/chat";
 import { GPTTokens } from "gpt-tokens";
-import { type OpenAIChatModels } from "~/server/types";
+import { type OpenAIChatModel } from "~/server/types";
 
 interface GPTTokensMessageItem {
   name?: string;
@@ -9,7 +9,7 @@ interface GPTTokensMessageItem {
 }
 
 export const countOpenAIChatTokens = (
-  model: OpenAIChatModels,
+  model: OpenAIChatModel,
   messages: ChatCompletion.Choice.Message[]
 ) => {
   return new GPTTokens({ model, messages: messages as unknown as GPTTokensMessageItem[] })


### PR DESCRIPTION
This PR allows the user to see token costs for individual cells, not for the prompt variant as a whole.

## Changes
* Add `getModelName`
* Add `calculateTokenCost`
* Display total cost of tokens in output stats

Before:
<img width="970" alt="Screenshot 2023-07-06 at 2 31 19 PM" src="https://github.com/corbt/querykey/assets/41524992/9834d1b6-5809-4c5c-a4a6-21834c28a103">


After:
<img width="944" alt="Screenshot 2023-07-06 at 2 31 00 PM" src="https://github.com/corbt/querykey/assets/41524992/b44d2ed7-40ef-402a-a38b-a6963dd0c084">
