### PR TITLE
Store model on LoggedCall

### DIFF
--- a/app/prisma/migrations/20230811231429_add_model_to_logged_call/migration.sql
+++ b/app/prisma/migrations/20230811231429_add_model_to_logged_call/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LoggedCall" ADD COLUMN     "model" TEXT;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -273,7 +273,8 @@ model LoggedCall {
     projectId String   @db.Uuid
     project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-    tags LoggedCallTag[]
+    model        String?
+    tags         LoggedCallTag[]
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt


### PR DESCRIPTION
We were previously storing model in a tag, but we're moving it to the LoggedCall schema now to make certain queries more efficient