### PR TITLE
Dynamically resize viewport height on mobile

### DIFF
--- a/src/components/nav/AppShell.tsx
+++ b/src/components/nav/AppShell.tsx
@@ -19,6 +19,7 @@ import { useRouter } from "next/router";
 import PublicPlaygroundWarning from "../PublicPlaygroundWarning";
 import { type IconType } from "react-icons";
 import { RiFlaskLine } from "react-icons/ri";
+import { useState, useEffect } from "react";
 
 type IconLinkProps = BoxProps & LinkProps & { label: string; icon: IconType; href: string };
 
@@ -84,9 +85,28 @@ const NavSidebar = () => {
 };
 
 export default function AppShell(props: { children: React.ReactNode; title?: string }) {
+  const [vh, setVh] = useState("100vh"); // Default height to prevent flicker on initial render
+
+  useEffect(() => {
+    const setHeight = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty("--vh", `${vh}px`);
+      setVh(`calc(var(--vh, 1vh) * 100)`);
+    };
+    setHeight(); // Set the height at the start
+
+    // Listen to resize events
+    window.addEventListener("resize", setHeight);
+
+    // Remove event listener on cleanup
+    return () => {
+      window.removeEventListener("resize", setHeight);
+    };
+  }, []);
+
   return (
     <Grid
-      h="100vh"
+      h={vh}
       w="100vw"
       templateColumns={{ base: "56px minmax(0, 1fr)", md: "200px minmax(0, 1fr)" }}
       templateRows="max-content 1fr"


### PR DESCRIPTION
This fixes a bug in which part of the side navbar was displayed outside the viewable area due to part of the expected viewport being infringed upon by mobile browsers' navigation panels. In turn, this made scrolling on mobile browsers a frustrating experience.

## Changes
* Dynamically recalculate `AppShell`'s height to account for changes in the mobile browser.

Before:
![telegram-cloud-photo-size-1-5001807025184811733-y](https://github.com/OpenPipe/OpenPipe/assets/41524992/762e9031-3b14-4d80-8742-53e8512b644b)

After:
![telegram-cloud-photo-size-1-5001807025184811732-y](https://github.com/OpenPipe/OpenPipe/assets/41524992/c2c11079-0be1-4a5b-89d1-7d0cb5743ad9)
