### PR TITLE
add cost tooltip

### DIFF
--- a/src/components/OutputsTable/OutputCell/OutputStats.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputStats.tsx
@@ -7,6 +7,7 @@ import { calculateTokenCost } from "~/utils/calculateTokenCost";
 import { evaluateOutput } from "~/server/utils/evaluateOutput";
 import { HStack, Icon, Text } from "@chakra-ui/react";
 import { BsCheck, BsClock, BsCurrencyDollar, BsX } from "react-icons/bs";
+import { CostTooltip } from "~/components/tooltip/CostTooltip";
 
 export const OutputStats = ({
   model,
@@ -48,10 +49,12 @@ export const OutputStats = ({
           );
         })}
       </HStack>
-      <HStack spacing={0}>
-        <Icon as={BsCurrencyDollar} />
-        <Text mr={1}>{cost.toFixed(3)}</Text>
-      </HStack>
+      <CostTooltip promptTokens={promptTokens} completionTokens={completionTokens} cost={cost}>
+        <HStack spacing={0}>
+          <Icon as={BsCurrencyDollar} />
+          <Text mr={1}>{cost.toFixed(3)}</Text>
+        </HStack>
+      </CostTooltip>
       <HStack spacing={0.5}>
         <Icon as={BsClock} />
         <Text>{(timeToComplete / 1000).toFixed(2)}s</Text>

--- a/src/components/OutputsTable/VariantStats.tsx
+++ b/src/components/OutputsTable/VariantStats.tsx
@@ -4,13 +4,23 @@ import { cellPadding } from "../constants";
 import { api } from "~/utils/api";
 import chroma from "chroma-js";
 import { BsCurrencyDollar } from "react-icons/bs";
+import { CostTooltip } from "../tooltip/CostTooltip";
 
 export default function VariantStats(props: { variant: PromptVariant }) {
   const { data } = api.promptVariants.stats.useQuery(
     {
       variantId: props.variant.id,
     },
-    { initialData: { evalResults: [], overallCost: 0, scenarioCount: 0, outputCount: 0 } }
+    {
+      initialData: {
+        evalResults: [],
+        overallCost: 0,
+        promptTokens: 0,
+        completionTokens: 0,
+        scenarioCount: 0,
+        outputCount: 0,
+      },
+    }
   );
 
   const [passColor, neutralColor, failColor] = useToken("colors", [
@@ -46,10 +56,16 @@ export default function VariantStats(props: { variant: PromptVariant }) {
         })}
       </HStack>
       {data.overallCost && (
-        <HStack spacing={0} align="center" color="gray.500" my="2">
-          <Icon as={BsCurrencyDollar} />
-          <Text mr={1}>{data.overallCost.toFixed(3)}</Text>
-        </HStack>
+        <CostTooltip
+          promptTokens={data.promptTokens}
+          completionTokens={data.completionTokens}
+          cost={data.overallCost}
+        >
+          <HStack spacing={0} align="center" color="gray.500" my="2">
+            <Icon as={BsCurrencyDollar} />
+            <Text mr={1}>{data.overallCost.toFixed(3)}</Text>
+          </HStack>
+        </CostTooltip>
       )}
     </HStack>
   );

