### PR TITLE
Add GPT4 Evals

### DIFF
--- a/prisma/migrations/20230718005301_add_gpt4_eval_type/migration.sql
+++ b/prisma/migrations/20230718005301_add_gpt4_eval_type/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the `EvaluationResult` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- AlterEnum
+ALTER TYPE "EvalType" ADD VALUE 'GPT4_EVAL';
+
+-- DropForeignKey
+ALTER TABLE "EvaluationResult" DROP CONSTRAINT "EvaluationResult_evaluationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "EvaluationResult" DROP CONSTRAINT "EvaluationResult_promptVariantId_fkey";
+
+-- DropTable
+DROP TABLE "EvaluationResult";
+
+-- CreateTable
+CREATE TABLE "OutputEvaluation" (
+    "id" UUID NOT NULL,
+    "result" DOUBLE PRECISION NOT NULL,
+    "details" TEXT,
+    "modelOutputId" UUID NOT NULL,
+    "evaluationId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OutputEvaluation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OutputEvaluation_modelOutputId_evaluationId_key" ON "OutputEvaluation"("modelOutputId", "evaluationId");
+
+-- AddForeignKey
+ALTER TABLE "OutputEvaluation" ADD CONSTRAINT "OutputEvaluation_modelOutputId_fkey" FOREIGN KEY ("modelOutputId") REFERENCES "ModelOutput"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OutputEvaluation" ADD CONSTRAINT "OutputEvaluation_evaluationId_fkey" FOREIGN KEY ("evaluationId") REFERENCES "Evaluation"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,6 @@ model PromptVariant {
     createdAt            DateTime              @default(now())
     updatedAt            DateTime              @updatedAt
     scenarioVariantCells ScenarioVariantCell[]
-    EvaluationResult     EvaluationResult[]
 
     @@index([uiId])
 }
