### PR TITLE
Add total token cost to variant stats

### DIFF
--- a/src/components/OutputsTable/EditEvaluations.tsx
+++ b/src/components/OutputsTable/EditEvaluations.tsx
@@ -105,7 +105,7 @@ export default function EditEvaluations() {
   const [onDelete] = useHandledAsyncCallback(async (id: string) => {
     await deleteMutation.mutateAsync({ id });
     await utils.evaluations.list.invalidate();
-    await utils.evaluations.results.invalidate();
+    await utils.promptVariants.stats.invalidate();
   }, []);
 
   const [onSave] = useHandledAsyncCallback(async (id: string | undefined, vals: EvalValues) => {
@@ -124,7 +124,7 @@ export default function EditEvaluations() {
       });
     }
     await utils.evaluations.list.invalidate();
-    await utils.evaluations.results.invalidate();
+    await utils.promptVariants.stats.invalidate();
   }, []);
 
   const onCancel = useCallback(() => {

--- a/src/components/OutputsTable/OutputCell.tsx
+++ b/src/components/OutputsTable/OutputCell.tsx
@@ -65,7 +65,7 @@ export default function OutputCell({
       channel,
     });
     setOutput(output);
-    await utils.evaluations.results.invalidate();
+    await utils.promptVariants.stats.invalidate();
   }, [outputMutation, scenario.id, variant.id, channel]);
 
   useEffect(fetchOutput, []);

--- a/src/components/OutputsTable/VariantStats.tsx
+++ b/src/components/OutputsTable/VariantStats.tsx
@@ -1,14 +1,14 @@
-import { HStack, Text, useToken } from "@chakra-ui/react";
+import { HStack, Icon, Text, useToken } from "@chakra-ui/react";
 import { type PromptVariant } from "./types";
 import { cellPadding } from "../constants";
 import { api } from "~/utils/api";
 import chroma from "chroma-js";
