### PR TITLE
Show more experiment content on screen, hide individual cost and time

### DIFF
--- a/src/components/OutputsTable/OutputCell/OutputStats.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputStats.tsx
@@ -9,6 +9,9 @@ import { HStack, Icon, Text } from "@chakra-ui/react";
 import { BsCheck, BsClock, BsCurrencyDollar, BsX } from "react-icons/bs";
 import { CostTooltip } from "~/components/tooltip/CostTooltip";
 
+const SHOW_COST = false;
+const SHOW_TIME = false;
+
 export const OutputStats = ({
   model,
   modelOutput,
@@ -32,8 +35,10 @@ export const OutputStats = ({
 
   const cost = promptCost + completionCost;
 
+  if (!evals.length) return null;
+
   return (
-    <HStack align="center" color="gray.500" fontSize="xs" mt={2}>
+    <HStack align="center" color="gray.500" fontSize="2xs" mt={{ base: 0, md: 1 }}>
       <HStack flex={1}>
         {evals.map((evaluation) => {
           const passed = evaluateOutput(modelOutput, scenario, evaluation);
@@ -49,16 +54,20 @@ export const OutputStats = ({
           );
         })}
       </HStack>
-      <CostTooltip promptTokens={promptTokens} completionTokens={completionTokens} cost={cost}>
-        <HStack spacing={0}>
-          <Icon as={BsCurrencyDollar} />
-          <Text mr={1}>{cost.toFixed(3)}</Text>
+      {SHOW_COST && (
+        <CostTooltip promptTokens={promptTokens} completionTokens={completionTokens} cost={cost}>
+          <HStack spacing={0}>
+            <Icon as={BsCurrencyDollar} />
+            <Text mr={1}>{cost.toFixed(3)}</Text>
+          </HStack>
+        </CostTooltip>
+      )}
+      {SHOW_TIME && (
+        <HStack spacing={0.5}>
+          <Icon as={BsClock} />
+          <Text>{(timeToComplete / 1000).toFixed(2)}s</Text>
         </HStack>
-      </CostTooltip>
-      <HStack spacing={0.5}>
-        <Icon as={BsClock} />
-        <Text>{(timeToComplete / 1000).toFixed(2)}s</Text>
-      </HStack>
+      )}
     </HStack>
   );
 };

--- a/src/components/OutputsTable/ScenarioEditor.tsx
+++ b/src/components/OutputsTable/ScenarioEditor.tsx
@@ -5,7 +5,7 @@ import { type Scenario } from "./types";
 import { useExperiment, useHandledAsyncCallback } from "~/utils/hooks";
 import { useState } from "react";
 
-import { Box, Button, Flex, HStack, Icon, Spinner, Stack, Tooltip } from "@chakra-ui/react";
+import { Box, Button, Flex, HStack, Icon, Spinner, Stack, Tooltip, VStack } from "@chakra-ui/react";
 import { cellPadding } from "../constants";
 import { BsX } from "react-icons/bs";
 import { RiDraggable } from "react-icons/ri";
@@ -120,7 +120,7 @@ export default function ScenarioEditor({
       {variableLabels.length === 0 ? (
         <Box color="gray.500">{vars.data ? "No scenario variables configured" : "Loading..."}</Box>
       ) : (
-        <Stack>
+        <VStack spacing={1}>
           {variableLabels.map((key) => {
             const value = values[key] ?? "";
             const layoutDirection = value.length > 20 ? "column" : "row";
@@ -130,11 +130,12 @@ export default function ScenarioEditor({
                 direction={layoutDirection}
                 alignItems={layoutDirection === "column" ? "flex-start" : "center"}
                 flexWrap="wrap"
+                width="full"
               >
                 <Box
                   bgColor="blue.100"
                   color="blue.600"
-                  px={2}
+                  px={1}
                   my="3px"
                   fontSize="xs"
                   fontWeight="bold"
@@ -146,6 +147,8 @@ export default function ScenarioEditor({
                   py={1}
                   placeholder="empty"
                   borderRadius="sm"
+                  fontSize="sm"
+                  lineHeight={1.2}
                   value={value}
                   onChange={(e) => {
                     setValues((prev) => ({ ...prev, [key]: e.target.value }));
@@ -187,7 +190,7 @@ export default function ScenarioEditor({
               </Button>
             </HStack>
           )}
-        </Stack>
+        </VStack>
       )}
     </HStack>
   );

--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -47,6 +47,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
           borderRightWidth: 1,
         },
       }}
+      fontSize="sm"
     >
       <GridItem
         display="flex"


### PR DESCRIPTION
This PR allows more relevant content to be easily viewed by the user. Spacing and font size are reduced, and individual outputs' cost and time are hidden.

Before:
<img width="933" alt="Screenshot 2023-07-11 at 1 16 34 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/42ef0426-96b3-433c-9af9-966206d84219">


After:
<img width="933" alt="Screenshot 2023-07-11 at 1 16 18 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/03938267-595a-47f0-b04c-6a7536b25168">