--- a/src/components/tooltip/CostTooltip.tsx
+++ b/src/components/tooltip/CostTooltip.tsx
@@ -1,4 +1,4 @@
-import { HStack, Icon, Text, Tooltip, type TooltipProps, VStack } from "@chakra-ui/react";
+import { HStack, Icon, Text, Tooltip, type TooltipProps, VStack, Divider } from "@chakra-ui/react";
 import { BsCurrencyDollar } from "react-icons/bs";
 
 type CostTooltipProps = {
@@ -17,25 +17,33 @@ export const CostTooltip = ({
   return (
     <Tooltip
       borderRadius="8"
-      color="black"
+      color="gray.800"
       bgColor="gray.50"
+      py={2}
       hasArrow
       label={
-        <VStack>
-          <HStack spacing={0}>
-            <Icon as={BsCurrencyDollar} />
-            <Text>{cost.toFixed(6)}</Text>
-          </HStack>
-          <HStack>
-            <VStack>
-              <Text>Prompt Tokens</Text>
-              <Text>{promptTokens ?? 0}</Text>
-            </VStack>
-            <VStack>
-              <Text>Completion Tokens</Text>
-              <Text>{completionTokens ?? 0}</Text>
-            </VStack>
-          </HStack>
+        <VStack fontSize="sm" w="200">
+          <VStack>
+            <Text fontWeight="bold">Cost</Text>
+            <HStack spacing={0}>
+              <Icon as={BsCurrencyDollar} />
+              <Text>{cost.toFixed(6)}</Text>
+            </HStack>
+          </VStack>
+          <VStack>
+            <Text fontWeight="bold">Tokens</Text>
+            <HStack>
+              <VStack w="28">
+                <Text>Prompt</Text>
+                <Text>{promptTokens ?? 0}</Text>
+              </VStack>
+              <Divider borderColor="gray.200" h={12} orientation="vertical" />
+              <VStack w="28">
+                <Text whiteSpace="nowrap">Completion</Text>
+                <Text>{completionTokens ?? 0}</Text>
+              </VStack>
+            </HStack>
+          </VStack>
         </VStack>
       }
       {...props}

--- a/src/components/tooltip/CostTooltip.tsx
+++ b/src/components/tooltip/CostTooltip.tsx
@@ -1,0 +1,46 @@
+import { HStack, Icon, Text, Tooltip, type TooltipProps, VStack } from "@chakra-ui/react";
+import { BsCurrencyDollar } from "react-icons/bs";
+
+type CostTooltipProps = {
+  promptTokens: number | null;
+  completionTokens: number | null;
+  cost: number;
+} & TooltipProps;
+
+export const CostTooltip = ({
+  promptTokens,
+  completionTokens,
+  cost,
+  children,
+  ...props
+}: CostTooltipProps) => {
+  return (
+    <Tooltip
+      borderRadius="8"
+      color="black"
+      bgColor="gray.50"
+      hasArrow
+      label={
+        <VStack>
+          <HStack spacing={0}>
+            <Icon as={BsCurrencyDollar} />
+            <Text>{cost.toFixed(6)}</Text>
+          </HStack>
+          <HStack>
+            <VStack>
+              <Text>Prompt Tokens</Text>
+              <Text>{promptTokens ?? 0}</Text>
+            </VStack>
+            <VStack>
+              <Text>Completion Tokens</Text>
+              <Text>{completionTokens ?? 0}</Text>
+            </VStack>
+          </HStack>
+        </VStack>
+      }
+      {...props}
+    >
+      {children}
+    </Tooltip>
+  );
+};

--- a/src/server/api/routers/promptVariants.router.ts
+++ b/src/server/api/routers/promptVariants.router.ts
@@ -66,7 +66,7 @@ export const promptVariantsRouter = createTRPCRouter({
 
     const overallCost = overallPromptCost + overallCompletionCost;
 
-    return { evalResults, overallCost, scenarioCount, outputCount };
+    return { evalResults, promptTokens, completionTokens, overallCost, scenarioCount, outputCount };
   }),
 
   create: publicProcedure


### PR DESCRIPTION
Implements issue https://github.com/open-pipe/openpipe/issues/20.

When hovering over the cost amount in an experiment and variant output, a tooltip with a more precise cost will be displayed, in addition to the prompt tokens and completion tokens.

Changes:

- Creates a CostTooltip component for use in the OutputStats and VariantStats components.
<img width="350" alt="Screenshot 2023-07-07 at 8 33 03 PM" src="https://github.com/open-pipe/openpipe/assets/50216013/6e190840-9b63-4e00-b1d8-5f4b44968ca7">
