### PR TITLE
Allow user to duplicate prompt

### DIFF
--- a/src/components/OutputsTable/VariantHeader.tsx
+++ b/src/components/OutputsTable/VariantHeader.tsx
@@ -13,6 +13,7 @@ import {
   MenuDivider,
   Text,
   GridItem,
+  Spinner,
 } from "@chakra-ui/react"; // Changed here
 import { BsFillTrashFill, BsGear } from "react-icons/bs";
 import { FaRegClone } from "react-icons/fa";
@@ -63,6 +64,16 @@ export default function VariantHeader(props: { variant: PromptVariant; canHide: 
   );
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const duplicateMutation = api.promptVariants.create.useMutation();
+
+  const [duplicateVariant, duplicationInProgress] = useHandledAsyncCallback(async () => {
+    console.log("duplicating variant");
+    await duplicateMutation.mutateAsync({
+      experimentId: props.variant.experimentId,
+      variantId: props.variant.id,
+    });
+    await utils.promptVariants.list.invalidate();
+  }, [duplicateMutation, props.variant.experimentId, props.variant.id]);
 
   return (
     <GridItem
@@ -75,7 +86,7 @@ export default function VariantHeader(props: { variant: PromptVariant; canHide: 
     >
       <HStack
         spacing={4}
-        alignItems="center"
+        alignItems="flex-start"
         minH={headerMinHeight}
         draggable={!isInputHovered}
         onDragStart={(e) => {
@@ -98,10 +109,11 @@ export default function VariantHeader(props: { variant: PromptVariant; canHide: 
         <Icon
           as={RiDraggable}
           boxSize={6}
+          mt={2}
           color="gray.400"
           _hover={{ color: "gray.800", cursor: "pointer" }}
         />
-        <AutoResizeTextArea // Changed to Input
+        <AutoResizeTextArea
           size="sm"
           value={label}
           onChange={(e) => setLabel(e.target.value)}
@@ -118,18 +130,26 @@ export default function VariantHeader(props: { variant: PromptVariant; canHide: 
           onMouseEnter={() => setIsInputHovered(true)}
           onMouseLeave={() => setIsInputHovered(false)}
         />
+
         <Menu
           z-index="dropdown"
           onOpen={() => setMenuOpen(true)}
           onClose={() => setMenuOpen(false)}
         >
-          <MenuButton>
-            <Button variant="ghost">
-              <Icon as={BsGear} />
-            </Button>
-          </MenuButton>
+          {duplicationInProgress ? (
+            <Spinner boxSize={4} mx={3} my={3} />
+          ) : (
+            <MenuButton>
+              <Button variant="ghost">
+                <Icon as={BsGear} />
+              </Button>
+            </MenuButton>
+          )}
+
           <MenuList mt={-3} fontSize="md">
-            <MenuItem icon={<Icon as={FaRegClone} boxSize={4} w={5} />}>Duplicate</MenuItem>
+            <MenuItem icon={<Icon as={FaRegClone} boxSize={4} w={5} />} onClick={duplicateVariant}>
+              Duplicate
+            </MenuItem>
             <MenuItem icon={<Icon as={RiExchangeFundsFill} boxSize={5} />}>Change Model</MenuItem>
             {props.canHide && (
               <>

--- a/src/components/OutputsTable/VariantHeader.tsx
+++ b/src/components/OutputsTable/VariantHeader.tsx
@@ -2,11 +2,24 @@ import { useState, type DragEvent } from "react";
 import { type PromptVariant } from "./types";
 import { api } from "~/utils/api";
 import { useHandledAsyncCallback } from "~/utils/hooks";
-import { Button, HStack, Icon, Tooltip } from "@chakra-ui/react"; // Changed here
-import { BsX } from "react-icons/bs";
-import { RiDraggable } from "react-icons/ri";
+import {
+  Button,
+  HStack,
+  Icon,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  MenuDivider,
+  Text,
+  GridItem,
+} from "@chakra-ui/react"; // Changed here
+import { BsFillTrashFill, BsGear } from "react-icons/bs";
+import { FaRegClone } from "react-icons/fa";
+import { RiDraggable, RiExchangeFundsFill } from "react-icons/ri";
 import { cellPadding, headerMinHeight } from "../constants";
 import AutoResizeTextArea from "../AutoResizeTextArea";
+import { stickyHeaderStyle } from "./styles";
 
 export default function VariantHeader(props: { variant: PromptVariant; canHide: boolean }) {
   const utils = api.useContext();
@@ -49,59 +62,91 @@ export default function VariantHeader(props: { variant: PromptVariant; canHide: 
     [reorderMutation, props.variant.id],
   );
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <HStack
-      spacing={4}
-      alignItems="center"
-      minH={headerMinHeight}
-      draggable={!isInputHovered}
-      onDragStart={(e) => {
-        e.dataTransfer.setData("text/plain", props.variant.id);
-        e.currentTarget.style.opacity = "0.4";
+    <GridItem
+      padding={0}
+      sx={{
+        ...stickyHeaderStyle,
+        zIndex: menuOpen ? "dropdown" : stickyHeaderStyle.zIndex,
       }}
-      onDragEnd={(e) => {
-        e.currentTarget.style.opacity = "1";
-      }}
-      onDragOver={(e) => {
-        e.preventDefault();
-        setIsDragTarget(true);
-      }}
-      onDragLeave={() => {
-        setIsDragTarget(false);
-      }}
-      onDrop={onReorder}
-      backgroundColor={isDragTarget ? "gray.100" : "transparent"}
+      borderTopWidth={1}
     >
-      <Icon
-        as={RiDraggable}
-        boxSize={6}
-        color="gray.400"
-        _hover={{ color: "gray.800", cursor: "pointer" }}
-      />
-      <AutoResizeTextArea // Changed to Input
-        size="sm"
-        value={label}
-        onChange={(e) => setLabel(e.target.value)}
-        onBlur={onSaveLabel}
-        placeholder="Variant Name"
-        borderWidth={1}
-        borderColor="transparent"
-        fontWeight="bold"
-        fontSize={16}
-        _hover={{ borderColor: "gray.300" }}
-        _focus={{ borderColor: "blue.500", outline: "none" }}
-        flex={1}
-        px={cellPadding.x}
-        onMouseEnter={() => setIsInputHovered(true)}
-        onMouseLeave={() => setIsInputHovered(false)}
-      />
-      {props.canHide && (
-        <Tooltip label="Remove Variant" hasArrow>
-          <Button variant="ghost" colorScheme="gray" size="sm" onClick={onHide}>
-            <Icon as={BsX} boxSize={6} />
-          </Button>
-        </Tooltip>
-      )}
-    </HStack>
+      <HStack
+        spacing={4}
+        alignItems="center"
+        minH={headerMinHeight}
+        draggable={!isInputHovered}
+        onDragStart={(e) => {
+          e.dataTransfer.setData("text/plain", props.variant.id);
+          e.currentTarget.style.opacity = "0.4";
+        }}
+        onDragEnd={(e) => {
+          e.currentTarget.style.opacity = "1";
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setIsDragTarget(true);
+        }}
+        onDragLeave={() => {
+          setIsDragTarget(false);
+        }}
+        onDrop={onReorder}
+        backgroundColor={isDragTarget ? "gray.100" : "transparent"}
+      >
+        <Icon
+          as={RiDraggable}
+          boxSize={6}
+          color="gray.400"
+          _hover={{ color: "gray.800", cursor: "pointer" }}
+        />
+        <AutoResizeTextArea // Changed to Input
+          size="sm"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          onBlur={onSaveLabel}
+          placeholder="Variant Name"
+          borderWidth={1}
+          borderColor="transparent"
+          fontWeight="bold"
+          fontSize={16}
+          _hover={{ borderColor: "gray.300" }}
+          _focus={{ borderColor: "blue.500", outline: "none" }}
+          flex={1}
+          px={cellPadding.x}
+          onMouseEnter={() => setIsInputHovered(true)}
+          onMouseLeave={() => setIsInputHovered(false)}
+        />
+        <Menu
+          z-index="dropdown"
+          onOpen={() => setMenuOpen(true)}
+          onClose={() => setMenuOpen(false)}
+        >
+          <MenuButton>
+            <Button variant="ghost">
+              <Icon as={BsGear} />
+            </Button>
+          </MenuButton>
+          <MenuList mt={-3} fontSize="md">
+            <MenuItem icon={<Icon as={FaRegClone} boxSize={4} w={5} />}>Duplicate</MenuItem>
+            <MenuItem icon={<Icon as={RiExchangeFundsFill} boxSize={5} />}>Change Model</MenuItem>
+            {props.canHide && (
+              <>
+                <MenuDivider />
+                <MenuItem
+                  onClick={onHide}
+                  icon={<Icon as={BsFillTrashFill} boxSize={5} />}
+                  color="red.600"
+                  _hover={{ backgroundColor: "red.50" }}
+                >
+                  <Text>Hide</Text>
+                </MenuItem>
+              </>
+            )}
+          </MenuList>
+        </Menu>
+      </HStack>
+    </GridItem>
   );
 }

--- a/src/components/OutputsTable/VariantHeader.tsx
+++ b/src/components/OutputsTable/VariantHeader.tsx
@@ -67,7 +67,6 @@ export default function VariantHeader(props: { variant: PromptVariant; canHide: 
   const duplicateMutation = api.promptVariants.create.useMutation();
 
   const [duplicateVariant, duplicationInProgress] = useHandledAsyncCallback(async () => {
-    console.log("duplicating variant");
     await duplicateMutation.mutateAsync({
       experimentId: props.variant.experimentId,
       variantId: props.variant.id,

--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -43,9 +43,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
       <ScenariosHeader headerRows={headerRows} numScenarios={scenarios.data.length} />
 
       {variants.data.map((variant) => (
-        <GridItem key={variant.uiId} padding={0} sx={stickyHeaderStyle} borderTopWidth={1}>
-          <VariantHeader variant={variant} canHide={variants.data.length > 1} />
-        </GridItem>
+        <VariantHeader key={variant.uiId} variant={variant} canHide={variants.data.length > 1} />
       ))}
       <GridItem
         rowSpan={scenarios.data.length + headerRows}

--- a/src/server/api/routers/promptVariants.router.ts
+++ b/src/server/api/routers/promptVariants.router.ts
@@ -141,7 +141,6 @@ export const promptVariantsRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ input }) => {
-      console.log('duplicating variant')
       let originalVariant: PromptVariant | null = null;
       if (input.variantId) {
         originalVariant = await prisma.promptVariant.findUnique({

--- a/src/server/utils/reorderPromptVariants.ts
+++ b/src/server/utils/reorderPromptVariants.ts
@@ -1,0 +1,61 @@
+import { prisma } from "~/server/db";
+
+export const reorderPromptVariants = async (movedId: string, stationaryTargetId: string, alwaysInsertRight?: boolean) => {
+  const moved = await prisma.promptVariant.findUnique({
+    where: {
+      id: movedId,
+    },
+  });
+
+  const target = await prisma.promptVariant.findUnique({
+    where: {
+      id: stationaryTargetId,
+    },
+  });
+
+  if (!moved || !target || moved.experimentId !== target.experimentId) {
+    throw new Error(`Prompt Variant with id ${movedId} or ${stationaryTargetId} does not exist`);
+  }
+
+  const visibleItems = await prisma.promptVariant.findMany({
+    where: {
+      experimentId: moved.experimentId,
+      visible: true,
+    },
+    orderBy: {
+      sortIndex: "asc",
+    },
+  });
+
+  // Remove the moved item from its current position
+  const orderedItems = visibleItems.filter((item) => item.id !== moved.id);
+
+  // Find the index of the moved item and the target item
+  const movedIndex = visibleItems.findIndex((item) => item.id === moved.id);
+  const targetIndex = visibleItems.findIndex((item) => item.id === target.id);
+
+  // Determine the new index for the moved item
+  let newIndex;
+  if (movedIndex < targetIndex || alwaysInsertRight) {
+    newIndex = targetIndex + 1; // Insert after the target item
+  } else {
+    newIndex = targetIndex; // Insert before the target item
+  }
+
+  // Insert the moved item at the new position
+  orderedItems.splice(newIndex, 0, moved);
+
+  // Now, we need to update all the items with their new sortIndex
+  await prisma.$transaction(
+    orderedItems.map((item, index) => {
+      return prisma.promptVariant.update({
+        where: {
+          id: item.id,
+        },
+        data: {
+          sortIndex: index,
+        },
+      });
+    }),
+  );
+};

--- a/src/server/utils/reorderPromptVariants.ts
+++ b/src/server/utils/reorderPromptVariants.ts
@@ -1,6 +1,10 @@
 import { prisma } from "~/server/db";
 
-export const reorderPromptVariants = async (movedId: string, stationaryTargetId: string, alwaysInsertRight?: boolean) => {
+export const reorderPromptVariants = async (
+  movedId: string,
+  stationaryTargetId: string,
+  alwaysInsertRight?: boolean,
+) => {
   const moved = await prisma.promptVariant.findUnique({
     where: {
       id: movedId,


### PR DESCRIPTION
This change is the first step to allow the user to choose new models for their prompts.

## Changes
* Add drop-down menu for duplicating/hiding a prompt
* Change promptVariants `create` route to optionally duplicate an optionally provided variant

Before:
<img width="684" alt="Screenshot 2023-07-18 at 1 43 05 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/0d9dba9d-b55a-40ff-9845-becf135186fb">

After:
<img width="542" alt="Screenshot 2023-07-18 at 1 42 55 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/907cb0f7-4f92-490e-906b-cc98c3a85833">
