### PR TITLE
Rename Organization to Project

### DIFF
--- a/app/prisma/migrations/20230809222649_rename_organization_to_project/migration.sql
+++ b/app/prisma/migrations/20230809222649_rename_organization_to_project/migration.sql
@@ -1,0 +1,37 @@
+-- Rename Enum
+ALTER TYPE "OrganizationUserRole" RENAME TO "ProjectUserRole";
+
+-- Drop and recreate foreign keys
+ALTER TABLE "ApiKey" DROP CONSTRAINT "ApiKey_organizationId_fkey";
+ALTER TABLE "Dataset" DROP CONSTRAINT "Dataset_organizationId_fkey";
+ALTER TABLE "Experiment" DROP CONSTRAINT "Experiment_organizationId_fkey";
+ALTER TABLE "LoggedCall" DROP CONSTRAINT "LoggedCall_organizationId_fkey";
+ALTER TABLE "OrganizationUser" DROP CONSTRAINT "OrganizationUser_organizationId_fkey";
+ALTER TABLE "OrganizationUser" DROP CONSTRAINT "OrganizationUser_userId_fkey";
+
+-- Rename columns
+ALTER TABLE "ApiKey" RENAME COLUMN "organizationId" TO "projectId";
+ALTER TABLE "Dataset" RENAME COLUMN "organizationId" TO "projectId";
+ALTER TABLE "Experiment" RENAME COLUMN "organizationId" TO "projectId";
+ALTER TABLE "LoggedCall" RENAME COLUMN "organizationId" TO "projectId";
+ALTER TABLE "OrganizationUser" RENAME COLUMN "organizationId" TO "projectId";
+ALTER TABLE "Organization" RENAME COLUMN "personalOrgUserId" TO "personalProjectUserId";
+
+-- Rename table
+ALTER TABLE "Organization" RENAME TO "Project";
+ALTER TABLE "OrganizationUser" RENAME TO "ProjectUser";
+
+-- Recreate foreign keys
+ALTER TABLE "Experiment" ADD CONSTRAINT "Experiment_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Dataset" ADD CONSTRAINT "Dataset_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProjectUser" ADD CONSTRAINT "ProjectUser_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ProjectUser" ADD CONSTRAINT "ProjectUser_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "LoggedCall" ADD CONSTRAINT "LoggedCall_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ApiKey" ADD CONSTRAINT "ApiKey_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Rename indexes
+ALTER TABLE "Project" RENAME CONSTRAINT "Organization_pkey" TO "Project_pkey";
+ALTER TABLE "ProjectUser" RENAME CONSTRAINT "OrganizationUser_pkey" TO "ProjectUser_pkey";
+ALTER TABLE "Project" RENAME CONSTRAINT "Organization_personalOrgUserId_fkey" TO "Project_personalProjectUserId_fkey";
+ALTER INDEX "Organization_personalOrgUserId_key" RENAME TO "Project_personalProjectUserId_key";
+ALTER INDEX "OrganizationUser_organizationId_userId_key" RENAME TO "ProjectUser_projectId_userId_key";

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -16,8 +16,8 @@ model Experiment {
 
     sortIndex Int @default(0)
 
-    organizationId String        @db.Uuid
-    organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+    projectId String   @db.Uuid
+    project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
@@ -180,8 +180,8 @@ model Dataset {
     name           String
     datasetEntries DatasetEntry[]
 
-    organizationId String       @db.Uuid
-    organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+    projectId String  @db.Uuid
+    project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
@@ -200,36 +200,35 @@ model DatasetEntry {
     updatedAt DateTime @updatedAt
 }
 
-// TODO rename Organization to Project
-model Organization {
-    id                String  @id @default(uuid()) @db.Uuid
-    name              String  @default("Project 1")
+model Project {
+    id   String @id @default(uuid()) @db.Uuid
+    name String @default("Project 1")
 
-    personalOrgUserId String? @unique @db.Uuid
-    personalOrgUser   User?   @relation(fields: [personalOrgUserId], references: [id], onDelete: Cascade)
+    personalProjectUserId String? @unique @db.Uuid
+    personalProjectUser   User?   @relation(fields: [personalProjectUserId], references: [id], onDelete: Cascade)
 
-    createdAt         DateTime           @default(now())
-    updatedAt         DateTime           @updatedAt
-    organizationUsers OrganizationUser[]
-    experiments       Experiment[]
-    datasets          Dataset[]
-    loggedCalls       LoggedCall[]
-    apiKeys           ApiKey[]
+    createdAt    DateTime      @default(now())
+    updatedAt    DateTime      @updatedAt
+    projectUsers ProjectUser[]
+    experiments  Experiment[]
+    datasets     Dataset[]
+    loggedCalls  LoggedCall[]
+    apiKeys      ApiKey[]
 }
 
-enum OrganizationUserRole {
+enum ProjectUserRole {
     ADMIN
     MEMBER
     VIEWER
 }
 
-model OrganizationUser {
+model ProjectUser {
     id String @id @default(uuid()) @db.Uuid
 
-    role OrganizationUserRole
+    role ProjectUserRole
 
-    organizationId String        @db.Uuid
-    organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+    projectId String   @db.Uuid
+    project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     userId String @db.Uuid
     user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -237,7 +236,7 @@ model OrganizationUser {
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
-    @@unique([organizationId, userId])
+    @@unique([projectId, userId])
 }
 
 model WorldChampEntrant {
@@ -265,14 +264,14 @@ model LoggedCall {
     // A LoggedCall is always associated with a LoggedCallModelResponse. If this
     // is a cache miss, we create a new LoggedCallModelResponse.
     // If it's a cache hit, it's a pre-existing LoggedCallModelResponse.    
-    modelResponseId String?                 @db.Uuid
+    modelResponseId String?                  @db.Uuid
     modelResponse   LoggedCallModelResponse? @relation(fields: [modelResponseId], references: [id], onDelete: Cascade)
 
     // The responses created by this LoggedCall. Will be empty if this LoggedCall was a cache hit.
     createdResponses LoggedCallModelResponse[] @relation(name: "ModelResponseOriginalCall")
 
-    organizationId String        @db.Uuid
-    organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+    projectId String   @db.Uuid
+    project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     tags LoggedCallTag[]
 
@@ -323,11 +322,11 @@ model LoggedCallModelResponse {
 }
 
 model LoggedCallTag {
-    id    String @id @default(uuid()) @db.Uuid
+    id    String  @id @default(uuid()) @db.Uuid
     name  String
     value String?
 
-    loggedCallId String        @db.Uuid
+    loggedCallId String     @db.Uuid
     loggedCall   LoggedCall @relation(fields: [loggedCallId], references: [id], onDelete: Cascade)
 
     @@index([name])
@@ -340,8 +339,8 @@ model ApiKey {
     name   String
     apiKey String @unique
 
-    organizationId String        @db.Uuid
-    organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+    projectId String   @db.Uuid
+    project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
@@ -390,8 +389,8 @@ model User {
 
     accounts          Account[]
     sessions          Session[]
-    organizationUsers OrganizationUser[]
-    organizations     Organization[]
+    projectUsers      ProjectUser[]
+    projects          Project[]
     worldChampEntrant WorldChampEntrant?
 
     createdAt DateTime @default(now())

--- a/app/prisma/seed.ts
+++ b/app/prisma/seed.ts
@@ -5,14 +5,14 @@ import { promptConstructorVersion } from "~/promptConstructor/version";
 
 const defaultId = "11111111-1111-1111-1111-111111111111";
 
-await prisma.organization.deleteMany({
+await prisma.project.deleteMany({
   where: { id: defaultId },
 });
 
-// If there's an existing org, just seed into it
-const org =
-  (await prisma.organization.findFirst({})) ??
-  (await prisma.organization.create({
+// If there's an existing project, just seed into it
+const project =
+  (await prisma.project.findFirst({})) ??
+  (await prisma.project.create({
     data: { id: defaultId },
   }));
 
@@ -26,7 +26,7 @@ await prisma.experiment.create({
   data: {
     id: defaultId,
     label: "Country Capitals Example",
-    organizationId: org.id,
+    projectId: project.id,
   },
 });
 

--- a/app/prisma/seedAgiEval.ts
+++ b/app/prisma/seedAgiEval.ts
@@ -7,14 +7,14 @@ import { promptConstructorVersion } from "~/promptConstructor/version";
 
 const defaultId = "11111111-1111-1111-1111-111111111112";
 
-await prisma.organization.deleteMany({
+await prisma.project.deleteMany({
   where: { id: defaultId },
 });
 
-// If there's an existing org, just seed into it
-const org =
-  (await prisma.organization.findFirst({})) ??
-  (await prisma.organization.create({
+// If there's an existing project, just seed into it
+const project =
+  (await prisma.project.findFirst({})) ??
+  (await prisma.project.create({
     data: { id: defaultId },
   }));
 
@@ -47,7 +47,7 @@ for (const dataset of datasets) {
   const oldExperiment = await prisma.experiment.findFirst({
     where: {
       label: experimentName,
-      organizationId: org.id,
+      projectId: project.id,
     },
   });
   if (oldExperiment) {
@@ -60,7 +60,7 @@ for (const dataset of datasets) {
     data: {
       id: oldExperiment?.id ?? undefined,
       label: experimentName,
-      organizationId: org.id,
+      projectId: project.id,
     },
   });
 

--- a/app/prisma/seedDashboard.ts
+++ b/app/prisma/seedDashboard.ts
@@ -311,9 +311,9 @@ const MODEL_RESPONSE_TEMPLATES: {
 
 await prisma.loggedCallModelResponse.deleteMany();
 
-const org = await prisma.organization.findFirst({
+const project = await prisma.project.findFirst({
   where: {
-    personalOrgUserId: {
+    personalProjectUserId: {
       not: null,
     },
   },
@@ -322,8 +322,8 @@ const org = await prisma.organization.findFirst({
   },
 });
 
-if (!org) {
-  console.error("No org found. Sign up to create your first org.");
+if (!project) {
+  console.error("No project found. Sign up to create your first project.");
   process.exit(1);
 }
 
@@ -348,7 +348,7 @@ for (let i = 0; i < 1437; i++) {
     id: loggedCallId,
     cacheHit: false,
     startTime,
-    organizationId: org.id,
+    projectId: project.id,
     createdAt: startTime,
   });
 
@@ -373,7 +373,7 @@ for (let i = 0; i < 1437; i++) {
     respStatus: template.respStatus,
     error: template.error,
     createdAt: startTime,
-    cacheKey: hashRequest(org.id, template.reqPayload as JsonValue),
+    cacheKey: hashRequest(project.id, template.reqPayload as JsonValue),
     durationMs: endTime.getTime() - startTime.getTime(),
     inputTokens: template.inputTokens,
     outputTokens: template.outputTokens,

--- a/app/prisma/seedTwitterSentiment.ts
+++ b/app/prisma/seedTwitterSentiment.ts
@@ -6,14 +6,14 @@ import { promptConstructorVersion } from "~/promptConstructor/version";
 
 const defaultId = "11111111-1111-1111-1111-111111111112";
 
-await prisma.organization.deleteMany({
+await prisma.project.deleteMany({
   where: { id: defaultId },
 });
 
-// If there's an existing org, just seed into it
-const org =
-  (await prisma.organization.findFirst({})) ??
-  (await prisma.organization.create({
+// If there's an existing project, just seed into it
+const project =
+  (await prisma.project.findFirst({})) ??
+  (await prisma.project.create({
     data: { id: defaultId },
   }));
 
@@ -27,7 +27,7 @@ const experimentName = `Twitter Sentiment Analysis`;
 const oldExperiment = await prisma.experiment.findFirst({
   where: {
     label: experimentName,
-    organizationId: org.id,
+    projectId: project.id,
   },
 });
 if (oldExperiment) {
@@ -40,7 +40,7 @@ const experiment = await prisma.experiment.create({
   data: {
     id: oldExperiment?.id ?? undefined,
     label: experimentName,
-    organizationId: org.id,
+    projectId: project.id,
   },
 });
 

--- a/app/src/components/datasets/DatasetCard.tsx
+++ b/app/src/components/datasets/DatasetCard.tsx
@@ -72,12 +72,12 @@ const CountLabel = ({ label, count }: { label: string; count: number }) => {
 
 export const NewDatasetCard = () => {
   const router = useRouter();
-  const selectedOrgId = useAppStore((s) => s.selectedOrgId);
+  const selectedProjectId = useAppStore((s) => s.selectedProjectId);
   const createMutation = api.datasets.create.useMutation();
   const [createDataset, isLoading] = useHandledAsyncCallback(async () => {
-    const newDataset = await createMutation.mutateAsync({ organizationId: selectedOrgId ?? "" });
+    const newDataset = await createMutation.mutateAsync({ projectId: selectedProjectId ?? "" });
     await router.push({ pathname: "/data/[id]", query: { id: newDataset.id } });
-  }, [createMutation, router, selectedOrgId]);
+  }, [createMutation, router, selectedProjectId]);
 
   return (
     <AspectRatio ratio={1.2} w="full">

--- a/app/src/components/experiments/ExperimentCard.tsx
+++ b/app/src/components/experiments/ExperimentCard.tsx
@@ -76,17 +76,17 @@ const CountLabel = ({ label, count }: { label: string; count: number }) => {
 
 export const NewExperimentCard = () => {
   const router = useRouter();
-  const selectedOrgId = useAppStore((s) => s.selectedOrgId);
+  const selectedProjectId = useAppStore((s) => s.selectedProjectId);
   const createMutation = api.experiments.create.useMutation();
   const [createExperiment, isLoading] = useHandledAsyncCallback(async () => {
     const newExperiment = await createMutation.mutateAsync({
-      organizationId: selectedOrgId ?? "",
+      projectId: selectedProjectId ?? "",
     });
     await router.push({
       pathname: "/experiments/[id]",
       query: { id: newExperiment.id },
     });
-  }, [createMutation, router, selectedOrgId]);
+  }, [createMutation, router, selectedProjectId]);
 
   return (
     <AspectRatio ratio={1.2} w="full">

--- a/app/src/components/experiments/ExperimentHeaderButtons/useOnForkButtonPressed.tsx
+++ b/app/src/components/experiments/ExperimentHeaderButtons/useOnForkButtonPressed.tsx
@@ -10,15 +10,15 @@ export const useOnForkButtonPressed = () => {
 
   const user = useSession().data;
   const experiment = useExperiment();
-  const selectedOrgId = useAppStore((state) => state.selectedOrgId);
+  const selectedProjectId = useAppStore((state) => state.selectedProjectId);
 
   const forkMutation = api.experiments.fork.useMutation();
 
   const [onFork, isForking] = useHandledAsyncCallback(async () => {
-    if (!experiment.data?.id || !selectedOrgId) return;
+    if (!experiment.data?.id || !selectedProjectId) return;
     const forkedExperimentId = await forkMutation.mutateAsync({
       id: experiment.data.id,
-      organizationId: selectedOrgId,
+      projectId: selectedProjectId,
     });
     await router.push({ pathname: "/experiments/[id]", query: { id: forkedExperimentId } });
   }, [forkMutation, experiment.data?.id, router]);

--- a/app/src/components/nav/ProjectBreadcrumbContents.tsx
+++ b/app/src/components/nav/ProjectBreadcrumbContents.tsx
@@ -1,12 +1,12 @@
 import { HStack, Flex, Text } from "@chakra-ui/react";
-import { useSelectedOrg } from "~/utils/hooks";
+import { useSelectedProject } from "~/utils/hooks";
 
 // Have to export only contents here instead of full BreadcrumbItem because Chakra doesn't
 // recognize a BreadcrumbItem exported with this component as a valid child of Breadcrumb.
-export default function ProjectBreadcrumbContents({ orgName = "" }: { orgName?: string }) {
-  const { data: selectedOrg } = useSelectedOrg();
+export default function ProjectBreadcrumbContents({ projectName = "" }: { projectName?: string }) {
+  const { data: selectedProject } = useSelectedProject();
 
-  orgName = orgName || selectedOrg?.name || "";
+  projectName = projectName || selectedProject?.name || "";
 
   return (
     <HStack w="full">
@@ -18,10 +18,10 @@ export default function ProjectBreadcrumbContents({ orgName = "" }: { orgName?: 
         alignItems="center"
         justifyContent="center"
       >
-        <Text>{orgName[0]?.toUpperCase()}</Text>
+        <Text>{projectName[0]?.toUpperCase()}</Text>
       </Flex>
       <Text display={{ base: "none", md: "block" }} py={1}>
-        {orgName}
+        {projectName}
       </Text>
     </HStack>
   );

--- a/app/src/components/nav/ProjectMenu.tsx
+++ b/app/src/components/nav/ProjectMenu.tsx
@@ -17,39 +17,42 @@ import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { AiFillCaretDown } from "react-icons/ai";
 import { BsGear, BsPlus } from "react-icons/bs";
-import { type Organization } from "@prisma/client";
+import { type Project } from "@prisma/client";
 
 import { useAppStore } from "~/state/store";
 import { api } from "~/utils/api";
 import NavSidebarOption from "./NavSidebarOption";
-import { useHandledAsyncCallback, useSelectedOrg } from "~/utils/hooks";
+import { useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
 import { useRouter } from "next/router";
 
 export default function ProjectMenu() {
   const router = useRouter();
-  const isActive = router.pathname.startsWith("/home");
   const utils = api.useContext();
 
-  const selectedOrgId = useAppStore((s) => s.selectedOrgId);
-  const setSelectedOrgId = useAppStore((s) => s.setSelectedOrgId);
+  const selectedProjectId = useAppStore((s) => s.selectedProjectId);
+  const setselectedProjectId = useAppStore((s) => s.setselectedProjectId);
 
-  const { data: orgs } = api.organizations.list.useQuery();
+  const { data: projects } = api.projects.list.useQuery();
 
   useEffect(() => {
-    if (orgs && orgs[0] && (!selectedOrgId || !orgs.find((org) => org.id === selectedOrgId))) {
-      setSelectedOrgId(orgs[0].id);
+    if (
+      projects &&
+      projects[0] &&
+      (!selectedProjectId || !projects.find((proj) => proj.id === selectedProjectId))
+    ) {
+      setselectedProjectId(projects[0].id);
     }
-  }, [selectedOrgId, setSelectedOrgId, orgs]);
+  }, [selectedProjectId, setselectedProjectId, projects]);
 
-  const { data: selectedOrg } = useSelectedOrg();
+  const { data: selectedProject } = useSelectedProject();
 
   const popover = useDisclosure();
 
-  const createMutation = api.organizations.create.useMutation();
+  const createMutation = api.projects.create.useMutation();
   const [createProject, isLoading] = useHandledAsyncCallback(async () => {
-    const newOrg = await createMutation.mutateAsync({ name: "New Project" });
-    await utils.organizations.list.invalidate();
-    setSelectedOrgId(newOrg.id);
+    const newProj = await createMutation.mutateAsync({ name: "New Project" });
+    await utils.projects.list.invalidate();
+    setselectedProjectId(newProj.id);
     await router.push({ pathname: "/project/settings" });
   }, [createMutation, router]);
 
@@ -84,10 +87,10 @@ export default function ProjectMenu() {
                 alignItems="center"
                 justifyContent="center"
               >
-                <Text>{selectedOrg?.name[0]?.toUpperCase()}</Text>
+                <Text>{selectedProject?.name[0]?.toUpperCase()}</Text>
               </Flex>
               <Text fontSize="sm" display={{ base: "none", md: "block" }} py={1} flex={1}>
-                {selectedOrg?.name}
+                {selectedProject?.name}
               </Text>
               <Icon as={AiFillCaretDown} boxSize={3} size="xs" color="gray.500" mr={2} />
             </HStack>
@@ -104,11 +107,11 @@ export default function ProjectMenu() {
               </Text>
               <Divider />
               <VStack spacing={0} w="full">
-                {orgs?.map((org) => (
+                {projects?.map((proj) => (
                   <ProjectOption
-                    key={org.id}
-                    org={org}
-                    isActive={org.id === selectedOrgId}
+                    key={proj.id}
+                    proj={proj}
+                    isActive={proj.id === selectedProjectId}
                     onClose={popover.onClose}
                   />
                 ))}
@@ -134,22 +137,22 @@ export default function ProjectMenu() {
 }
 
 const ProjectOption = ({
-  org,
+  proj,
   isActive,
   onClose,
 }: {
-  org: Organization;
+  proj: Project;
   isActive: boolean;
   onClose: () => void;
 }) => {
-  const setSelectedOrgId = useAppStore((s) => s.setSelectedOrgId);
+  const setselectedProjectId = useAppStore((s) => s.setselectedProjectId);
   const [gearHovered, setGearHovered] = useState(false);
   return (
     <HStack
       as={Link}
       href="/experiments"
       onClick={() => {
-        setSelectedOrgId(org.id);
+        setselectedProjectId(proj.id);
         onClose();
       }}
       w="full"
@@ -158,11 +161,11 @@ const ProjectOption = ({
       _hover={gearHovered ? undefined : { bgColor: "gray.200", textDecoration: "none" }}
       p={2}
     >
-      <Text>{org.name}</Text>
+      <Text>{proj.name}</Text>
       <IconButton
         as={Link}
         href="/project/settings"
-        aria-label={`Open ${org.name} settings`}
+        aria-label={`Open ${proj.name} settings`}
         icon={<Icon as={BsGear} boxSize={5} strokeWidth={0.5} color="gray.500" />}
         variant="ghost"
         size="xs"

--- a/app/src/components/projectSettings/DeleteProjectDialog.tsx
+++ b/app/src/components/projectSettings/DeleteProjectDialog.tsx
@@ -16,7 +16,7 @@ import {
 import { useRouter } from "next/router";
 import { useRef, useState } from "react";
 import { api } from "~/utils/api";
-import { useHandledAsyncCallback, useSelectedOrg } from "~/utils/hooks";
+import { useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
 
 export const DeleteProjectDialog = ({
   isOpen,
@@ -25,20 +25,20 @@ export const DeleteProjectDialog = ({
   isOpen: boolean;
   onClose: () => void;
 }) => {
-  const selectedOrg = useSelectedOrg();
-  const deleteMutation = api.organizations.delete.useMutation();
+  const selectedProject = useSelectedProject();
+  const deleteMutation = api.projects.delete.useMutation();
   const utils = api.useContext();
   const router = useRouter();
 
   const cancelRef = useRef<HTMLButtonElement>(null);
 
   const [onDeleteConfirm, isDeleting] = useHandledAsyncCallback(async () => {
-    if (!selectedOrg.data?.id) return;
-    await deleteMutation.mutateAsync({ id: selectedOrg.data.id });
-    await utils.organizations.list.invalidate();
+    if (!selectedProject.data?.id) return;
+    await deleteMutation.mutateAsync({ id: selectedProject.data.id });
+    await utils.projects.list.invalidate();
     await router.push({ pathname: "/experiments" });
     onClose();
-  }, [deleteMutation, selectedOrg, router]);
+  }, [deleteMutation, selectedProject, router]);
 
   const [nameToDelete, setNameToDelete] = useState("");
 
@@ -58,10 +58,10 @@ export const DeleteProjectDialog = ({
                 of the project below.
               </Text>
               <Box bgColor="orange.100" w="full" p={2} borderRadius={4}>
-                <Text fontFamily="inconsolata">{selectedOrg.data?.name}</Text>
+                <Text fontFamily="inconsolata">{selectedProject.data?.name}</Text>
               </Box>
               <Input
-                placeholder={selectedOrg.data?.name}
+                placeholder={selectedProject.data?.name}
                 value={nameToDelete}
                 onChange={(e) => setNameToDelete(e.target.value)}
               />
@@ -76,7 +76,7 @@ export const DeleteProjectDialog = ({
               colorScheme="red"
               onClick={onDeleteConfirm}
               ml={3}
-              isDisabled={nameToDelete !== selectedOrg.data?.name}
+              isDisabled={nameToDelete !== selectedProject.data?.name}
               w={20}
             >
               {isDeleting ? <Spinner /> : "Delete"}

--- a/app/src/pages/data/[id].tsx
+++ b/app/src/pages/data/[id].tsx
@@ -60,7 +60,7 @@ export default function Dataset() {
         <PageHeaderContainer>
           <Breadcrumb>
             <BreadcrumbItem>
-              <ProjectBreadcrumbContents orgName={dataset.data?.organization?.name} />
+              <ProjectBreadcrumbContents projectName={dataset.data?.project?.name} />
             </BreadcrumbItem>
             <BreadcrumbItem>
               <Link href="/data">

--- a/app/src/pages/experiments/[id].tsx
+++ b/app/src/pages/experiments/[id].tsx
@@ -109,7 +109,7 @@ export default function Experiment() {
           <PageHeaderContainer>
             <Breadcrumb>
               <BreadcrumbItem>
-                <ProjectBreadcrumbContents orgName={experiment.data?.organization?.name} />
+                <ProjectBreadcrumbContents projectName={experiment.data?.project?.name} />
               </BreadcrumbItem>
               <BreadcrumbItem>
                 <Link href="/experiments">

--- a/app/src/pages/logged-calls/index.tsx
+++ b/app/src/pages/logged-calls/index.tsx
@@ -34,17 +34,17 @@ import { useMemo } from "react";
 import AppShell from "~/components/nav/AppShell";
 import PageHeaderContainer from "~/components/nav/PageHeaderContainer";
 import ProjectBreadcrumbContents from "~/components/nav/ProjectBreadcrumbContents";
-import { useSelectedOrg } from "~/utils/hooks";
+import { useSelectedProject } from "~/utils/hooks";
 import dayjs from "~/utils/dayjs";
 import { api } from "~/utils/api";
 import LoggedCallTable from "~/components/dashboard/LoggedCallTable";
 
 export default function LoggedCalls() {
-  const { data: selectedOrg } = useSelectedOrg();
+  const { data: selectedProject } = useSelectedProject();
 
   const stats = api.dashboard.stats.useQuery(
-    { organizationId: selectedOrg?.id ?? "" },
-    { enabled: !!selectedOrg },
+    { projectId: selectedProject?.id ?? "" },
+    { enabled: !!selectedProject },
   );
 
   const data = useMemo(() => {
@@ -71,7 +71,7 @@ export default function LoggedCalls() {
       </PageHeaderContainer>
       <VStack px={8} pt={4} alignItems="flex-start" spacing={4}>
         <Text fontSize="2xl" fontWeight="bold">
-          {selectedOrg?.name}
+          {selectedProject?.name}
         </Text>
         <Divider />
         <VStack margin="auto" spacing={4} align="stretch" w="full">

--- a/app/src/pages/project/settings/index.tsx
+++ b/app/src/pages/project/settings/index.tsx
@@ -17,33 +17,35 @@ import { BsTrash } from "react-icons/bs";
 import AppShell from "~/components/nav/AppShell";
 import PageHeaderContainer from "~/components/nav/PageHeaderContainer";
 import { api } from "~/utils/api";
-import { useHandledAsyncCallback, useSelectedOrg } from "~/utils/hooks";
+import { useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
 import ProjectBreadcrumbContents from "~/components/nav/ProjectBreadcrumbContents";
 import CopiableCode from "~/components/CopiableCode";
 import { DeleteProjectDialog } from "~/components/projectSettings/DeleteProjectDialog";
 
 export default function Settings() {
   const utils = api.useContext();
-  const { data: selectedOrg } = useSelectedOrg();
+  const { data: selectedProject } = useSelectedProject();
 
   const apiKey =
-    selectedOrg?.apiKeys?.length && selectedOrg?.apiKeys[0] ? selectedOrg?.apiKeys[0].apiKey : "";
+    selectedProject?.apiKeys?.length && selectedProject?.apiKeys[0]
+      ? selectedProject?.apiKeys[0].apiKey
+      : "";
 
-  const updateMutation = api.organizations.update.useMutation();
+  const updateMutation = api.projects.update.useMutation();
   const [onSaveName] = useHandledAsyncCallback(async () => {
-    if (name && name !== selectedOrg?.name && selectedOrg?.id) {
+    if (name && name !== selectedProject?.name && selectedProject?.id) {
       await updateMutation.mutateAsync({
-        id: selectedOrg.id,
+        id: selectedProject.id,
         updates: { name },
       });
-      await Promise.all([utils.organizations.get.invalidate({ id: selectedOrg.id })]);
+      await Promise.all([utils.projects.get.invalidate({ id: selectedProject.id })]);
     }
-  }, [updateMutation, selectedOrg]);
+  }, [updateMutation, selectedProject]);
 
-  const [name, setName] = useState(selectedOrg?.name);
+  const [name, setName] = useState(selectedProject?.name);
   useEffect(() => {
-    setName(selectedOrg?.name);
-  }, [selectedOrg?.name]);
+    setName(selectedProject?.name);
+  }, [selectedProject?.name]);
 
   const deleteProjectOpen = useDisclosure();
 
@@ -66,7 +68,7 @@ export default function Settings() {
               Project Settings
             </Text>
             <Text fontSize="sm">
-              Configure your project settings. These settings only apply to {selectedOrg?.name}.
+              Configure your project settings. These settings only apply to {selectedProject?.name}.
             </Text>
           </VStack>
           <VStack
@@ -90,7 +92,7 @@ export default function Settings() {
                 borderColor="gray.300"
               />
               <Button
-                isDisabled={!name || name === selectedOrg?.name}
+                isDisabled={!name || name === selectedProject?.name}
                 colorScheme="orange"
                 borderRadius={4}
                 mt={2}
@@ -113,12 +115,12 @@ export default function Settings() {
             </VStack>
             <CopiableCode code={apiKey} />
             <Divider />
-            {selectedOrg?.personalOrgUserId ? (
+            {selectedProject?.personalProjectUserId ? (
               <VStack alignItems="flex-start">
                 <Subtitle>Personal Project</Subtitle>
                 <Text fontSize="sm">
-                  This project is {selectedOrg?.personalOrgUser?.name}'s personal project. It cannot
-                  be deleted.
+                  This project is {selectedProject?.personalProjectUser?.name}'s personal project.
+                  It cannot be deleted.
                 </Text>
               </VStack>
             ) : (
@@ -129,7 +131,7 @@ export default function Settings() {
                 </Text>
                 <HStack
                   as={Button}
-                  isDisabled={selectedOrg?.role !== "ADMIN"}
+                  isDisabled={selectedProject?.role !== "ADMIN"}
                   colorScheme="red"
                   variant="outline"
                   borderRadius={4}
@@ -137,7 +139,7 @@ export default function Settings() {
                   onClick={deleteProjectOpen.onOpen}
                 >
                   <Icon as={BsTrash} />
-                  <Text>Delete {selectedOrg?.name}</Text>
+                  <Text>Delete {selectedProject?.name}</Text>
                 </HStack>
               </VStack>
             )}

--- a/app/src/server/api/root.router.ts
+++ b/app/src/server/api/root.router.ts
@@ -9,7 +9,7 @@ import { worldChampsRouter } from "./routers/worldChamps.router";
 import { datasetsRouter } from "./routers/datasets.router";
 import { datasetEntries } from "./routers/datasetEntries.router";
 import { externalApiRouter } from "./routers/externalApi.router";
-import { organizationsRouter } from "./routers/organizations.router";
+import { projectsRouter } from "./routers/projects.router";
 import { dashboardRouter } from "./routers/dashboard.router";
 
 /**
@@ -27,7 +27,7 @@ export const appRouter = createTRPCRouter({
   worldChamps: worldChampsRouter,
   datasets: datasetsRouter,
   datasetEntries: datasetEntries,
-  organizations: organizationsRouter,
+  projects: projectsRouter,
   dashboard: dashboardRouter,
   externalApi: externalApiRouter,
 });

--- a/app/src/server/api/routers/dashboard.router.ts
+++ b/app/src/server/api/routers/dashboard.router.ts
@@ -10,7 +10,7 @@ export const dashboardRouter = createTRPCRouter({
       z.object({
         // TODO: actually take startDate into account
         startDate: z.string().optional(),
-        organizationId: z.string(),
+        projectId: z.string(),
       }),
     )
     .query(async ({ input }) => {
@@ -22,7 +22,7 @@ export const dashboardRouter = createTRPCRouter({
           "LoggedCall.id",
           "LoggedCallModelResponse.originalLoggedCallId",
         )
-        .where("organizationId", "=", input.organizationId)
+        .where("projectId", "=", input.projectId)
         .select(({ fn }) => [
           sql<Date>`date_trunc('day', "LoggedCallModelResponse"."startTime")`.as("period"),
           sql<number>`count("LoggedCall"."id")::int`.as("numQueries"),
@@ -70,7 +70,7 @@ export const dashboardRouter = createTRPCRouter({
           "LoggedCall.id",
           "LoggedCallModelResponse.originalLoggedCallId",
         )
-        .where("organizationId", "=", input.organizationId)
+        .where("projectId", "=", input.projectId)
         .select(({ fn }) => [
           fn.sum(fn.coalesce("LoggedCallModelResponse.totalCost", sql<number>`0`)).as("totalCost"),
           fn.count("LoggedCall.id").as("numQueries"),
@@ -79,7 +79,7 @@ export const dashboardRouter = createTRPCRouter({
 
       const errors = await kysely
         .selectFrom("LoggedCall")
-        .where("organizationId", "=", input.organizationId)
+        .where("projectId", "=", input.projectId)
         .leftJoin(
           "LoggedCallModelResponse",
           "LoggedCall.id",

--- a/app/src/server/api/routers/datasets.router.ts
+++ b/app/src/server/api/routers/datasets.router.ts
@@ -3,20 +3,20 @@ import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/
 import { prisma } from "~/server/db";
 import {
   requireCanModifyDataset,
-  requireCanModifyOrganization,
+  requireCanModifyProject,
   requireCanViewDataset,
-  requireCanViewOrganization,
+  requireCanViewProject,
 } from "~/utils/accessControl";
 
 export const datasetsRouter = createTRPCRouter({
   list: protectedProcedure
-    .input(z.object({ organizationId: z.string() }))
+    .input(z.object({ projectId: z.string() }))
     .query(async ({ input, ctx }) => {
-      await requireCanViewOrganization(input.organizationId, ctx);
+      await requireCanViewProject(input.projectId, ctx);
 
       const datasets = await prisma.dataset.findMany({
         where: {
-          organizationId: input.organizationId,
+          projectId: input.projectId,
         },
         orderBy: {
           createdAt: "desc",
@@ -36,26 +36,26 @@ export const datasetsRouter = createTRPCRouter({
     return await prisma.dataset.findFirstOrThrow({
       where: { id: input.id },
       include: {
-        organization: true,
+        project: true,
       },
     });
   }),
 
   create: protectedProcedure
-    .input(z.object({ organizationId: z.string() }))
+    .input(z.object({ projectId: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      await requireCanModifyOrganization(input.organizationId, ctx);
+      await requireCanModifyProject(input.projectId, ctx);
 
       const numDatasets = await prisma.dataset.count({
         where: {
-          organizationId: input.organizationId,
+          projectId: input.projectId,
         },
       });
 
       return await prisma.dataset.create({
         data: {
           name: `Dataset ${numDatasets + 1}`,
-          organizationId: input.organizationId,
+          projectId: input.projectId,
         },
       });
     }),

--- a/app/src/server/api/routers/externalApi.router.ts
+++ b/app/src/server/api/routers/externalApi.router.ts
@@ -66,7 +66,7 @@ export const externalApiRouter = createTRPCRouter({
         throw new TRPCError({ code: "UNAUTHORIZED" });
       }
       const reqPayload = await reqValidator.spa(input.reqPayload);
-      const cacheKey = hashRequest(key.organizationId, reqPayload as JsonValue);
+      const cacheKey = hashRequest(key.projectId, reqPayload as JsonValue);
 
       const existingResponse = await prisma.loggedCallModelResponse.findFirst({
         where: {
@@ -84,7 +84,7 @@ export const externalApiRouter = createTRPCRouter({
 
       await prisma.loggedCall.create({
         data: {
-          organizationId: key.organizationId,
+          projectId: key.projectId,
           startTime: new Date(input.startTime),
           cacheHit: true,
           modelResponseId: existingResponse.id,
@@ -135,7 +135,7 @@ export const externalApiRouter = createTRPCRouter({
       const reqPayload = await reqValidator.spa(input.reqPayload);
       const respPayload = await respValidator.spa(input.respPayload);
 
-      const requestHash = hashRequest(key.organizationId, reqPayload as JsonValue);
+      const requestHash = hashRequest(key.projectId, reqPayload as JsonValue);
 
       const newLoggedCallId = uuidv4();
       const newModelResponseId = uuidv4();
@@ -146,7 +146,7 @@ export const externalApiRouter = createTRPCRouter({
         prisma.loggedCall.create({
           data: {
             id: newLoggedCallId,
-            organizationId: key.organizationId,
+            projectId: key.projectId,
             startTime: new Date(input.startTime),
             cacheHit: false,
           },

--- a/app/src/server/db.ts
+++ b/app/src/server/db.ts
@@ -9,8 +9,8 @@ import {
   type OutputEvaluation,
   type Dataset,
   type DatasetEntry,
-  type Organization,
-  type OrganizationUser,
+  type Project,
+  type ProjectUser,
   type WorldChampEntrant,
   type LoggedCall,
   type LoggedCallModelResponse,
@@ -43,8 +43,8 @@ interface DB {
   OutputEvaluation: OutputEvaluation;
   Dataset: Dataset;
   DatasetEntry: DatasetEntry;
-  Organization: Organization;
-  OrganizationUser: OrganizationUser;
+  Project: Project;
+  ProjectUser: ProjectUser;
   WorldChampEntrant: WorldChampEntrant;
   LoggedCall: LoggedCall;
   LoggedCallModelResponse: LoggedCallModelResponse;

--- a/app/src/server/scripts/backfillApiKeys.ts
+++ b/app/src/server/scripts/backfillApiKeys.ts
@@ -4,21 +4,21 @@ import { generateApiKey } from "~/server/utils/generateApiKey";
 
 console.log("backfilling api keys");
 
-const organizations = await prisma.organization.findMany({
+const projects = await prisma.project.findMany({
   include: {
     apiKeys: true,
   },
 });
 
-console.log(`found ${organizations.length} organizations`);
+console.log(`found ${projects.length} projects`);
 
 const apiKeysToCreate: Prisma.ApiKeyCreateManyInput[] = [];
 
-for (const org of organizations) {
-  if (!org.apiKeys.length) {
+for (const proj of projects) {
+  if (!proj.apiKeys.length) {
     apiKeysToCreate.push({
       name: "Default API Key",
-      organizationId: org.id,
+      projectId: proj.id,
       apiKey: generateApiKey(),
     });
   }

--- a/app/src/server/scripts/test-queries.ts
+++ b/app/src/server/scripts/test-queries.ts
@@ -6,7 +6,7 @@ const projectId = "1234";
 // Find all calls in the last 24 hours
 const responses = await prisma.loggedCall.findMany({
   where: {
-    organizationId: projectId,
+    projectId: projectId,
     startTime: {
       gt: dayjs()
         .subtract(24 * 3600)
@@ -24,7 +24,7 @@ const responses = await prisma.loggedCall.findMany({
 // Find all calls in the last 24 hours with promptId 'hello-world'
 const helloWorld = await prisma.loggedCall.findMany({
   where: {
-    organizationId: projectId,
+    projectId: projectId,
     startTime: {
       gt: dayjs()
         .subtract(24 * 3600)
@@ -52,7 +52,7 @@ const totalSpent = await prisma.loggedCallModelResponse.aggregate({
   },
   where: {
     originalLoggedCall: {
-      organizationId: projectId,
+      projectId: projectId,
     },
     startTime: {
       gt: dayjs()

--- a/app/src/server/utils/hashObject.ts
+++ b/app/src/server/utils/hashObject.ts
@@ -24,9 +24,9 @@ function sortKeys(obj: JsonValue): JsonValue {
   return sortedObj;
 }
 
-export function hashRequest(organizationId: string, reqPayload: JsonValue): string {
+export function hashRequest(projectId: string, reqPayload: JsonValue): string {
   const obj = {
-    organizationId,
+    projectId,
     reqPayload,
   };
   return hashObject(obj);

--- a/app/src/server/utils/userProject.ts
+++ b/app/src/server/utils/userProject.ts
@@ -1,15 +1,15 @@
 import { prisma } from "~/server/db";
 import { generateApiKey } from "./generateApiKey";
 
-export default async function userOrg(userId: string) {
-  return await prisma.organization.upsert({
+export default async function userProject(userId: string) {
+  return await prisma.project.upsert({
     where: {
-      personalOrgUserId: userId,
+      personalProjectUserId: userId,
     },
     update: {},
     create: {
-      personalOrgUserId: userId,
-      organizationUsers: {
+      personalProjectUserId: userId,
+      projectUsers: {
         create: {
           userId: userId,
           role: "ADMIN",

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -14,8 +14,8 @@ export type State = {
   api: APIClient | null;
   setApi: (api: APIClient) => void;
   sharedVariantEditor: SharedVariantEditorSlice;
-  selectedOrgId: string | null;
-  setSelectedOrgId: (orgId: string) => void;
+  selectedProjectId: string | null;
+  setselectedProjectId: (id: string) => void;
 };
 
 export type SliceCreator<T> = StateCreator<State, [["zustand/immer", never]], [], T>;
@@ -41,10 +41,10 @@ const useBaseStore = create<State, [["zustand/immer", never]]>(
         state.drawerOpen = false;
       }),
     sharedVariantEditor: createVariantEditorSlice(set, get, ...rest),
-    selectedOrgId: null,
-    setSelectedOrgId: (orgId: string) =>
+    selectedProjectId: null,
+    setselectedProjectId: (id: string) =>
       set((state) => {
-        state.selectedOrgId = orgId;
+        state.selectedProjectId = id;
       }),
   })),
 );

--- a/app/src/utils/accessControl.ts
+++ b/app/src/utils/accessControl.ts
@@ -1,4 +1,4 @@
-import { OrganizationUserRole } from "@prisma/client";
+import { ProjectUserRole } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { type TRPCContext } from "~/server/api/trpc";
 import { prisma } from "~/server/db";
@@ -16,16 +16,16 @@ export const requireNothing = (ctx: TRPCContext) => {
   ctx.markAccessControlRun();
 };
 
-export const requireIsOrgAdmin = async (organizationId: string, ctx: TRPCContext) => {
+export const requireIsProjectAdmin = async (projectId: string, ctx: TRPCContext) => {
   const userId = ctx.session?.user.id;
   if (!userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
-  const isAdmin = await prisma.organizationUser.findFirst({
+  const isAdmin = await prisma.projectUser.findFirst({
     where: {
       userId,
-      organizationId,
+      projectId,
       role: "ADMIN",
     },
   });
@@ -37,16 +37,16 @@ export const requireIsOrgAdmin = async (organizationId: string, ctx: TRPCContext
   ctx.markAccessControlRun();
 };
 
-export const requireCanViewOrganization = async (organizationId: string, ctx: TRPCContext) => {
+export const requireCanViewProject = async (projectId: string, ctx: TRPCContext) => {
   const userId = ctx.session?.user.id;
   if (!userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
-  const canView = await prisma.organizationUser.findFirst({
+  const canView = await prisma.projectUser.findFirst({
     where: {
       userId,
-      organizationId,
+      projectId,
     },
   });
 
@@ -57,17 +57,17 @@ export const requireCanViewOrganization = async (organizationId: string, ctx: TR
   ctx.markAccessControlRun();
 };
 
-export const requireCanModifyOrganization = async (organizationId: string, ctx: TRPCContext) => {
+export const requireCanModifyProject = async (projectId: string, ctx: TRPCContext) => {
   const userId = ctx.session?.user.id;
   if (!userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
-  const canModify = await prisma.organizationUser.findFirst({
+  const canModify = await prisma.projectUser.findFirst({
     where: {
       userId,
-      organizationId,
-      role: { in: [OrganizationUserRole.ADMIN, OrganizationUserRole.MEMBER] },
+      projectId,
+      role: { in: [ProjectUserRole.ADMIN, ProjectUserRole.MEMBER] },
     },
   });
 
@@ -82,10 +82,10 @@ export const requireCanViewDataset = async (datasetId: string, ctx: TRPCContext)
   const dataset = await prisma.dataset.findFirst({
     where: {
       id: datasetId,
-      organization: {
-        organizationUsers: {
+      project: {
+        projectUsers: {
           some: {
-            role: { in: [OrganizationUserRole.ADMIN, OrganizationUserRole.MEMBER] },
+            role: { in: [ProjectUserRole.ADMIN, ProjectUserRole.MEMBER] },
             userId: ctx.session?.user.id,
           },
         },
@@ -120,10 +120,10 @@ export const canModifyExperiment = async (experimentId: string, userId: string) 
     prisma.experiment.findFirst({
       where: {
         id: experimentId,
-        organization: {
-          organizationUsers: {
+        project: {
+          projectUsers: {
             some: {
-              role: { in: [OrganizationUserRole.ADMIN, OrganizationUserRole.MEMBER] },
+              role: { in: [ProjectUserRole.ADMIN, ProjectUserRole.MEMBER] },
               userId,
             },
           },

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -5,10 +5,10 @@ import { NumberParam, useQueryParam, withDefault } from "use-query-params";
 import { useAppStore } from "~/state/store";
 
 export const useExperiments = () => {
-  const selectedOrgId = useAppStore((state) => state.selectedOrgId);
+  const selectedProjectId = useAppStore((state) => state.selectedProjectId);
   return api.experiments.list.useQuery(
-    { organizationId: selectedOrgId ?? "" },
-    { enabled: !!selectedOrgId },
+    { projectId: selectedProjectId ?? "" },
+    { enabled: !!selectedProjectId },
   );
 };
 
@@ -27,10 +27,10 @@ export const useExperimentAccess = () => {
 };
 
 export const useDatasets = () => {
-  const selectedOrgId = useAppStore((state) => state.selectedOrgId);
+  const selectedProjectId = useAppStore((state) => state.selectedProjectId);
   return api.datasets.list.useQuery(
-    { organizationId: selectedOrgId ?? "" },
-    { enabled: !!selectedOrgId },
+    { projectId: selectedProjectId ?? "" },
+    { enabled: !!selectedProjectId },
   );
 };
 
@@ -150,7 +150,10 @@ export const useScenario = (scenarioId: string) => {
 
 export const useVisibleScenarioIds = () => useScenarios().data?.scenarios.map((s) => s.id) ?? [];
 
-export const useSelectedOrg = () => {
-  const selectedOrgId = useAppStore((state) => state.selectedOrgId);
-  return api.organizations.get.useQuery({ id: selectedOrgId ?? "" }, { enabled: !!selectedOrgId });
+export const useSelectedProject = () => {
+  const selectedProjectId = useAppStore((state) => state.selectedProjectId);
+  return api.projects.get.useQuery(
+    { id: selectedProjectId ?? "" },
+    { enabled: !!selectedProjectId },
+  );
 };


### PR DESCRIPTION
We'll probably need a concept of organizations at some point in the future, but in practice the way we're using these in the codebase right now is as a project, so this renames it to that to avoid confusion.