### PR TITLE
Change prompt variant section background color

### DIFF
--- a/src/components/OutputsTable/OutputCell/CellContent.tsx
+++ b/src/components/OutputsTable/OutputCell/CellContent.tsx
@@ -10,8 +10,10 @@ export const CellContent = ({
   hardRefetch: () => void;
   hardRefetching: boolean;
 } & StackProps) => (
-  <VStack maxH={500} w="full" overflowY="auto" alignItems="flex-start" {...props}>
+  <VStack w="full" alignItems="flex-start" {...props}>
     <CellOptions refetchingOutput={hardRefetching} refetchOutput={hardRefetch} />
-    {children}
+    <VStack w="full" alignItems="flex-start" maxH={500} overflowY="auto">
+      {children}
+    </VStack>
   </VStack>
 );

--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -33,7 +33,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
     <Grid
       pt={4}
       pb={24}
-      pl={4}
+      pl={8}
       display="grid"
       gridTemplateColumns={`250px repeat(${variants.data.length}, minmax(300px, 1fr)) auto`}
       sx={{
@@ -53,6 +53,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
           colStart: i + 2,
           borderLeftWidth: i === 0 ? 1 : 0,
           marginLeft: i === 0 ? "-1px" : 0,
+          backgroundColor: "gray.100",
         };
         return (
           <Fragment key={variant.uiId}>

--- a/src/components/OutputsTable/styles.ts
+++ b/src/components/OutputsTable/styles.ts
@@ -1,11 +1,4 @@
-import { type GridItemProps, type SystemStyleObject } from "@chakra-ui/react";
-
-export const stickyHeaderStyle: SystemStyleObject = {
-  position: "sticky",
-  top: "0",
-  backgroundColor: "#fff",
-  zIndex: 10,
-};
+import { type GridItemProps } from "@chakra-ui/react";
 
 export const borders: GridItemProps = {
   borderRightWidth: 1,

--- a/src/components/VariantHeader/VariantHeader.tsx
+++ b/src/components/VariantHeader/VariantHeader.tsx
@@ -6,7 +6,6 @@ import { useExperimentAccess, useHandledAsyncCallback } from "~/utils/hooks";
 import { HStack, Icon, Text, GridItem, type GridItemProps } from "@chakra-ui/react"; // Changed here
 import { cellPadding, headerMinHeight } from "../constants";
 import AutoResizeTextArea from "../AutoResizeTextArea";
-import { stickyHeaderStyle } from "../OutputsTable/styles";
 import VariantHeaderMenuButton from "./VariantHeaderMenuButton";
 
 export default function VariantHeader(
@@ -53,7 +52,17 @@ export default function VariantHeader(
 
   if (!canModify) {
     return (
-      <GridItem padding={0} sx={stickyHeaderStyle} borderTopWidth={1} {...gridItemProps}>
+      <GridItem
+        padding={0}
+        sx={{
+          position: "sticky",
+          top: "0",
+          // Ensure that the menu always appears above the sticky header of other variants
+          zIndex: menuOpen ? "dropdown" : 10,
+        }}
+        borderTopWidth={1}
+        {...gridItemProps}
+      >
         <Text fontSize={16} fontWeight="bold" px={cellPadding.x} py={cellPadding.y}>
           {variant.label}
         </Text>
@@ -65,15 +74,16 @@ export default function VariantHeader(
     <GridItem
       padding={0}
       sx={{
-        ...stickyHeaderStyle,
+        position: "sticky",
+        top: "0",
         // Ensure that the menu always appears above the sticky header of other variants
-        zIndex: menuOpen ? "dropdown" : stickyHeaderStyle.zIndex,
+        zIndex: menuOpen ? "dropdown" : 10,
       }}
       borderTopWidth={1}
       {...gridItemProps}
     >
       <HStack
-        spacing={4}
+        spacing={2}
         alignItems="flex-start"
         minH={headerMinHeight}
         draggable={!isInputHovered}
@@ -92,7 +102,8 @@ export default function VariantHeader(
           setIsDragTarget(false);
         }}
         onDrop={onReorder}
-        backgroundColor={isDragTarget ? "gray.100" : "transparent"}
+        backgroundColor={isDragTarget ? "gray.200" : "gray.100"}
+        h="full"
       >
         <Icon
           as={RiDraggable}


### PR DESCRIPTION
## Changes
* Change prompt variant section background color from white to light gray
* Move cell refresh control out of scrollable area

Before:
<img width="1409" alt="Screenshot 2023-07-26 at 10 49 59 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/9d086db3-7c6a-4c08-a8a9-b85e04994e99">


After:
<img width="989" alt="Screenshot 2023-07-26 at 10 50 11 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/2a4c1d54-e0df-4d98-9e0d-bb63f78f8e55">
