### PR TITLE
Redirect to experiments page after deleting experiment

### DIFF
--- a/src/pages/experiments/[id].tsx
+++ b/src/pages/experiments/[id].tsx
@@ -41,12 +41,9 @@ const DeleteButton = () => {
 
   const [onDeleteConfirm] = useHandledAsyncCallback(async () => {
     if (!experiment.data?.id) return;
-    const nextExperiment = await mutation.mutateAsync({ id: experiment.data.id });
+    await mutation.mutateAsync({ id: experiment.data.id });
     await utils.experiments.list.invalidate();
-
-    if (nextExperiment) {
-      await router.push({ pathname: "/experiments/[id]", query: { id: nextExperiment } });
-    }
+    await router.push({ pathname: "/experiments" });
     onClose();
   }, [mutation, experiment.data?.id, router]);
 

--- a/src/server/api/routers/experiments.router.ts
+++ b/src/server/api/routers/experiments.router.ts
@@ -110,14 +110,5 @@ export const experimentsRouter = createTRPCRouter({
         id: input.id,
       },
     });
-
-    // Return the ID of the newest existing experiment so the client can redirect to it
-    const newestExperiment = await prisma.experiment.findFirst({
-      orderBy: {
-        sortIndex: "desc",
-      },
-    });
-
-    return newestExperiment?.id;
   }),
 });


### PR DESCRIPTION
## Changes
* Redirect to /experiments after deleting experiment
* Stop calculating newest experiment id after deleting mutation (no longer needed)