### PR TITLE
Show cost tooltip on mobile, modify styles

### DIFF
--- a/src/components/tooltip/CostTooltip.tsx
+++ b/src/components/tooltip/CostTooltip.tsx
@@ -19,25 +19,27 @@ export const CostTooltip = ({
       borderRadius="8"
       color="gray.800"
       bgColor="gray.50"
+      borderWidth={1}
       py={2}
       hasArrow
+      shouldWrapChildren
       label={
-        <VStack fontSize="sm" w="200">
-          <VStack>
+        <VStack fontSize="sm" w="200" spacing={4}>
+          <VStack spacing={0}>
             <Text fontWeight="bold">Cost</Text>
             <HStack spacing={0}>
               <Icon as={BsCurrencyDollar} />
               <Text>{cost.toFixed(6)}</Text>
             </HStack>
           </VStack>
-          <VStack>
+          <VStack spacing={0}>
             <Text fontWeight="bold">Tokens</Text>
             <HStack>
               <VStack w="28">
                 <Text>Prompt</Text>
                 <Text>{promptTokens ?? 0}</Text>
               </VStack>
-              <Divider borderColor="gray.200" h={12} orientation="vertical" />
+              <Divider borderColor="gray.200" h={8} orientation="vertical" />
               <VStack w="28">
                 <Text whiteSpace="nowrap">Completion</Text>
                 <Text>{completionTokens ?? 0}</Text>

--- a/src/components/tooltip/CostTooltip.tsx
+++ b/src/components/tooltip/CostTooltip.tsx
@@ -32,15 +32,15 @@ export const CostTooltip = ({
               <Text>{cost.toFixed(6)}</Text>
             </HStack>
           </VStack>
-          <VStack spacing={0}>
-            <Text fontWeight="bold">Tokens</Text>
+          <VStack spacing={1}>
+            <Text fontWeight="bold">Token Usage</Text>
             <HStack>
-              <VStack w="28">
+              <VStack w="28" spacing={1}>
                 <Text>Prompt</Text>
                 <Text>{promptTokens ?? 0}</Text>
               </VStack>
               <Divider borderColor="gray.200" h={8} orientation="vertical" />
-              <VStack w="28">
+              <VStack w="28" spacing={1}>
                 <Text whiteSpace="nowrap">Completion</Text>
                 <Text>{completionTokens ?? 0}</Text>
               </VStack>


### PR DESCRIPTION
This change shows the cost tooltip on mobile and slightly modified its styles.

## Changes
* Set `shouldWrapChildren` to `true`
* Compress vertical spacing
* Add slight border

Before:
<img width="320" alt="Screenshot 2023-07-08 at 10 29 09 AM" src="https://github.com/open-pipe/openpipe/assets/41524992/d497250d-c2c6-4693-9fe8-46344493341d">

After:
<img width="292" alt="Screenshot 2023-07-08 at 10 28 53 AM" src="https://github.com/open-pipe/openpipe/assets/41524992/7faf8cf7-d0b9-447c-a404-30c8c769bdb8">
