### PR TITLE
Requeue rate-limited query model tasks

### DIFF
--- a/src/components/OutputsTable/VariantStats.tsx
+++ b/src/components/OutputsTable/VariantStats.tsx
@@ -21,7 +21,7 @@ export default function VariantStats(props: { variant: PromptVariant }) {
         completionTokens: 0,
         scenarioCount: 0,
         outputCount: 0,
-        awaitingRetrievals: false,
+        awaitingEvals: false,
       },
       refetchInterval,
     },
@@ -29,8 +29,8 @@ export default function VariantStats(props: { variant: PromptVariant }) {
 
   // Poll every two seconds while we are waiting for LLM retrievals to finish
   useEffect(
-    () => setRefetchInterval(data.awaitingRetrievals ? 2000 : 0),
-    [data.awaitingRetrievals],
+    () => setRefetchInterval(data.awaitingEvals ? 5000 : 0),
+    [data.awaitingEvals],
   );
 
   const [passColor, neutralColor, failColor] = useToken("colors", [
@@ -69,7 +69,7 @@ export default function VariantStats(props: { variant: PromptVariant }) {
           );
         })}
       </HStack>
-      {data.overallCost && !data.awaitingRetrievals && (
+      {data.overallCost && (
         <CostTooltip
           promptTokens={data.promptTokens}
           completionTokens={data.completionTokens}

--- a/src/components/OutputsTable/VariantStats.tsx
+++ b/src/components/OutputsTable/VariantStats.tsx
@@ -28,10 +28,7 @@ export default function VariantStats(props: { variant: PromptVariant }) {
   );
 
   // Poll every two seconds while we are waiting for LLM retrievals to finish
-  useEffect(
-    () => setRefetchInterval(data.awaitingEvals ? 5000 : 0),
-    [data.awaitingEvals],
-  );
+  useEffect(() => setRefetchInterval(data.awaitingEvals ? 5000 : 0), [data.awaitingEvals]);
 
   const [passColor, neutralColor, failColor] = useToken("colors", [
     "green.500",

--- a/src/server/api/routers/promptVariants.router.ts
+++ b/src/server/api/routers/promptVariants.router.ts
@@ -130,16 +130,7 @@ export const promptVariantsRouter = createTRPCRouter({
       const promptTokens = overallTokens._sum?.promptTokens ?? 0;
       const completionTokens = overallTokens._sum?.completionTokens ?? 0;
 
-      const awaitingRetrievals = !!(await prisma.scenarioVariantCell.findFirst({
-        where: {
-          promptVariantId: input.variantId,
-          testScenario: { visible: true },
-          // Check if is PENDING or IN_PROGRESS
-          retrievalStatus: {
-            in: ["PENDING", "IN_PROGRESS"],
-          },
-        },
-      }));
+      const awaitingEvals = !!evalResults.find((result) => result.totalCount < scenarioCount * evals.length);
 
       return {
         evalResults,
@@ -148,7 +139,7 @@ export const promptVariantsRouter = createTRPCRouter({
         overallCost: overallTokens._sum?.cost ?? 0,
         scenarioCount,
         outputCount,
-        awaitingRetrievals,
+        awaitingEvals,
       };
     }),
 

--- a/src/server/api/routers/promptVariants.router.ts
+++ b/src/server/api/routers/promptVariants.router.ts
@@ -130,7 +130,9 @@ export const promptVariantsRouter = createTRPCRouter({
       const promptTokens = overallTokens._sum?.promptTokens ?? 0;
       const completionTokens = overallTokens._sum?.completionTokens ?? 0;
 
-      const awaitingEvals = !!evalResults.find((result) => result.totalCount < scenarioCount * evals.length);
+      const awaitingEvals = !!evalResults.find(
+        (result) => result.totalCount < scenarioCount * evals.length,
+      );
 
       return {
         evalResults,

--- a/src/server/tasks/defineTask.ts
+++ b/src/server/tasks/defineTask.ts
@@ -7,9 +7,9 @@ function defineTask<TPayload>(
   taskIdentifier: string,
   taskHandler: (payload: TPayload, helpers: Helpers) => Promise<void>,
 ) {
-  const enqueue = async (payload: TPayload) => {
+  const enqueue = async (payload: TPayload, runAt?: Date) => {
     console.log("Enqueuing task", taskIdentifier, payload);
-    await quickAddJob({ connectionString: env.DATABASE_URL }, taskIdentifier, payload);
+    await quickAddJob({ connectionString: env.DATABASE_URL }, taskIdentifier, payload, { runAt });
   };
 
   const handler = (payload: TPayload, helpers: Helpers) => {

--- a/src/server/tasks/runNewEval.task.ts
+++ b/src/server/tasks/runNewEval.task.ts
@@ -1,0 +1,17 @@
+import { runAllEvals } from "../utils/evaluations";
+import defineTask from "./defineTask";
+
+export type RunNewEvalJob = {
+  experimentId: string;
+};
+
+// When a new eval is created, we want to run it on all existing outputs, but return the new eval first
+export const runNewEval = defineTask<RunNewEvalJob>("runNewEval", async (task) => {
+  console.log("RUNNING TASK", task);
+  const { experimentId } = task;
+  await runAllEvals(experimentId);
+});
+
+export const queueRunNewEval = async (experimentId: string) => {
+  await runNewEval.enqueue({ experimentId });
+};

--- a/src/server/tasks/worker.ts
+++ b/src/server/tasks/worker.ts
@@ -3,10 +3,11 @@ import "dotenv/config";
 
 import { env } from "~/env.mjs";
 import { queryModel } from "./queryModel.task";
+import { runNewEval } from "./runNewEval.task";
 
 console.log("Starting worker");
 
-const registeredTasks = [queryModel];
+const registeredTasks = [queryModel, runNewEval];
 
 const taskList = registeredTasks.reduce((acc, task) => {
   acc[task.task.identifier] = task.task.handler;
@@ -16,7 +17,7 @@ const taskList = registeredTasks.reduce((acc, task) => {
 // Run a worker to execute jobs:
 const runner = await run({
   connectionString: env.DATABASE_URL,
-  concurrency: 20,
+  concurrency: 50,
   // Install signal handlers for graceful shutdown on SIGINT, SIGTERM, etc
   noHandleSignals: false,
   pollInterval: 1000,

--- a/src/server/utils/evaluations.ts
+++ b/src/server/utils/evaluations.ts
@@ -46,6 +46,7 @@ export const runEvalsForOutput = async (
   );
 };
 
+// Will not run eval-output pairs that already exist in the database
 export const runAllEvals = async (experimentId: string) => {
   const outputs = await prisma.modelResponse.findMany({
     where: {


### PR DESCRIPTION
Requeueing query tasks (instead of sleeping within the worker and trying later) allows non-rate-limited tasks to supersede their precedence and complete while the rate limit is being recovered from.

## Changes
* Requeue tasks
* Run evals in background task
* Continue polling VariantStats while evals are running