@@ -124,6 +123,7 @@ model ModelOutput {
 
     scenarioVariantCellId String              @db.Uuid
     scenarioVariantCell   ScenarioVariantCell @relation(fields: [scenarioVariantCellId], references: [id], onDelete: Cascade)
+    outputEvaluation      OutputEvaluation[]
 
     @@unique([scenarioVariantCellId])
     @@index([inputHash])
@@ -146,25 +146,26 @@ model Evaluation {
 
     createdAt        DateTime           @default(now())
     updatedAt        DateTime           @updatedAt
-    EvaluationResult EvaluationResult[]
+    OutputEvaluation OutputEvaluation[]
 }
 
-model EvaluationResult {
+model OutputEvaluation {
     id String @id @default(uuid()) @db.Uuid
 
-    passCount Int
-    failCount Int
+    // Number between 0 (fail) and 1 (pass)
+    result  Float
+    details String?
+
+    modelOutputId String      @db.Uuid
+    modelOutput   ModelOutput @relation(fields: [modelOutputId], references: [id], onDelete: Cascade)
 
     evaluationId String     @db.Uuid
     evaluation   Evaluation @relation(fields: [evaluationId], references: [id], onDelete: Cascade)
 
-    promptVariantId String        @db.Uuid
-    promptVariant   PromptVariant @relation(fields: [promptVariantId], references: [id], onDelete: Cascade)
-
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
-    @@unique([evaluationId, promptVariantId])
+    @@unique([modelOutputId, evaluationId])
 }
 
 // Necessary for Next auth

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,6 +132,7 @@ model ModelOutput {
 enum EvalType {
     CONTAINS
     DOES_NOT_CONTAIN
+    GPT4_EVAL
 }
 
 model Evaluation {

--- a/src/components/AutoResizeTextArea.tsx
+++ b/src/components/AutoResizeTextArea.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 export const AutoResizeTextarea: React.ForwardRefRenderFunction<
   HTMLTextAreaElement,
-  TextareaProps
+  TextareaProps & { minRows?: number }
 > = (props, ref) => {
   return (
     <Textarea

--- a/src/components/OutputsTable/EditEvaluations.tsx
+++ b/src/components/OutputsTable/EditEvaluations.tsx
@@ -40,7 +40,7 @@ export function EvaluationEditor(props: {
           <Input
             size="sm"
             value={values.label}
-            onChange={(e) => setValues((values) => ({ ...values, name: e.target.value }))}
+            onChange={(e) => setValues((values) => ({ ...values, label: e.target.value }))}
           />
         </FormControl>
         <FormControl flex={1}>
@@ -125,6 +125,7 @@ export default function EditEvaluations() {
     }
     await utils.evaluations.list.invalidate();
     await utils.promptVariants.stats.invalidate();
+    await utils.scenarioVariantCells.get.invalidate();
   }, []);
 
   const onCancel = useCallback(() => {

--- a/src/components/OutputsTable/EditEvaluations.tsx
+++ b/src/components/OutputsTable/EditEvaluations.tsx
@@ -11,12 +11,14 @@ import {
   FormLabel,
   Select,
   FormHelperText,
+  Code,
 } from "@chakra-ui/react";
 import { type Evaluation, EvalType } from "@prisma/client";
 import { useCallback, useState } from "react";
 import { BsPencil, BsX } from "react-icons/bs";
 import { api } from "~/utils/api";
 import { useExperiment, useHandledAsyncCallback } from "~/utils/hooks";
+import AutoResizeTextArea from "../AutoResizeTextArea";
 
 type EvalValues = Pick<Evaluation, "label" | "value" | "evalType">;
 
@@ -36,7 +38,7 @@ export function EvaluationEditor(props: {
     <VStack borderTopWidth={1} borderColor="gray.200" py={4}>
       <HStack w="100%">
         <FormControl flex={1}>
-          <FormLabel fontSize="sm">Evaluation Name</FormLabel>
+          <FormLabel fontSize="sm">Eval Name</FormLabel>
           <Input
             size="sm"
             value={values.label}
@@ -44,7 +46,7 @@ export function EvaluationEditor(props: {
           />
         </FormControl>
         <FormControl flex={1}>
-          <FormLabel fontSize="sm">Match Type</FormLabel>
+          <FormLabel fontSize="sm">Eval Type</FormLabel>
           <Select
             size="sm"
             value={values.evalType}
@@ -63,17 +65,37 @@ export function EvaluationEditor(props: {
           </Select>
         </FormControl>
       </HStack>
-      <FormControl>
-        <FormLabel fontSize="sm">Match String</FormLabel>
-        <Input
-          size="sm"
-          value={values.value}
-          onChange={(e) => setValues((values) => ({ ...values, value: e.target.value }))}
-        />
-        <FormHelperText>
-          This string will be interpreted as a regex and checked against each model output.
-        </FormHelperText>
-      </FormControl>
+      {["CONTAINS", "DOES_NOT_CONTAIN"].includes(values.evalType) && (
+        <FormControl>
+          <FormLabel fontSize="sm">Match String</FormLabel>
+          <Input
+            size="sm"
+            value={values.value}
+            onChange={(e) => setValues((values) => ({ ...values, value: e.target.value }))}
+          />
+          <FormHelperText>
+            This string will be interpreted as a regex and checked against each model output. You
+            can include scenario variables using <Code>{"{{curly_braces}}"}</Code>
+          </FormHelperText>
+        </FormControl>
+      )}
+      {values.evalType === "GPT4_EVAL" && (
+        <FormControl pt={2}>
+          <FormLabel fontSize="sm">GPT4 Instructions</FormLabel>
+          <AutoResizeTextArea
+            size="sm"
+            value={values.value}
+            onChange={(e) => setValues((values) => ({ ...values, value: e.target.value }))}
+            minRows={3}
+          />
+          <FormHelperText>
+            Give instructions to GPT-4 for how to evaluate your prompt. It will have access to the
+            full scenario as well as the output it is evaluating. It will <strong>not</strong> have
+            access to the specific prompt variant, so be sure to be clear about the task you want it
+            to perform.
+          </FormHelperText>
+        </FormControl>
+      )}
       <HStack alignSelf="flex-end">
         <Button size="sm" onClick={props.onCancel} colorScheme="gray">
           Cancel

--- a/src/components/OutputsTable/EditScenarioVars.tsx
+++ b/src/components/OutputsTable/EditScenarioVars.tsx
@@ -1,4 +1,4 @@
-import { Text, Button, HStack, Heading, Icon, Input, Stack, Code } from "@chakra-ui/react";
+import { Text, Button, HStack, Heading, Icon, Input, Stack } from "@chakra-ui/react";
 import { useState } from "react";
 import { BsCheck, BsX } from "react-icons/bs";
 import { api } from "~/utils/api";
@@ -36,8 +36,7 @@ export default function EditScenarioVars() {
       <Heading size="sm">Scenario Variables</Heading>
       <Stack spacing={2}>
         <Text fontSize="sm">
-          Scenario variables can be used in your prompt variants as well as evaluations. Reference
-          them using <Code>{"{{curly_braces}}"}</Code>.
+          Scenario variables can be used in your prompt variants as well as evaluations.
         </Text>
         <HStack spacing={0}>
           <Input

--- a/src/components/OutputsTable/OutputCell/OutputStats.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputStats.tsx
@@ -1,10 +1,7 @@
-import { type ModelOutput } from "@prisma/client";
 import { type SupportedModel } from "~/server/types";
 import { type Scenario } from "../types";
-import { useExperiment } from "~/utils/hooks";
-import { api } from "~/utils/api";
+import { type RouterOutputs } from "~/utils/api";
 import { calculateTokenCost } from "~/utils/calculateTokenCost";
-import { evaluateOutput } from "~/server/utils/evaluateOutput";
 import { HStack, Icon, Text } from "@chakra-ui/react";
 import { BsCheck, BsClock, BsCurrencyDollar, BsX } from "react-icons/bs";
 import { CostTooltip } from "~/components/tooltip/CostTooltip";
@@ -15,16 +12,14 @@ const SHOW_TIME = true;
 export const OutputStats = ({
   model,
   modelOutput,
-  scenario,
 }: {
   model: SupportedModel | string | null;
-  modelOutput: ModelOutput;
+  modelOutput: NonNullable<
+    NonNullable<RouterOutputs["scenarioVariantCells"]["get"]>["modelOutput"]
+  >;
   scenario: Scenario;
 }) => {
   const timeToComplete = modelOutput.timeToComplete;
-  const experiment = useExperiment();
-  const evals =
-    api.evaluations.list.useQuery({ experimentId: experiment.data?.id ?? "" }).data ?? [];
 
   const promptTokens = modelOutput.promptTokens;
   const completionTokens = modelOutput.completionTokens;
@@ -38,11 +33,11 @@ export const OutputStats = ({
   return (
     <HStack align="center" color="gray.500" fontSize="2xs" mt={{ base: 0, md: 1 }}>
       <HStack flex={1}>
-        {evals.map((evaluation) => {
-          const passed = evaluateOutput(modelOutput, scenario, evaluation);
+        {modelOutput.outputEvaluation.map((evaluation) => {
+          const passed = evaluation.result > 0.5;
           return (
             <HStack spacing={0} key={evaluation.id}>
-              <Text>{evaluation.label}</Text>
+              <Text>{evaluation.evaluation.label}</Text>
               <Icon
                 as={passed ? BsCheck : BsX}
                 color={passed ? "green.500" : "red.500"}

--- a/src/components/OutputsTable/OutputCell/OutputStats.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputStats.tsx
@@ -2,7 +2,7 @@ import { type SupportedModel } from "~/server/types";
 import { type Scenario } from "../types";
 import { type RouterOutputs } from "~/utils/api";
 import { calculateTokenCost } from "~/utils/calculateTokenCost";
-import { HStack, Icon, Text } from "@chakra-ui/react";
+import { HStack, Icon, Text, Tooltip } from "@chakra-ui/react";
 import { BsCheck, BsClock, BsCurrencyDollar, BsX } from "react-icons/bs";
 import { CostTooltip } from "~/components/tooltip/CostTooltip";
 
@@ -36,14 +36,20 @@ export const OutputStats = ({
         {modelOutput.outputEvaluation.map((evaluation) => {
           const passed = evaluation.result > 0.5;
           return (
-            <HStack spacing={0} key={evaluation.id}>
-              <Text>{evaluation.evaluation.label}</Text>
-              <Icon
-                as={passed ? BsCheck : BsX}
-                color={passed ? "green.500" : "red.500"}
-                boxSize={6}
-              />
-            </HStack>
+            <Tooltip
+              isDisabled={!evaluation.details}
+              label={evaluation.details}
+              key={evaluation.id}
+            >
+              <HStack spacing={0}>
+                <Text>{evaluation.evaluation.label}</Text>
+                <Icon
+                  as={passed ? BsCheck : BsX}
+                  color={passed ? "green.500" : "red.500"}
+                  boxSize={6}
+                />
+              </HStack>
+            </Tooltip>
           );
         })}
       </HStack>

--- a/src/components/OutputsTable/VariantStats.tsx
+++ b/src/components/OutputsTable/VariantStats.tsx
@@ -44,10 +44,10 @@ export default function VariantStats(props: { variant: PromptVariant }) {
       )}
       <HStack px={cellPadding.x} py={cellPadding.y}>
         {data.evalResults.map((result) => {
-          const passedFrac = result.passCount / (result.passCount + result.failCount);
+          const passedFrac = result.passCount / result.totalCount;
           return (
             <HStack key={result.id}>
-              <Text>{result.evaluation.label}</Text>
+              <Text>{result.label}</Text>
               <Text color={scale(passedFrac).hex()} fontWeight="bold">
                 {(passedFrac * 100).toFixed(1)}%
               </Text>

--- a/src/server/api/routers/evaluations.router.ts
+++ b/src/server/api/routers/evaluations.router.ts
@@ -2,7 +2,7 @@ import { EvalType } from "@prisma/client";
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { prisma } from "~/server/db";
-import { reevaluateEvaluation } from "~/server/utils/evaluations";
+import { runAllEvals } from "~/server/utils/evaluations";
 
 export const evaluationsRouter = createTRPCRouter({
   list: publicProcedure.input(z.object({ experimentId: z.string() })).query(async ({ input }) => {
@@ -24,7 +24,7 @@ export const evaluationsRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ input }) => {
-      const evaluation = await prisma.evaluation.create({
+      await prisma.evaluation.create({
         data: {
           experimentId: input.experimentId,
           label: input.label,
@@ -32,7 +32,10 @@ export const evaluationsRouter = createTRPCRouter({
           evalType: input.evalType,
         },
       });
-      await reevaluateEvaluation(evaluation);
+
+      // TODO: this may be a bad UX for slow evals (eg. GPT-4 evals) Maybe need
+      // to kick off a background job or something instead
+      await runAllEvals(input.experimentId);
     }),
 
   update: publicProcedure
@@ -40,24 +43,30 @@ export const evaluationsRouter = createTRPCRouter({
       z.object({
         id: z.string(),
         updates: z.object({
-          name: z.string().optional(),
+          label: z.string().optional(),
           value: z.string().optional(),
           evalType: z.nativeEnum(EvalType).optional(),
         }),
       }),
     )
     .mutation(async ({ input }) => {
-      await prisma.evaluation.update({
+      const evaluation = await prisma.evaluation.update({
         where: { id: input.id },
         data: {
-          label: input.updates.name,
+          label: input.updates.label,
           value: input.updates.value,
           evalType: input.updates.evalType,
         },
       });
-      await reevaluateEvaluation(
-        await prisma.evaluation.findUniqueOrThrow({ where: { id: input.id } }),
-      );
+
+      await prisma.outputEvaluation.deleteMany({
+        where: {
+          evaluationId: evaluation.id,
+        },
+      });
+      // Re-run all evals. Other eval results will already be cached, so this
+      // should only re-run the updated one.
+      await runAllEvals(evaluation.experimentId);
     }),
 
   delete: publicProcedure.input(z.object({ id: z.string() })).mutation(async ({ input }) => {

--- a/src/server/api/routers/scenarioVariantCells.router.ts
+++ b/src/server/api/routers/scenarioVariantCells.router.ts
@@ -21,7 +21,17 @@ export const scenarioVariantCellsRouter = createTRPCRouter({
           },
         },
         include: {
-          modelOutput: true,
+          modelOutput: {
+            include: {
+              outputEvaluation: {
+                include: {
+                  evaluation: {
+                    select: { label: true },
+                  },
+                },
+              },
+            },
+          },
         },
       });
     }),

--- a/src/server/api/routers/scenarios.router.ts
+++ b/src/server/api/routers/scenarios.router.ts
@@ -3,7 +3,7 @@ import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { prisma } from "~/server/db";
 import { autogenerateScenarioValues } from "../autogen";
 import { recordExperimentUpdated } from "~/server/utils/recordExperimentUpdated";
-import { reevaluateAll } from "~/server/utils/evaluations";
+import { runAllEvals } from "~/server/utils/evaluations";
 import { generateNewCell } from "~/server/utils/generateNewCell";
 
 export const scenariosRouter = createTRPCRouter({
@@ -73,7 +73,7 @@ export const scenariosRouter = createTRPCRouter({
     });
 
     // Reevaluate all evaluations now that this scenario is hidden
-    await reevaluateAll(hiddenScenario.experimentId);
+    await runAllEvals(hiddenScenario.experimentId);
 
     return hiddenScenario;
   }),

--- a/src/server/tasks/queryLLM.task.ts
+++ b/src/server/tasks/queryLLM.task.ts
@@ -6,7 +6,7 @@ import { type JSONSerializable } from "../types";
 import { sleep } from "../utils/sleep";
 import { shouldStream } from "../utils/shouldStream";
 import { generateChannel } from "~/utils/generateChannel";
-import { reevaluateVariant } from "../utils/evaluations";
+import { runEvalsForOutput } from "../utils/evaluations";
 import { constructPrompt } from "../utils/constructPrompt";
 import { type CompletionCreateParams } from "openai/resources/chat";
 import { type Prisma } from "@prisma/client";
@@ -148,5 +148,7 @@ export const queryLLM = defineTask<queryLLMJob>("queryLLM", async (task) => {
     },
   });
 
-  await reevaluateVariant(cell.promptVariantId);
+  if (modelOutput) {
+    await runEvalsForOutput(variant.experimentId, scenario, modelOutput);
+  }
 });

--- a/src/server/utils/evaluations.ts
+++ b/src/server/utils/evaluations.ts
@@ -1,105 +1,154 @@
 import { type ModelOutput, type Evaluation } from "@prisma/client";
 import { prisma } from "../db";
-import { evaluateOutput } from "./evaluateOutput";
+import { runOneEval } from "./runOneEval";
+import { type Scenario } from "~/components/OutputsTable/types";
 
-export const reevaluateVariant = async (variantId: string) => {
-  const variant = await prisma.promptVariant.findUnique({
-    where: { id: variantId },
-  });
-  if (!variant) return;
-
-  const evaluations = await prisma.evaluation.findMany({
-    where: { experimentId: variant.experimentId },
-  });
-
-  const cells = await prisma.scenarioVariantCell.findMany({
+const saveResult = async (evaluation: Evaluation, scenario: Scenario, modelOutput: ModelOutput) => {
+  const result = runOneEval(evaluation, scenario, modelOutput);
+  return await prisma.outputEvaluation.upsert({
     where: {
-      promptVariantId: variantId,
-      retrievalStatus: "COMPLETE",
-      testScenario: { visible: true },
-      modelOutput: { isNot: null },
+      modelOutputId_evaluationId: {
+        modelOutputId: modelOutput.id,
+        evaluationId: evaluation.id,
+      },
     },
-    include: { testScenario: true, modelOutput: true },
+    create: {
+      modelOutputId: modelOutput.id,
+      evaluationId: evaluation.id,
+      result,
+    },
+    update: {
+      result,
+    },
   });
-
-  await Promise.all(
-    evaluations.map(async (evaluation) => {
-      const passCount = cells.filter((cell) =>
-        evaluateOutput(cell.modelOutput as ModelOutput, cell.testScenario, evaluation),
-      ).length;
-      const failCount = cells.length - passCount;
-
-      await prisma.evaluationResult.upsert({
-        where: {
-          evaluationId_promptVariantId: {
-            evaluationId: evaluation.id,
-            promptVariantId: variantId,
-          },
-        },
-        create: {
-          evaluationId: evaluation.id,
-          promptVariantId: variantId,
-          passCount,
-          failCount,
-        },
-        update: {
-          passCount,
-          failCount,
-        },
-      });
-    }),
-  );
 };
 
-export const reevaluateEvaluation = async (evaluation: Evaluation) => {
-  const variants = await prisma.promptVariant.findMany({
-    where: { experimentId: evaluation.experimentId, visible: true },
-  });
-
-  const cells = await prisma.scenarioVariantCell.findMany({
-    where: {
-      promptVariantId: { in: variants.map((v) => v.id) },
-      testScenario: { visible: true },
-      statusCode: { notIn: [429] },
-      modelOutput: { isNot: null },
-    },
-    include: { testScenario: true, modelOutput: true },
-  });
-
-  await Promise.all(
-    variants.map(async (variant) => {
-      const variantCells = cells.filter((cell) => cell.promptVariantId === variant.id);
-      const passCount = variantCells.filter((cell) =>
-        evaluateOutput(cell.modelOutput as ModelOutput, cell.testScenario, evaluation),
-      ).length;
-      const failCount = variantCells.length - passCount;
-
-      await prisma.evaluationResult.upsert({
-        where: {
-          evaluationId_promptVariantId: {
-            evaluationId: evaluation.id,
-            promptVariantId: variant.id,
-          },
-        },
-        create: {
-          evaluationId: evaluation.id,
-          promptVariantId: variant.id,
-          passCount,
-          failCount,
-        },
-        update: {
-          passCount,
-          failCount,
-        },
-      });
-    }),
-  );
-};
-
-export const reevaluateAll = async (experimentId: string) => {
+export const runEvalsForOutput = async (
+  experimentId: string,
+  scenario: Scenario,
+  modelOutput: ModelOutput,
+) => {
   const evaluations = await prisma.evaluation.findMany({
     where: { experimentId },
   });
 
-  await Promise.all(evaluations.map(reevaluateEvaluation));
+  await Promise.all(
+    evaluations.map(async (evaluation) => await saveResult(evaluation, scenario, modelOutput)),
+  );
+
+  // const cells = await prisma.scenarioVariantCell.findMany({
+  //   where: {
+  //     promptVariantId: variantId,
+  //     retrievalStatus: "COMPLETE",
+  //     testScenario: { visible: true },
+  //   },
+  //   include: { testScenario: true, modelOutput: { include: { OutputEvaluation: true } } },
+  // });
+
+  // await Promise.all(
+  //   evaluations.map(async (evaluation) => {
+  //     const passCount = cells.filter((cell) =>
+  //       runOneEval(cell.modelOutput as ModelOutput, cell.testScenario, evaluation),
+  //     ).length;
+  //     const failCount = cells.length - passCount;
+
+  //     await prisma.evaluationResult.upsert({
+  //       where: {
+  //         evaluationId_promptVariantId: {
+  //           evaluationId: evaluation.id,
+  //           promptVariantId: variantId,
+  //         },
+  //       },
+  //       create: {
+  //         evaluationId: evaluation.id,
+  //         promptVariantId: variantId,
+  //         passCount,
+  //         failCount,
+  //       },
+  //       update: {
+  //         passCount,
+  //         failCount,
+  //       },
+  //     });
+  //   }),
+  // );
+};
+
+export const runAllEvals = async (experimentId: string) => {
+  const outputs = await prisma.modelOutput.findMany({
+    where: {
+      scenarioVariantCell: {
+        promptVariant: {
+          experimentId,
+          visible: true,
+        },
+        testScenario: {
+          visible: true,
+        },
+      },
+    },
+    include: {
+      scenarioVariantCell: {
+        include: {
+          testScenario: true,
+        },
+      },
+      outputEvaluation: true,
+    },
+  });
+  const evals = await prisma.evaluation.findMany({
+    where: { experimentId },
+  });
+
+  await Promise.all(
+    outputs.map(async (output) => {
+      const unrunEvals = evals.filter(
+        (evaluation) => !output.outputEvaluation.find((e) => e.evaluationId === evaluation.id),
+      );
+
+      await Promise.all(
+        unrunEvals.map(async (evaluation) => {
+          await saveResult(evaluation, output.scenarioVariantCell.testScenario, output);
+        }),
+      );
+    }),
+  );
+
+  // const cells = await prisma.scenarioVariantCell.findMany({
+  //   where: {
+  //     promptVariantId: { in: variants.map((v) => v.id) },
+  //     testScenario: { visible: true },
+  //     statusCode: { notIn: [429] },
+  //   },
+  //   include: { testScenario: true, modelOutput: true },
+  // });
+
+  // await Promise.all(
+  //   variants.map(async (variant) => {
+  //     const variantCells = cells.filter((cell) => cell.promptVariantId === variant.id);
+  //     const passCount = variantCells.filter((cell) =>
+  //       runOneEval(cell.modelOutput as ModelOutput, cell.testScenario, evaluation),
+  //     ).length;
+  //     const failCount = variantCells.length - passCount;
+
+  //     await prisma.evaluationResult.upsert({
+  //       where: {
+  //         evaluationId_promptVariantId: {
+  //           evaluationId: evaluation.id,
+  //           promptVariantId: variant.id,
+  //         },
+  //       },
+  //       create: {
+  //         evaluationId: evaluation.id,
+  //         promptVariantId: variant.id,
+  //         passCount,
+  //         failCount,
+  //       },
+  //       update: {
+  //         passCount,
+  //         failCount,
+  //       },
+  //     });
+  //   }),
+  // );
 };

--- a/src/server/utils/evaluations.ts
+++ b/src/server/utils/evaluations.ts
@@ -4,7 +4,7 @@ import { runOneEval } from "./runOneEval";
 import { type Scenario } from "~/components/OutputsTable/types";
 
 const saveResult = async (evaluation: Evaluation, scenario: Scenario, modelOutput: ModelOutput) => {
-  const result = runOneEval(evaluation, scenario, modelOutput);
+  const result = await runOneEval(evaluation, scenario, modelOutput);
   return await prisma.outputEvaluation.upsert({
     where: {
       modelOutputId_evaluationId: {
@@ -15,10 +15,10 @@ const saveResult = async (evaluation: Evaluation, scenario: Scenario, modelOutpu
     create: {
       modelOutputId: modelOutput.id,
       evaluationId: evaluation.id,
-      result,
+      ...result,
     },
     update: {
-      result,
+      ...result,
     },
   });
 };
@@ -35,43 +35,6 @@ export const runEvalsForOutput = async (
   await Promise.all(
     evaluations.map(async (evaluation) => await saveResult(evaluation, scenario, modelOutput)),
   );
-
-  // const cells = await prisma.scenarioVariantCell.findMany({
-  //   where: {
-  //     promptVariantId: variantId,
-  //     retrievalStatus: "COMPLETE",
-  //     testScenario: { visible: true },
-  //   },
-  //   include: { testScenario: true, modelOutput: { include: { OutputEvaluation: true } } },
-  // });
-
-  // await Promise.all(
-  //   evaluations.map(async (evaluation) => {
-  //     const passCount = cells.filter((cell) =>
-  //       runOneEval(cell.modelOutput as ModelOutput, cell.testScenario, evaluation),
-  //     ).length;
-  //     const failCount = cells.length - passCount;
-
-  //     await prisma.evaluationResult.upsert({
-  //       where: {
-  //         evaluationId_promptVariantId: {
-  //           evaluationId: evaluation.id,
-  //           promptVariantId: variantId,
-  //         },
-  //       },
-  //       create: {
-  //         evaluationId: evaluation.id,
-  //         promptVariantId: variantId,
-  //         passCount,
-  //         failCount,
-  //       },
-  //       update: {
-  //         passCount,
-  //         failCount,
-  //       },
-  //     });
-  //   }),
-  // );
 };
 
 export const runAllEvals = async (experimentId: string) => {
@@ -113,42 +76,4 @@ export const runAllEvals = async (experimentId: string) => {
       );
     }),
   );
-
-  // const cells = await prisma.scenarioVariantCell.findMany({
-  //   where: {
-  //     promptVariantId: { in: variants.map((v) => v.id) },
-  //     testScenario: { visible: true },
-  //     statusCode: { notIn: [429] },
-  //   },
-  //   include: { testScenario: true, modelOutput: true },
-  // });
-
-  // await Promise.all(
-  //   variants.map(async (variant) => {
-  //     const variantCells = cells.filter((cell) => cell.promptVariantId === variant.id);
-  //     const passCount = variantCells.filter((cell) =>
-  //       runOneEval(cell.modelOutput as ModelOutput, cell.testScenario, evaluation),
-  //     ).length;
-  //     const failCount = variantCells.length - passCount;
-
-  //     await prisma.evaluationResult.upsert({
-  //       where: {
-  //         evaluationId_promptVariantId: {
-  //           evaluationId: evaluation.id,
-  //           promptVariantId: variant.id,
-  //         },
-  //       },
-  //       create: {
-  //         evaluationId: evaluation.id,
-  //         promptVariantId: variant.id,
-  //         passCount,
-  //         failCount,
-  //       },
-  //       update: {
-  //         passCount,
-  //         failCount,
-  //       },
-  //     });
-  //   }),
-  // );
 };

--- a/src/server/utils/runOneEval.ts
+++ b/src/server/utils/runOneEval.ts
@@ -2,30 +2,31 @@ import { type Evaluation, type ModelOutput, type TestScenario } from "@prisma/cl
 import { type ChatCompletion } from "openai/resources/chat";
 import { type VariableMap, fillTemplate } from "./fillTemplate";
 
-export const evaluateOutput = (
-  modelOutput: ModelOutput,
-  scenario: TestScenario,
+export const runOneEval = (
   evaluation: Evaluation,
-): boolean => {
+  scenario: TestScenario,
+  modelOutput: ModelOutput,
+): number => {
   const output = modelOutput.output as unknown as ChatCompletion;
+
   const message = output?.choices?.[0]?.message;
 
-  if (!message) return false;
+  if (!message) return 0;
 
   const stringifiedMessage = message.content ?? JSON.stringify(message.function_call);
 
   const matchRegex = fillTemplate(evaluation.value, scenario.variableValues as VariableMap);
 
-  let match;
+  let result;
 
   switch (evaluation.evalType) {
     case "CONTAINS":
-      match = stringifiedMessage.match(matchRegex) !== null;
+      result = stringifiedMessage.match(matchRegex) !== null ? 1 : 0;
       break;
     case "DOES_NOT_CONTAIN":
-      match = stringifiedMessage.match(matchRegex) === null;
+      result = stringifiedMessage.match(matchRegex) === null ? 1 : 0;
       break;
   }
 
-  return match;
+  return result;
 };

--- a/src/server/utils/runOneEval.ts
+++ b/src/server/utils/runOneEval.ts
@@ -1,32 +1,93 @@
 import { type Evaluation, type ModelOutput, type TestScenario } from "@prisma/client";
 import { type ChatCompletion } from "openai/resources/chat";
 import { type VariableMap, fillTemplate } from "./fillTemplate";
+import { openai } from "./openai";
+import dedent from "dedent";
 
-export const runOneEval = (
+export const runGpt4Eval = async (
+  evaluation: Evaluation,
+  scenario: TestScenario,
+  message: ChatCompletion.Choice.Message,
+): Promise<{ result: number; details: string }> => {
+  const output = await openai.chat.completions.create({
+    model: "gpt-4-0613",
+    messages: [
+      {
+        role: "system",
+        content: dedent`
+        You are a highly intelligent AI model and have been tasked with evaluating the quality of a simpler model. Your objective is to determine whether the simpler model has produced a successful and correct output. You should return "true" if the output was successful and "false" if it was not. Pay more attention to the semantics of the output than the formatting. Success is defined in the following terms:
+        ---
+        ${evaluation.value}
+        `,
+      },
+      {
+        role: "user",
+        content: `Scenario:\n---\n${JSON.stringify(scenario.variableValues, null, 2)}`,
+      },
+      {
+        role: "user",
+        content: `The full output of the simpler message:\n---\n${JSON.stringify(
+          message.content ?? message.function_call,
+          null,
+          2,
+        )}`,
+      },
+    ],
+    function_call: {
+      name: "report_success",
+    },
+    functions: [
+      {
+        name: "report_success",
+        parameters: {
+          type: "object",
+          required: ["thoughts", "success"],
+          properties: {
+            thoughts: {
+              type: "string",
+              description: "Explain your reasoning for considering this a pass or fail",
+            },
+            success: {
+              type: "boolean",
+              description:
+                "Whether the simpler model successfully completed the task for this scenario",
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  try {
+    const out = JSON.parse(output.choices[0]?.message?.function_call?.arguments ?? "");
+    return { result: out.success ? 1 : 0, details: out.thoughts ?? JSON.stringify(out) };
+  } catch (e) {
+    console.error(e);
+    return { result: 0, details: "Error parsing GPT-4 output" };
+  }
+};
+
+export const runOneEval = async (
   evaluation: Evaluation,
   scenario: TestScenario,
   modelOutput: ModelOutput,
-): number => {
+): Promise<{ result: number; details?: string }> => {
   const output = modelOutput.output as unknown as ChatCompletion;
 
   const message = output?.choices?.[0]?.message;
 
-  if (!message) return 0;
+  if (!message) return { result: 0 };
 
   const stringifiedMessage = message.content ?? JSON.stringify(message.function_call);
 
   const matchRegex = fillTemplate(evaluation.value, scenario.variableValues as VariableMap);
 
-  let result;
-
   switch (evaluation.evalType) {
     case "CONTAINS":
-      result = stringifiedMessage.match(matchRegex) !== null ? 1 : 0;
-      break;
+      return { result: stringifiedMessage.match(matchRegex) !== null ? 1 : 0 };
     case "DOES_NOT_CONTAIN":
-      result = stringifiedMessage.match(matchRegex) === null ? 1 : 0;
-      break;
+      return { result: stringifiedMessage.match(matchRegex) === null ? 1 : 0 };
+    case "GPT4_EVAL":
+      return await runGpt4Eval(evaluation, scenario, message);
   }
-
-  return result;
 };


### PR DESCRIPTION
This is a fairly large refactoring of our eval code and the addition of a major new feature: GPT-4 evals!

You can now add an evaluation of the type "GPT4_EVAL". This lets you enter arbitrary eval instructions, which will be passed along with your scenario variables and the completion to be evaluated to GPT-4.

GPT-4 will then evaluate each output based on those instructions and decide whether it passes or fails.