### PR TITLE
Add link to demo experiment

### DIFF
--- a/src/pages/world-champs/signup.tsx
+++ b/src/pages/world-champs/signup.tsx
@@ -18,6 +18,7 @@ import {
   VStack,
   useInterval,
   Image,
+  Flex,
 } from "@chakra-ui/react";
 import { signIn, useSession } from "next-auth/react";
 import Head from "next/head";
@@ -124,8 +125,16 @@ function ApplicationStatus(props: BoxProps) {
   } else if (user) {
     return (
       <Wrapper>
-        <HStack spacing={8}>
-          <UserMenu user={user} borderRadius={2} borderColor={"gray.700"} borderWidth={1} pr={6} />
+        <Flex flexDirection={{ base: "column", md: "row" }} alignItems="center">
+          <UserMenu
+            user={user}
+            borderRadius={2}
+            borderColor={"gray.700"}
+            borderWidth={1}
+            pr={6}
+            mr={{ base: 0, md: 8 }}
+            mb={{ base: 8, md: 0 }}
+          />
           <Box flex={1}>
             {entrant?.approved ? (
               <Text fontSize="sm">
@@ -145,7 +154,7 @@ function ApplicationStatus(props: BoxProps) {
               </Button>
             )}
           </Box>
-        </HStack>
+        </Flex>
       </Wrapper>
     );
   }
@@ -186,6 +195,10 @@ export default function Signup() {
           <Text fontSize="lg" textAlign="left">
             Think you have what it takes to be the best? Compete with the world's top prompt
             engineers and see where you rank!
+          </Text>
+
+          <Text fontSize="lg" textAlign="left" w="full" pt={4}>
+            In the meantime, hone your skills on a <Link color="orange.400" href="https://app.openpipe.ai/experiments/62c20a73-2012-4a64-973c-4b665ad46a57">demo experiment</Link>.
           </Text>
 
           <Heading size="lg" pt={12} alignSelf="left">


### PR DESCRIPTION
# Changes
* Add link to demo experiment
* Display application button and github profile in column on smaller devices

Before:
<img width="408" alt="Screenshot 2023-08-02 at 10 49 15 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/0753ab68-ef63-432d-9f79-2908adfef3d0">

After:
<img width="403" alt="Screenshot 2023-08-02 at 10 48 49 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/4d2e9bfe-cd11-4d43-8967-39fc7d0c99d8">
