### PR TITLE
Initially render AutoResizeTextArea without overflow

### DIFF
--- a/src/components/AutoResizeTextArea.tsx
+++ b/src/components/AutoResizeTextArea.tsx
@@ -14,7 +14,6 @@ export const AutoResizeTextarea: React.ForwardRefRenderFunction<
       minH="unset"
       minRows={minRows}
       overflowY={isRerendered ? overflowY : "hidden"}
-      overflow="hidden"
       w="100%"
       resize="none"
       ref={ref}

--- a/src/components/AutoResizeTextArea.tsx
+++ b/src/components/AutoResizeTextArea.tsx
@@ -1,19 +1,23 @@
 import { Textarea, type TextareaProps } from "@chakra-ui/react";
 import ResizeTextarea from "react-textarea-autosize";
-import React from "react";
+import React, { useLayoutEffect, useState } from "react";
 
 export const AutoResizeTextarea: React.ForwardRefRenderFunction<
   HTMLTextAreaElement,
   TextareaProps & { minRows?: number }
-> = (props, ref) => {
+> = ({ minRows = 1, overflowY = "hidden", ...props }, ref) => {
+  const [isRerendered, setIsRerendered] = useState(false);
+  useLayoutEffect(() => setIsRerendered(true), []);
+
   return (
     <Textarea
       minH="unset"
+      minRows={minRows}
+      overflowY={isRerendered ? overflowY : "hidden"}
       overflow="hidden"
       w="100%"
       resize="none"
       ref={ref}
-      minRows={1}
       transition="height none"
       as={ResizeTextarea}
       {...props}


### PR DESCRIPTION
Fixes a bug that caused the scrollbar to occasionally push text that should have been contained in one line of an AutoResizeTextArea onto two by rendering all AutoResizeTextArea's first with no scroll bar and then with one if necessary.

Before:
<img width="289" alt="Screenshot 2023-07-20 at 2 56 25 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/e7720520-a6f6-4eeb-9dc9-b10a9b4d9a8f">


After:
<img width="273" alt="Screenshot 2023-07-20 at 2 55 59 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/de63cc89-547f-4f1f-8031-517aea31319b">
