### PR TITLE
Limit evaluations to visible test scenarios

### DIFF
--- a/src/server/utils/evaluations.ts
+++ b/src/server/utils/evaluations.ts
@@ -13,7 +13,7 @@ export const reevaluateVariant = async (variantId: string) => {
   });
 
   const modelOutputs = await prisma.modelOutput.findMany({
-    where: { promptVariantId: variantId, statusCode: { notIn: [429] } },
+    where: { promptVariantId: variantId, statusCode: { notIn: [429] }, testScenario: { visible: true } },
     include: { testScenario: true },
   });
 


### PR DESCRIPTION
Previously, we were inadvertently evaluating outputs from hidden scenarios and including their results in the overall prompt variant statistics. This change limits evaluations to scenarios that are visible.