### PR TITLE
Auto-resize project menu width

### DIFF
--- a/app/src/components/nav/ProjectMenu.tsx
+++ b/app/src/components/nav/ProjectMenu.tsx
@@ -90,7 +90,7 @@ export default function ProjectMenu() {
             </HStack>
           </NavSidebarOption>
         </PopoverTrigger>
-        <PopoverContent _focusVisible={{ outline: "unset" }} ml={-1} minW={0} w="full">
+        <PopoverContent _focusVisible={{ outline: "unset" }} ml={-1} w="auto" minW={100} maxW={280}>
           <VStack alignItems="flex-start" spacing={2} py={4} px={2}>
             <Text color="gray.500" fontSize="xs" fontWeight="bold" pb={1}>
               PROJECTS
@@ -150,6 +150,7 @@ const ProjectOption = ({
       _hover={gearHovered ? undefined : { bgColor: "gray.200", textDecoration: "none" }}
       p={2}
       borderRadius={4}
+      spacing={4}
     >
       <Text>{proj.name}</Text>
       <IconButton


### PR DESCRIPTION
Before:
<img width="584" alt="Screenshot 2023-08-10 at 10 48 36 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/7bccf00d-a76e-456e-a05f-ab013a079803">

After:
<img width="523" alt="Screenshot 2023-08-10 at 10 46 41 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/694c31cf-1d64-4870-903b-8e541e5efebd">
