### PR TITLE
Move experiment scrollbar to bottom of page, make scenarios header sticky

### DIFF
--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -53,6 +53,9 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
         rowSpan={headerRows}
         px={cellPadding.x}
         py={cellPadding.y}
+        // TODO: This is a hack to get the sticky header to work. It's not ideal because it's not responsive to the height of the header,
+        // so if the header height changes, this will need to be updated.
+        sx={{...stickyHeaderStyle, top: "-336px"}}
       >
         <HStack w="100%">
           <Heading size="xs" fontWeight="bold" flex={1}>

--- a/src/pages/experiments/[id].tsx
+++ b/src/pages/experiments/[id].tsx
@@ -16,6 +16,7 @@ import {
   useDisclosure,
   Text,
   HStack,
+  VStack,
 } from "@chakra-ui/react";
 import Link from "next/link";
 
@@ -123,7 +124,7 @@ export default function Experiment() {
 
   return (
     <AppShell title={experiment.data?.label}>
-      <Box minH="100%" pb={50}>
+      <VStack h="full">
         <Flex
           px={4}
           py={2}
@@ -172,10 +173,10 @@ export default function Experiment() {
           </HStack>
         </Flex>
         <SettingsDrawer />
-        <Box w="100%" overflowX="auto">
+        <Box w="100%" overflowX="auto" flex={1}>
           <OutputsTable experimentId={router.query.id as string | undefined} />
         </Box>
-      </Box>
+      </VStack>
     </AppShell>
   );
 }

--- a/src/server/api/routers/promptVariants.router.ts
+++ b/src/server/api/routers/promptVariants.router.ts
@@ -149,7 +149,6 @@ export const promptVariantsRouter = createTRPCRouter({
       ]);
   
       return updatedPromptVariant;
-
     }),
 
   hide: publicProcedure


### PR DESCRIPTION
This PR includes UI changes to the individual experiment viewing page.

## Changes
* Move horizontal scroll bar to bottom of the page
* Make scenarios header sticky (use hacky hardcoded `top: -337px` value for now)

Before:
<img width="1140" alt="Screenshot 2023-07-10 at 12 39 17 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/85b80517-4113-4c8c-854e-f0fc69429524">

After:
<img width="922" alt="Screenshot 2023-07-10 at 12 39 43 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/5f8b24d7-40b9-4fa2-9276-3a7951f47452">
