### PR TITLE
Record experiment updated in more places

### DIFF
--- a/src/server/utils/recordExperimentUpdated.ts
+++ b/src/server/utils/recordExperimentUpdated.ts
@@ -1,0 +1,12 @@
+import { prisma } from "~/server/db";
+
+export const recordExperimentUpdated = async (experimentId: string) => {
+  await prisma.experiment.update({
+    where: {
+      id: experimentId,
+    },
+    data: {
+      updatedAt: new Date(),
+    },
+  });
+};

--- a/src/server/utils/recordExperimentUpdated.ts
+++ b/src/server/utils/recordExperimentUpdated.ts
@@ -1,7 +1,7 @@
 import { prisma } from "~/server/db";
 
-export const recordExperimentUpdated = async (experimentId: string) => {
-  await prisma.experiment.update({
+export const recordExperimentUpdated = (experimentId: string) => {
+  return prisma.experiment.update({
     where: {
       id: experimentId,
     },


### PR DESCRIPTION
Previously we were only updating an experiment's `updatedAt` time when a new variant or scenario was created. We're now doing it every time a write command occurs against a variant or scenario.

## Changes
* Create new `recordExperimentUpdated` utility function
* Record updates for all write operations against variants and scenarios