### PR TITLE
Increase scenarios header negative margin

### DIFF
--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -55,7 +55,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
         py={cellPadding.y}
         // TODO: This is a hack to get the sticky header to work. It's not ideal because it's not responsive to the height of the header,
         // so if the header height changes, this will need to be updated.
-        sx={{...stickyHeaderStyle, top: "-336px"}}
+        sx={{...stickyHeaderStyle, top: "-337px"}}
       >
         <HStack w="100%">
           <Heading size="xs" fontWeight="bold" flex={1}>


### PR DESCRIPTION
In https://github.com/OpenPipe/OpenPipe/pull/29 I forgot to change the negative margin back to `-337px` for the scenarios header.

Before:
<img width="90" alt="Screenshot 2023-07-10 at 12 53 13 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/830bbec9-2c08-4792-89e2-60f9722ad208">


After:
<img width="105" alt="Screenshot 2023-07-10 at 12 54 41 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/30cdddae-2ec7-4afc-8b0e-4ce163327861">

