### PR TITLE
Add new predefined refinement options

### DIFF
--- a/src/components/OutputsTable/OutputCell/OutputCell.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputCell.tsx
@@ -42,8 +42,7 @@ export default function OutputCell({
     { refetchInterval },
   );
 
-  const { mutateAsync: hardRefetchMutate } =
-    api.scenarioVariantCells.forceRefetch.useMutation();
+  const { mutateAsync: hardRefetchMutate } = api.scenarioVariantCells.forceRefetch.useMutation();
   const [hardRefetch, hardRefetching] = useHandledAsyncCallback(async () => {
     await hardRefetchMutate({ scenarioId: scenario.id, variantId: variant.id });
     await utils.scenarioVariantCells.get.invalidate({

--- a/src/components/RefinePromptModal/CompareFunctions.tsx
+++ b/src/components/RefinePromptModal/CompareFunctions.tsx
@@ -35,7 +35,7 @@ const CompareFunctions = ({
 
   return (
     <HStack w="full" spacing={5}>
-      <VStack w="full" spacing={4} maxH="50vh" fontSize={12} lineHeight={1} overflowY="auto">
+      <VStack w="full" spacing={4} maxH="40vh" fontSize={12} lineHeight={1} overflowY="auto">
         <DiffViewer
           oldValue={originalFunction}
           newValue={newFunction || originalFunction}

--- a/src/components/RefinePromptModal/CustomInstructionsInput.tsx
+++ b/src/components/RefinePromptModal/CustomInstructionsInput.tsx
@@ -1,0 +1,82 @@
+import {
+  Button,
+  Spinner,
+  InputGroup,
+  InputRightElement,
+  Icon,
+  HStack,
+} from "@chakra-ui/react";
+import { IoMdSend } from "react-icons/io";
+import AutoResizeTextArea from "../AutoResizeTextArea";
+
+export const CustomInstructionsInput = ({
+  instructions,
+  setInstructions,
+  loading,
+  onSubmit,
+}: {
+  instructions: string;
+  setInstructions: (instructions: string) => void;
+  loading: boolean;
+  onSubmit: () => void;
+}) => {
+  return (
+    <InputGroup
+      size="md"
+      w="full"
+      maxW="600"
+      boxShadow="0 0 40px 4px rgba(0, 0, 0, 0.1);"
+      borderRadius={8}
+      alignItems="center"
+      colorScheme="orange"
+    >
+      <AutoResizeTextArea
+        value={instructions}
+        onChange={(e) => setInstructions(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.metaKey && !e.ctrlKey && !e.shiftKey) {
+            e.preventDefault();
+            e.currentTarget.blur();
+            onSubmit();
+          }
+        }}
+        placeholder="Send custom instructions"
+        py={4}
+        pl={4}
+        pr={12}
+        colorScheme="orange"
+        borderColor="gray.300"
+        borderWidth={1}
+        _hover={{
+          borderColor: "gray.300",
+        }}
+        _focus={{
+          borderColor: "gray.300",
+        }}
+        isDisabled={loading}
+      />
+      <HStack></HStack>
+      <InputRightElement width="8" height="full">
+        <Button
+          h="8"
+          w="8"
+          minW="unset"
+          size="sm"
+          onClick={() => onSubmit()}
+          disabled={!instructions}
+          variant={instructions ? "solid" : "ghost"}
+          mr={4}
+          borderRadius="8"
+          bgColor={instructions ? "orange.400" : "transparent"}
+          colorScheme="orange"
+        >
+          {loading ? (
+            <Spinner boxSize={4} />
+          ) : (
+            <Icon as={IoMdSend} color={instructions ? "white" : "gray.500"} boxSize={5} />
+          )}
+        </Button>
+      </InputRightElement>
+    </InputGroup>
+  );
+};

--- a/src/components/RefinePromptModal/CustomInstructionsInput.tsx
+++ b/src/components/RefinePromptModal/CustomInstructionsInput.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Spinner,
-  InputGroup,
-  InputRightElement,
-  Icon,
-  HStack,
-} from "@chakra-ui/react";
+import { Button, Spinner, InputGroup, InputRightElement, Icon, HStack } from "@chakra-ui/react";
 import { IoMdSend } from "react-icons/io";
 import AutoResizeTextArea from "../AutoResizeTextArea";
 

--- a/src/components/RefinePromptModal/RefineOption.tsx
+++ b/src/components/RefinePromptModal/RefineOption.tsx
@@ -1,0 +1,64 @@
+import { HStack, Icon, Heading, Text, VStack, GridItem } from "@chakra-ui/react";
+import { type IconType } from "react-icons";
+import { refineOptions, type RefineOptionLabel } from "./refineOptions";
+
+export const RefineOption = ({
+  label,
+  activeLabel,
+  icon,
+  onClick,
+  loading,
+}: {
+  label: RefineOptionLabel;
+  activeLabel: RefineOptionLabel | undefined;
+  icon: IconType;
+  onClick: (label: RefineOptionLabel) => void;
+  loading: boolean;
+}) => {
+  const isActive = activeLabel === label;
+  const desciption = refineOptions[label].description;
+
+  return (
+    <GridItem w="80" h="44">
+      <VStack
+        w="full"
+        h="full"
+        onClick={() => {
+          !loading && onClick(label);
+        }}
+        borderColor={isActive ? "blue.500" : "gray.200"}
+        borderWidth={2}
+        borderRadius={16}
+        padding={6}
+        backgroundColor="gray.50"
+        _hover={
+          loading
+            ? undefined
+            : {
+                backgroundColor: "gray.100",
+              }
+        }
+        spacing={8}
+        boxShadow="0 0 40px 4px rgba(0, 0, 0, 0.1);"
+        cursor="pointer"
+        opacity={loading ? 0.5 : 1}
+      >
+        <HStack cursor="pointer" spacing={6} fontSize="sm" fontWeight="medium" color="gray.500">
+          <Icon as={icon} boxSize={12} />
+          <Heading size="md" fontFamily="inconsolata, monospace">
+            {label}
+          </Heading>
+        </HStack>
+        <Text
+          fontSize="sm"
+          color="gray.500"
+          flexWrap="wrap"
+          wordBreak="break-word"
+          overflowWrap="break-word"
+        >
+          {desciption}
+        </Text>
+      </VStack>
+    </GridItem>
+  );
+};

--- a/src/components/RefinePromptModal/refineOptions.ts
+++ b/src/components/RefinePromptModal/refineOptions.ts
@@ -1,0 +1,70 @@
+// Super hacky, but we'll redo the organization when we have more models
+
+export type RefineOptionLabel = "Add chain of thought" | "Convert to function call";
+
+export const refineOptions: Record<
+  RefineOptionLabel,
+  { description: string; instructions: string }
+> = {
+  "Add chain of thought": {
+    description: "Asks the model to think about its answer before it gives it to you.",
+    instructions: `Adding chain of thought means asking the model to think about its answer before it gives it to you. This is useful for getting more accurate answers. Do not add an assistant message.
+      
+      Add chain of thought to the original prompt.`,
+  },
+  "Convert to function call": {
+    description: "Converts the prompt to a function call.",
+    instructions: `Function calls are a specific way for an LLM to return output. This is what a prompt looks like without using function calls:
+    
+    prompt = {
+      model: "gpt-4",
+      stream: true,
+      messages: [
+        {
+          role: "system",
+          content: \`Evaluate sentiment.\`,
+        },
+        {
+          role: "user",
+          content: \`This is the user's message: \${scenario.user_message}. Return "positive" or "negative" or "neutral"\`,
+        },
+      ],
+    };
+  
+    This is what one looks like using function calls:
+  
+    prompt = {
+      model: "gpt-3.5-turbo-0613",
+      stream: true,
+      messages: [
+        {
+          role: "system",
+          content: "Evaluate sentiment.",
+        },
+        {
+          role: "user",
+          content: scenario.user_message,
+        },
+      ],
+      functions: [
+        {
+          name: "extract_sentiment",
+          parameters: {
+            type: "object", // parameters must always be an object with a properties key
+            properties: { // properties key is required
+              sentiment: {
+                type: "string",
+                description: "one of positive/negative/neutral",
+              },
+            },
+          },
+        },
+      ],
+      function_call: {
+        name: "extract_sentiment",
+      },
+    };  
+    
+    Add a function call that takes one or more nested parameters.`,
+  },
+};

--- a/src/components/SelectModelModal/SelectModelModal.tsx
+++ b/src/components/SelectModelModal/SelectModelModal.tsx
@@ -10,7 +10,10 @@ import {
   VStack,
   Text,
   Spinner,
+  HStack,
+  Icon,
 } from "@chakra-ui/react";
+import { RiExchangeFundsFill } from "react-icons/ri";
 import { useState } from "react";
 import { type SupportedModel } from "~/server/types";
 import { ModelStatsCard } from "./ModelStatsCard";
@@ -49,7 +52,12 @@ export const SelectModelModal = ({
     <Modal isOpen onClose={onClose} size={{ base: "xl", sm: "2xl", md: "3xl" }}>
       <ModalOverlay />
       <ModalContent w={1200}>
-        <ModalHeader>Select a New Model</ModalHeader>
+        <ModalHeader>
+          <HStack>
+            <Icon as={RiExchangeFundsFill} />
+            <Text>Change Model</Text>
+          </HStack>
+        </ModalHeader>
         <ModalCloseButton />
         <ModalBody maxW="unset">
           <VStack spacing={8}>

--- a/src/components/VariantHeader/VariantHeaderMenuButton.tsx
+++ b/src/components/VariantHeader/VariantHeaderMenuButton.tsx
@@ -12,9 +12,8 @@ import {
   Text,
   Spinner,
 } from "@chakra-ui/react";
-import { BsFillTrashFill, BsGear } from "react-icons/bs";
+import { BsFillTrashFill, BsGear, BsStars } from "react-icons/bs";
 import { FaRegClone } from "react-icons/fa";
-import { AiOutlineDiff } from "react-icons/ai";
 import { useState } from "react";
 import { RefinePromptModal } from "../RefinePromptModal/RefinePromptModal";
 import { RiExchangeFundsFill } from "react-icons/ri";
@@ -79,7 +78,7 @@ export default function VariantHeaderMenuButton({
             Change Model
           </MenuItem>
           <MenuItem
-            icon={<Icon as={AiOutlineDiff} boxSize={5} />}
+            icon={<Icon as={BsStars} boxSize={5} />}
             onClick={() => setRefinePromptModalOpen(true)}
           >
             Refine

--- a/src/server/utils/deriveNewContructFn.ts
+++ b/src/server/utils/deriveNewContructFn.ts
@@ -40,59 +40,6 @@ const requestUpdatedPromptFunction = async (
 ) => {
   const originalModel = originalVariant.model as SupportedModel;
   let newContructionFn = "";
-  const usefulTips = `Adding chain of thought means asking the model to think about its answer before it gives it to you. This is useful for getting more accurate answers. Do not add an assistant message.
-  
-  Function calls are a specific way for an LLM to return output. This is what a prompt looks like without using function calls:
-  
-  prompt = {
-    model: "gpt-4",
-    stream: true,
-    messages: [
-      {
-        role: "system",
-        content: \`Evaluate sentiment.\`,
-      },
-      {
-        role: "user",
-        content: \`This is the user's message: \${scenario.user_message}. Return "positive" or "negative" or "neutral"\`,
-      },
-    ],
-  };
-
-  This is what one looks like using function calls:
-
-  prompt = {
-    model: "gpt-3.5-turbo-0613",
-    stream: true,
-    messages: [
-      {
-        role: "system",
-        content: "Evaluate sentiment.",
-      },
-      {
-        role: "user",
-        content: scenario.user_message,
-      },
-    ],
-    functions: [
-      {
-        name: "extract_sentiment",
-        parameters: {
-          type: "object", // parameters must always be an object with a properties key
-          properties: { // properties key is required
-            sentiment: {
-              type: "string",
-              description: "one of positive/negative/neutral",
-            },
-          },
-        },
-      },
-    ],
-    function_call: {
-      name: "extract_sentiment",
-    },
-  };  
-  `;
   for (let i = 0; i < NUM_RETRIES; i++) {
     try {
       const messages: CompletionCreateParams.CreateChatCompletionRequestNonStreaming.Message[] = [
@@ -113,12 +60,8 @@ const requestUpdatedPromptFunction = async (
       }
       if (instructions) {
         messages.push({
-          role: "system",
-          content: `Here is some useful information about prompt engineering: ${usefulTips}`,
-        });
-        messages.push({
           role: "user",
-          content: `Follow these instructions: ${instructions}`,
+          content: instructions,
         });
       }
       messages.push({


### PR DESCRIPTION
Now the user can select from a couple provided refinement options that work reasonably well (but are not perfect).

## Changes
* Modularize CustomInstructionsInput
* Add RefineOption
* Store custom instructions in `refineOptions.ts`

Before:
<img width="1370" alt="Screenshot 2023-07-19 at 8 01 22 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/645f75f6-1af2-470a-9a6e-cf1ca0ec0cbe">

After:
<img width="1315" alt="Screenshot 2023-07-19 at 8 01 37 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/b1b6260c-4427-429b-8cfa-9e581a2afc83">

