### PR TITLE
Allow custom config file

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -44,3 +44,6 @@ yarn-error.log*
 
 # Sentry Auth Token
 .sentryclirc
+
+# custom openai intialization
+src/server/utils/openaiCustomConfig.json

--- a/app/src/server/utils/openai.ts
+++ b/app/src/server/utils/openai.ts
@@ -1,13 +1,23 @@
+import { type ClientOptions, default as OriginalOpenAI } from "openai";
+import fs from "fs";
+import path from "path";
+
 import { env } from "~/env.mjs";
 
-import { default as OriginalOpenAI } from "openai";
-// import { OpenAI } from "openpipe";
+import { OpenAI } from "~/../../client-libs/typescript/dist";
 
-const openAIConfig = { apiKey: env.OPENAI_API_KEY ?? "dummy-key" };
+let config: ClientOptions;
 
-// Set a dummy key so it doesn't fail at build time
-// export const openai = env.OPENPIPE_API_KEY
-//   ? new OpenAI.OpenAI(openAIConfig)
-//   : new OriginalOpenAI(openAIConfig);
+try {
+  // Allow developers to override the config with a local file
+  const jsonData = fs.readFileSync(
+    path.join(path.dirname(import.meta.url).replace("file://", ""), "./openaiCustomConfig.json"),
+    "utf8",
+  );
+  config = JSON.parse(jsonData.toString());
+} catch (error) {
+  // Set a dummy key so it doesn't fail at build time
+  config = { apiKey: env.OPENAI_API_KEY ?? "dummy-key" };
+}
 
-export const openai = new OriginalOpenAI(openAIConfig);
+export const openai = env.OPENPIPE_API_KEY ? new OpenAI.OpenAI(config) : new OriginalOpenAI(config);

--- a/app/src/server/utils/openai.ts
+++ b/app/src/server/utils/openai.ts
@@ -4,7 +4,8 @@ import path from "path";
 
 import { env } from "~/env.mjs";
 
-import { OpenAI } from "~/../../client-libs/typescript/dist";
+// TODO: use local dependency
+// import { OpenAI } from "openpipe";
 
 let config: ClientOptions;
 
@@ -20,4 +21,6 @@ try {
   config = { apiKey: env.OPENAI_API_KEY ?? "dummy-key" };
 }
 
-export const openai = env.OPENPIPE_API_KEY ? new OpenAI.OpenAI(config) : new OriginalOpenAI(config);
+// export const openai = env.OPENPIPE_API_KEY ? new OpenAI.OpenAI(config) : new OriginalOpenAI(config);
+
+export const openai = new OriginalOpenAI(config);


### PR DESCRIPTION
Developers can now define custom configurations for their openai instance outside of the git history