### PR TITLE
Give prompt variants negative margin to account for border

### DIFF
--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -51,6 +51,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
           ...borders,
           colStart: i + 2,
           borderLeftWidth: i === 0 ? 1 : 0,
+          marginLeft: i === 0 ? "-1px" : 0,
         };
         return (
           <>


### PR DESCRIPTION
Very small UI tweak that fixes border alignment with the left-most prompt variant and the first column of cells' border.

Before:
<img width="481" alt="Screenshot 2023-07-23 at 4 47 58 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/1e9d3a41-b4a1-4a2a-8f4f-4c5aba897932">


After:
<img width="378" alt="Screenshot 2023-07-23 at 4 48 37 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/92954d71-4b86-4437-8e34-9cd64538aa13">

