### PR TITLE
Wrap evals

### DIFF
--- a/src/components/OutputsTable/OutputCell/OutputStats.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputStats.tsx
@@ -23,7 +23,14 @@ export const OutputStats = ({
   const completionTokens = modelResponse.completionTokens;
 
   return (
-    <HStack w="full" align="center" color="gray.500" fontSize="2xs" mt={{ base: 0, md: 1 }} alignItems="flex-end">
+    <HStack
+      w="full"
+      align="center"
+      color="gray.500"
+      fontSize="2xs"
+      mt={{ base: 0, md: 1 }}
+      alignItems="flex-end"
+    >
       <HStack flex={1} flexWrap="wrap">
         {modelResponse.outputEvaluations.map((evaluation) => {
           const passed = evaluation.result > 0.5;

--- a/src/components/OutputsTable/OutputCell/OutputStats.tsx
+++ b/src/components/OutputsTable/OutputCell/OutputStats.tsx
@@ -23,8 +23,8 @@ export const OutputStats = ({
   const completionTokens = modelResponse.completionTokens;
 
   return (
-    <HStack w="full" align="center" color="gray.500" fontSize="2xs" mt={{ base: 0, md: 1 }}>
-      <HStack flex={1}>
+    <HStack w="full" align="center" color="gray.500" fontSize="2xs" mt={{ base: 0, md: 1 }} alignItems="flex-end">
+      <HStack flex={1} flexWrap="wrap">
         {modelResponse.outputEvaluations.map((evaluation) => {
           const passed = evaluation.result > 0.5;
           return (

--- a/src/components/OutputsTable/VariantStats.tsx
+++ b/src/components/OutputsTable/VariantStats.tsx
@@ -43,12 +43,12 @@ export default function VariantStats(props: { variant: PromptVariant }) {
   return (
     <HStack
       justifyContent="space-between"
-      alignItems="center"
+      alignItems="flex-end"
       mx="2"
       fontSize="xs"
       py={cellPadding.y}
     >
-      <HStack px={cellPadding.x}>
+      <HStack px={cellPadding.x} flexWrap="wrap">
         {showNumFinished && (
           <Text>
             {data.outputCount} / {data.scenarioCount}

--- a/src/components/OutputsTable/index.tsx
+++ b/src/components/OutputsTable/index.tsx
@@ -35,7 +35,7 @@ export default function OutputsTable({ experimentId }: { experimentId: string | 
       pb={24}
       pl={8}
       display="grid"
-      gridTemplateColumns={`250px repeat(${variants.data.length}, minmax(360px, 1fr)) auto`}
+      gridTemplateColumns={`250px repeat(${variants.data.length}, minmax(320px, 1fr)) auto`}
       sx={{
         "> *": {
           borderColor: "gray.300",


### PR DESCRIPTION
Before:
<img width="662" alt="Screenshot 2023-08-03 at 11 56 07 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/313a3d76-8592-4e9f-a238-a1044a87d8cb">


After:
<img width="681" alt="Screenshot 2023-08-03 at 11 55 53 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/acc5b320-52cc-492e-b9ac-b9626a5e28a9">