+import { BsCurrencyDollar } from "react-icons/bs";
 
 export default function VariantStats(props: { variant: PromptVariant }) {
-  const evalResults =
-    api.evaluations.results.useQuery({
-      variantId: props.variant.id,
-    }).data ?? [];
+  const { evalResults, overallCost } = api.promptVariants.stats.useQuery({
+    variantId: props.variant.id,
+  }).data ?? { evalResults: [] };
 
   const [passColor, neutralColor, failColor] = useToken("colors", [
     "green.500",
@@ -18,21 +18,29 @@ export default function VariantStats(props: { variant: PromptVariant }) {
 
   const scale = chroma.scale([failColor, neutralColor, passColor]).domain([0, 0.5, 1]);
 
-  if (!(evalResults.length > 0)) return null;
+  if (!(evalResults.length > 0) && !overallCost) return null;
 
   return (
-    <HStack px={cellPadding.x} py={cellPadding.y} fontSize="sm">
-      {evalResults.map((result) => {
-        const passedFrac = result.passCount / (result.passCount + result.failCount);
-        return (
-          <HStack key={result.id}>
-            <Text>{result.evaluation.name}</Text>
-            <Text color={scale(passedFrac).hex()} fontWeight="bold">
-              {(passedFrac * 100).toFixed(1)}%
-            </Text>
-          </HStack>
-        );
-      })}
+    <HStack justifyContent="space-between" alignItems="center" mx="2">
+      <HStack px={cellPadding.x} py={cellPadding.y} fontSize="sm">
+        {evalResults.map((result) => {
+          const passedFrac = result.passCount / (result.passCount + result.failCount);
+          return (
+            <HStack key={result.id}>
+              <Text>{result.evaluation.name}</Text>
+              <Text color={scale(passedFrac).hex()} fontWeight="bold">
+                {(passedFrac * 100).toFixed(1)}%
+              </Text>
+            </HStack>
+          );
+        })}
+      </HStack>
+      {overallCost && (
+        <HStack spacing={0} align="center" color="gray.500" fontSize="xs" my="2">
+          <Icon as={BsCurrencyDollar} />
+          <Text mr={1}>{overallCost.toFixed(3)}</Text>
+        </HStack>
+      )}
     </HStack>
   );
 }

--- a/src/server/api/routers/evaluations.router.ts
+++ b/src/server/api/routers/evaluations.router.ts
@@ -14,15 +14,6 @@ export const evaluationsRouter = createTRPCRouter({
     });
   }),
 
-  results: publicProcedure.input(z.object({ variantId: z.string() })).query(async ({ input }) => {
-    return await prisma.evaluationResult.findMany({
-      where: {
-        promptVariantId: input.variantId,
-      },
-      include: { evaluation: true },
-    });
-  }),
-
   create: publicProcedure
     .input(
       z.object({

--- a/src/server/api/routers/modelOutputs.router.ts
+++ b/src/server/api/routers/modelOutputs.router.ts
@@ -62,6 +62,8 @@ export const modelOutputsRouter = createTRPCRouter({
           statusCode: existingResponse.statusCode,
           errorMessage: existingResponse.errorMessage,
           timeToComplete: existingResponse.timeToComplete,
+          promptTokens: existingResponse.promptTokens ?? undefined,
+          completionTokens: existingResponse.completionTokens ?? undefined,
         };
       } else {
         modelResponse = await getCompletion(filledTemplate, input.channel);

--- a/src/server/utils/getModelName.ts
+++ b/src/server/utils/getModelName.ts
@@ -1,8 +1,9 @@
 import { isObject } from "lodash";
 import { type JSONSerializable, type SupportedModel } from "../types";
+import { type Prisma } from "@prisma/client";
 
-export function getModelName(config: JSONSerializable): SupportedModel | null {
+export function getModelName(config: JSONSerializable | Prisma.JsonValue): SupportedModel | null {
   if (!isObject(config)) return null;
   if ("model" in config && typeof config.model === "string") return config.model as SupportedModel;
-  return null
+  return null;
 }

--- a/src/utils/calculateTokenCost.ts
+++ b/src/utils/calculateTokenCost.ts
@@ -22,18 +22,25 @@ const openAICompletionTokensToDollars: { [key in OpenAIChatModel]: number } = {
   "gpt-3.5-turbo-16k-0613": 0.000004,
 };
 
-export const calculateTokenCost = (model: SupportedModel, numTokens: number, isCompletion = false) => {
-    if (model in OpenAIChatModel) {
-        return calculateOpenAIChatTokenCost(model as OpenAIChatModel, numTokens, isCompletion);
-    }
-    return 0;
-}
+export const calculateTokenCost = (
+  model: SupportedModel | null,
+  numTokens: number,
+  isCompletion = false
+) => {
+  if (!model) return 0;
+  if (model in OpenAIChatModel) {
+    return calculateOpenAIChatTokenCost(model as OpenAIChatModel, numTokens, isCompletion);
+  }
+  return 0;
+};
 
 const calculateOpenAIChatTokenCost = (
   model: OpenAIChatModel,
   numTokens: number,
   isCompletion: boolean
 ) => {
-    const tokensToDollars = isCompletion ? openAICompletionTokensToDollars[model] : openAIPromptTokensToDollars[model];
-    return tokensToDollars * numTokens;
+  const tokensToDollars = isCompletion
+    ? openAICompletionTokensToDollars[model]
+    : openAIPromptTokensToDollars[model];
+  return tokensToDollars * numTokens;
 };


### PR DESCRIPTION
Users can now see the overall cost of their prompt variant.

#### Changes
* Add `promptVariants.stats`
* Remove `evaluations.results`
* Add total cost to prompt variant UI
* Copy token counts for outputs of new variants

Before:
<img width="1293" alt="Screenshot 2023-07-06 at 3 19 22 PM" src="https://github.com/corbt/querykey/assets/41524992/9cab7b5f-4bf2-4b53-910b-5922bd50be7f">

After:
<img width="1210" alt="Screenshot 2023-07-06 at 3 18 44 PM" src="https://github.com/corbt/querykey/assets/41524992/70057404-d55e-4e1a-8cc6-6cd8c90607a1">
