### PR TITLE
Allow user to toggle visible columns

### DIFF
--- a/app/src/components/Paginator.tsx
+++ b/app/src/components/Paginator.tsx
@@ -1,15 +1,19 @@
-import { HStack, IconButton, Text, Select, type StackProps, Icon } from "@chakra-ui/react";
+import {
+  HStack,
+  IconButton,
+  Text,
+  Select,
+  type StackProps,
+  Icon,
+  useBreakpointValue,
+} from "@chakra-ui/react";
 import React, { useCallback } from "react";
 import { FiChevronsLeft, FiChevronsRight, FiChevronLeft, FiChevronRight } from "react-icons/fi";
 import { usePageParams } from "~/utils/hooks";
 
 const pageSizeOptions = [10, 25, 50, 100];
 
-const Paginator = ({
-  count,
-  condense,
-  ...props
-}: { count: number; condense?: boolean } & StackProps) => {
+const Paginator = ({ count, ...props }: { count: number; condense?: boolean } & StackProps) => {
   const { page, pageSize, setPageParams } = usePageParams();
 
   const lastPage = Math.ceil(count / pageSize);
@@ -36,6 +40,9 @@ const Paginator = ({
 
   const goToLastPage = () => setPageParams({ page: lastPage }, "replace");
   const goToFirstPage = () => setPageParams({ page: 1 }, "replace");
+
+  const isMobile = useBreakpointValue({ base: true, md: false });
+  const condense = isMobile || props.condense;
 
   if (count === 0) return null;
 

--- a/app/src/components/nav/UserMenu.tsx
+++ b/app/src/components/nav/UserMenu.tsx
@@ -23,50 +23,48 @@ export default function UserMenu({ user, ...rest }: { user: Session } & StackPro
   );
 
   return (
-    <>
-      <Popover placement="right">
-        <PopoverTrigger>
-          <NavSidebarOption>
-            <HStack
-              // Weird values to make mobile look right; can clean up when we make the sidebar disappear on mobile
-              py={2}
-              px={1}
-              spacing={3}
-              {...rest}
-            >
-              {profileImage}
-              <VStack spacing={0} align="start" flex={1} flexShrink={1}>
-                <Text fontWeight="bold" fontSize="sm">
-                  {user.user.name}
-                </Text>
-                <Text color="gray.500" fontSize="xs">
-                  {/* {user.user.email} */}
-                </Text>
-              </VStack>
-              <Icon as={BsChevronRight} boxSize={4} color="gray.500" />
-            </HStack>
-          </NavSidebarOption>
-        </PopoverTrigger>
-        <PopoverContent _focusVisible={{ outline: "unset" }} ml={-1} minW={48} w="full">
-          <VStack align="stretch" spacing={0}>
-            {/* sign out */}
-            <HStack
-              as={Link}
-              onClick={() => {
-                signOut().catch(console.error);
-              }}
-              px={4}
-              py={2}
-              spacing={4}
-              color="gray.500"
-              fontSize="sm"
-            >
-              <Icon as={BsBoxArrowRight} boxSize={6} />
-              <Text>Sign out</Text>
-            </HStack>
-          </VStack>
-        </PopoverContent>
-      </Popover>
-    </>
+    <Popover placement="right">
+      <PopoverTrigger>
+        <NavSidebarOption>
+          <HStack
+            // Weird values to make mobile look right; can clean up when we make the sidebar disappear on mobile
+            py={2}
+            px={1}
+            spacing={3}
+            {...rest}
+          >
+            {profileImage}
+            <VStack spacing={0} align="start" flex={1} flexShrink={1}>
+              <Text fontWeight="bold" fontSize="sm">
+                {user.user.name}
+              </Text>
+              <Text color="gray.500" fontSize="xs">
+                {/* {user.user.email} */}
+              </Text>
+            </VStack>
+            <Icon as={BsChevronRight} boxSize={4} color="gray.500" />
+          </HStack>
+        </NavSidebarOption>
+      </PopoverTrigger>
+      <PopoverContent _focusVisible={{ outline: "unset" }} ml={-1} minW={48} w="full">
+        <VStack align="stretch" spacing={0}>
+          {/* sign out */}
+          <HStack
+            as={Link}
+            onClick={() => {
+              signOut().catch(console.error);
+            }}
+            px={4}
+            py={2}
+            spacing={4}
+            color="gray.500"
+            fontSize="sm"
+          >
+            <Icon as={BsBoxArrowRight} boxSize={6} />
+            <Text>Sign out</Text>
+          </HStack>
+        </VStack>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/app/src/components/requestLogs/ActionButton.tsx
+++ b/app/src/components/requestLogs/ActionButton.tsx
@@ -21,7 +21,7 @@ const ActionButton = ({
     >
       <HStack spacing={1}>
         {icon && <Icon as={icon} />}
-        <Text>{label}</Text>
+        <Text display={{ base: "none", md: "flex" }}>{label}</Text>
       </HStack>
     </Button>
   );

--- a/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
+++ b/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
@@ -24,8 +24,6 @@ const ColumnVisiblityDropdown = () => {
 
   const wholeStore = useAppStore();
 
-  console.log("wholeStore", wholeStore);
-
   const visibleColumns = useAppStore((s) => s.columnVisibility.visibleColumns);
   const toggleColumnVisibility = useAppStore((s) => s.columnVisibility.toggleColumnVisibility);
   const totalColumns = Object.keys(StaticColumnKeys).length + (tagNames?.length ?? 0);

--- a/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
+++ b/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
@@ -1,0 +1,114 @@
+import {
+  Icon,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  VStack,
+  HStack,
+  Button,
+  Text,
+  useDisclosure,
+  Box,
+} from "@chakra-ui/react";
+import { BiCheck } from "react-icons/bi";
+import { BsToggles } from "react-icons/bs";
+
+import { useTagNames } from "~/utils/hooks";
+import { useAppStore } from "~/state/store";
+import { StaticColumnKeys } from "~/state/columnVisiblitySlice";
+import ActionButton from "./ActionButton";
+import { useMemo } from "react";
+
+const ColumnVisiblityDropdown = () => {
+  const tagNames = useTagNames().data;
+
+  const wholeStore = useAppStore();
+
+  console.log("wholeStore", wholeStore);
+
+  const visibleColumns = useAppStore((s) => s.columnVisibility.visibleColumns);
+  const toggleColumnVisibility = useAppStore((s) => s.columnVisibility.toggleColumnVisibility);
+  const totalColumns = Object.keys(StaticColumnKeys).length + (tagNames?.length ?? 0);
+
+  const popover = useDisclosure();
+
+  const columnVisiblityOptions = useMemo(() => {
+    const options: { label: string; key: string }[] = [
+      {
+        label: "Sent At",
+        key: StaticColumnKeys.SENT_AT,
+      },
+      {
+        label: "Model",
+        key: StaticColumnKeys.MODEL,
+      },
+      {
+        label: "Duration",
+        key: StaticColumnKeys.DURATION,
+      },
+      {
+        label: "Input Tokens",
+        key: StaticColumnKeys.INPUT_TOKENS,
+      },
+      {
+        label: "Output Tokens",
+        key: StaticColumnKeys.OUTPUT_TOKENS,
+      },
+      {
+        label: "Status Code",
+        key: StaticColumnKeys.STATUS_CODE,
+      },
+    ];
+    for (const tagName of tagNames ?? []) {
+      options.push({
+        label: tagName,
+        key: tagName,
+      });
+    }
+    return options;
+  }, [tagNames]);
+
+  return (
+    <Popover
+      placement="bottom-start"
+      isOpen={popover.isOpen}
+      onOpen={popover.onOpen}
+      onClose={popover.onClose}
+    >
+      <PopoverTrigger>
+        <Box>
+          <ActionButton
+            label={`Columns (${totalColumns - visibleColumns.size}/${totalColumns})`}
+            icon={BsToggles}
+          />
+        </Box>
+      </PopoverTrigger>
+      <PopoverContent boxShadow="0 0 40px 4px rgba(0, 0, 0, 0.1);" minW={0} w="auto">
+        <VStack spacing={0} maxH={400} overflowY="auto">
+          {columnVisiblityOptions?.map((option, index) => (
+            <HStack
+              key={index}
+              as={Button}
+              onClick={() => toggleColumnVisibility(option.key)}
+              w="full"
+              minH={10}
+              variant="ghost"
+              justifyContent="space-between"
+              fontWeight="semibold"
+              borderRadius={0}
+              colorScheme="blue"
+              color="black"
+              fontSize="sm"
+              borderBottomWidth={1}
+            >
+              <Text mr={16}>{option.label}</Text>
+              {visibleColumns.has(option.key) && <Icon as={BiCheck} color="blue.500" boxSize={5} />}
+            </HStack>
+          ))}
+        </VStack>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default ColumnVisiblityDropdown;

--- a/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
+++ b/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
@@ -12,19 +12,15 @@ import {
 } from "@chakra-ui/react";
 import { BiCheck } from "react-icons/bi";
 import { BsToggles } from "react-icons/bs";
+import { useMemo } from "react";
 
 import { useTagNames } from "~/utils/hooks";
 import { useAppStore } from "~/state/store";
 import { StaticColumnKeys } from "~/state/columnVisiblitySlice";
 import ActionButton from "./ActionButton";
-import { useMemo } from "react";
 
 const ColumnVisiblityDropdown = () => {
   const tagNames = useTagNames().data;
-
-  const wholeStore = useAppStore();
-
-  console.log("wholeStore", wholeStore);
 
   const visibleColumns = useAppStore((s) => s.columnVisibility.visibleColumns);
   const toggleColumnVisibility = useAppStore((s) => s.columnVisibility.toggleColumnVisibility);
@@ -68,6 +64,9 @@ const ColumnVisiblityDropdown = () => {
     return options;
   }, [tagNames]);
 
+  const isRehydrated = useAppStore((s) => s.isRehydrated);
+  if (!isRehydrated) return null;
+
   return (
     <Popover
       placement="bottom-start"
@@ -78,7 +77,7 @@ const ColumnVisiblityDropdown = () => {
       <PopoverTrigger>
         <Box>
           <ActionButton
-            label={`Columns (${totalColumns - visibleColumns.size}/${totalColumns})`}
+            label={`Columns (${visibleColumns.size}/${totalColumns})`}
             icon={BsToggles}
           />
         </Box>

--- a/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
+++ b/app/src/components/requestLogs/ColumnVisiblityDropdown.tsx
@@ -14,7 +14,7 @@ import { BiCheck } from "react-icons/bi";
 import { BsToggles } from "react-icons/bs";
 import { useMemo } from "react";
 
-import { useTagNames } from "~/utils/hooks";
+import { useIsClientRehydrated, useTagNames } from "~/utils/hooks";
 import { useAppStore } from "~/state/store";
 import { StaticColumnKeys } from "~/state/columnVisiblitySlice";
 import ActionButton from "./ActionButton";
@@ -64,8 +64,8 @@ const ColumnVisiblityDropdown = () => {
     return options;
   }, [tagNames]);
 
-  const isRehydrated = useAppStore((s) => s.isRehydrated);
-  if (!isRehydrated) return null;
+  const isClientRehydrated = useIsClientRehydrated();
+  if (!isClientRehydrated) return null;
 
   return (
     <Popover
@@ -101,7 +101,11 @@ const ColumnVisiblityDropdown = () => {
               borderBottomWidth={1}
             >
               <Text mr={16}>{option.label}</Text>
-              {visibleColumns.has(option.key) && <Icon as={BiCheck} color="blue.500" boxSize={5} />}
+              <Box w={5}>
+                {visibleColumns.has(option.key) && (
+                  <Icon as={BiCheck} color="blue.500" boxSize={5} />
+                )}
+              </Box>
             </HStack>
           ))}
         </VStack>

--- a/app/src/components/requestLogs/LoggedCallsTable.tsx
+++ b/app/src/components/requestLogs/LoggedCallsTable.tsx
@@ -10,7 +10,7 @@ export default function LoggedCallsTable() {
   return (
     <Card width="100%" overflowX="auto">
       <Table>
-        <TableHeader showCheckbox />
+        <TableHeader isSimple />
         <Tbody>
           {loggedCalls?.calls?.map((loggedCall) => {
             return (
@@ -25,7 +25,7 @@ export default function LoggedCallsTable() {
                     setExpandedRow(loggedCall.id);
                   }
                 }}
-                showCheckbox
+                isSimple
               />
             );
           })}

--- a/app/src/components/requestLogs/TableRow.tsx
+++ b/app/src/components/requestLogs/TableRow.tsx
@@ -21,14 +21,15 @@ import Link from "next/link";
 import { type RouterOutputs } from "~/utils/api";
 import { FormattedJson } from "./FormattedJson";
 import { useAppStore } from "~/state/store";
-import { useLoggedCalls, useTagNames } from "~/utils/hooks";
+import { useIsClientRehydrated, useLoggedCalls, useTagNames } from "~/utils/hooks";
 import { useMemo } from "react";
+import { StaticColumnKeys } from "~/state/columnVisiblitySlice";
 
 dayjs.extend(relativeTime);
 
 type LoggedCall = RouterOutputs["loggedCalls"]["list"]["calls"][0];
 
-export const TableHeader = ({ showCheckbox }: { showCheckbox?: boolean }) => {
+export const TableHeader = ({ isSimple }: { isSimple?: boolean }) => {
   const matchingLogIds = useLoggedCalls().data?.matchingLogIds;
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
   const addAll = useAppStore((s) => s.selectedLogs.addSelectedLogIds);
@@ -38,10 +39,14 @@ export const TableHeader = ({ showCheckbox }: { showCheckbox?: boolean }) => {
     return matchingLogIds.every((id) => selectedLogIds.has(id));
   }, [selectedLogIds, matchingLogIds]);
   const tagNames = useTagNames().data;
+  const visibleColumns = useAppStore((s) => s.columnVisibility.visibleColumns);
+  const isClientRehydrated = useIsClientRehydrated();
+  if (!isClientRehydrated) return null;
+
   return (
     <Thead>
       <Tr>
-        {showCheckbox && (
+        {isSimple && (
           <Th pr={0}>
             <HStack minW={16}>
               <Checkbox
@@ -57,17 +62,19 @@ export const TableHeader = ({ showCheckbox }: { showCheckbox?: boolean }) => {
             </HStack>
           </Th>
         )}
-        <Th>Sent At</Th>
-        <Th>Model</Th>
-        {tagNames?.map((tagName) => (
-          <Th key={tagName} textTransform={"none"}>
-            {tagName}
-          </Th>
-        ))}
-        <Th isNumeric>Duration</Th>
-        <Th isNumeric>Input tokens</Th>
-        <Th isNumeric>Output tokens</Th>
-        <Th isNumeric>Status</Th>
+        {visibleColumns.has(StaticColumnKeys.SENT_AT) && <Th>Sent At</Th>}
+        {visibleColumns.has(StaticColumnKeys.MODEL) && <Th>Model</Th>}
+        {tagNames
+          ?.filter((tagName) => visibleColumns.has(tagName))
+          .map((tagName) => (
+            <Th key={tagName} textTransform={"none"}>
+              {tagName}
+            </Th>
+          ))}
+        {visibleColumns.has(StaticColumnKeys.DURATION) && <Th isNumeric>Duration</Th>}
+        {visibleColumns.has(StaticColumnKeys.INPUT_TOKENS) && <Th isNumeric>Input tokens</Th>}
+        {visibleColumns.has(StaticColumnKeys.OUTPUT_TOKENS) && <Th isNumeric>Output tokens</Th>}
+        {visibleColumns.has(StaticColumnKeys.STATUS_CODE) && <Th isNumeric>Status</Th>}
       </Tr>
     </Thead>
   );
@@ -77,12 +84,12 @@ export const TableRow = ({
   loggedCall,
   isExpanded,
   onToggle,
-  showCheckbox,
+  isSimple,
 }: {
   loggedCall: LoggedCall;
   isExpanded: boolean;
   onToggle: () => void;
-  showCheckbox?: boolean;
+  isSimple?: boolean;
 }) => {
   const isError = loggedCall.modelResponse?.statusCode !== 200;
   const requestedAt = dayjs(loggedCall.requestedAt).format("MMMM D h:mm A");
@@ -92,6 +99,10 @@ export const TableRow = ({
   const toggleChecked = useAppStore((s) => s.selectedLogs.toggleSelectedLogId);
 
   const tagNames = useTagNames().data;
+  const visibleColumns = useAppStore((s) => s.columnVisibility.visibleColumns);
+
+  const isClientRehydrated = useIsClientRehydrated();
+  if (!isClientRehydrated) return null;
 
   return (
     <>
@@ -104,47 +115,61 @@ export const TableRow = ({
         }}
         fontSize="sm"
       >
-        {showCheckbox && (
+        {isSimple && (
           <Td>
             <Checkbox isChecked={isChecked} onChange={() => toggleChecked(loggedCall.id)} />
           </Td>
         )}
-        <Td>
-          <Tooltip label={fullTime} placement="top">
-            <Box whiteSpace="nowrap" minW="120px">
-              {requestedAt}
-            </Box>
-          </Tooltip>
-        </Td>
-        <Td>
-          <HStack justifyContent="flex-start">
-            <Text
-              colorScheme="purple"
-              color="purple.500"
-              borderColor="purple.500"
-              px={1}
-              borderRadius={4}
-              borderWidth={1}
-              fontSize="xs"
-              whiteSpace="nowrap"
-            >
-              {loggedCall.model}
-            </Text>
-          </HStack>
-        </Td>
-        {tagNames?.map((tagName) => <Td key={tagName}>{loggedCall.tags[tagName]}</Td>)}
-        <Td isNumeric>
-          {loggedCall.cacheHit ? (
-            <Text color="gray.500">Cached</Text>
-          ) : (
-            ((loggedCall.modelResponse?.durationMs ?? 0) / 1000).toFixed(2) + "s"
-          )}
-        </Td>
-        <Td isNumeric>{loggedCall.modelResponse?.inputTokens}</Td>
-        <Td isNumeric>{loggedCall.modelResponse?.outputTokens}</Td>
-        <Td sx={{ color: isError ? "red.500" : "green.500", fontWeight: "semibold" }} isNumeric>
-          {loggedCall.modelResponse?.statusCode ?? "No response"}
-        </Td>
+        {visibleColumns.has(StaticColumnKeys.SENT_AT) && (
+          <Td>
+            <Tooltip label={fullTime} placement="top">
+              <Box whiteSpace="nowrap" minW="120px">
+                {requestedAt}
+              </Box>
+            </Tooltip>
+          </Td>
+        )}
+        {visibleColumns.has(StaticColumnKeys.MODEL) && (
+          <Td>
+            <HStack justifyContent="flex-start">
+              <Text
+                colorScheme="purple"
+                color="purple.500"
+                borderColor="purple.500"
+                px={1}
+                borderRadius={4}
+                borderWidth={1}
+                fontSize="xs"
+                whiteSpace="nowrap"
+              >
+                {loggedCall.model}
+              </Text>
+            </HStack>
+          </Td>
+        )}
+        {tagNames
+          ?.filter((tagName) => visibleColumns.has(tagName))
+          .map((tagName) => <Td key={tagName}>{loggedCall.tags[tagName]}</Td>)}
+        {visibleColumns.has(StaticColumnKeys.DURATION) && (
+          <Td isNumeric>
+            {loggedCall.cacheHit ? (
+              <Text color="gray.500">Cached</Text>
+            ) : (
+              ((loggedCall.modelResponse?.durationMs ?? 0) / 1000).toFixed(2) + "s"
+            )}
+          </Td>
+        )}
+        {visibleColumns.has(StaticColumnKeys.INPUT_TOKENS) && (
+          <Td isNumeric>{loggedCall.modelResponse?.inputTokens}</Td>
+        )}
+        {visibleColumns.has(StaticColumnKeys.OUTPUT_TOKENS) && (
+          <Td isNumeric>{loggedCall.modelResponse?.outputTokens}</Td>
+        )}
+        {visibleColumns.has(StaticColumnKeys.STATUS_CODE) && (
+          <Td sx={{ color: isError ? "red.500" : "green.500", fontWeight: "semibold" }} isNumeric>
+            {loggedCall.modelResponse?.statusCode ?? "No response"}
+          </Td>
+        )}
       </Tr>
       <Tr>
         <Td colSpan={8} p={0}>

--- a/app/src/components/requestLogs/TableRow.tsx
+++ b/app/src/components/requestLogs/TableRow.tsx
@@ -59,7 +59,11 @@ export const TableHeader = ({ showCheckbox }: { showCheckbox?: boolean }) => {
         )}
         <Th>Sent At</Th>
         <Th>Model</Th>
-        {tagNames?.map((tagName) => <Th key={tagName}>{tagName}</Th>)}
+        {tagNames?.map((tagName) => (
+          <Th key={tagName} textTransform={"none"}>
+            {tagName}
+          </Th>
+        ))}
         <Th isNumeric>Duration</Th>
         <Th isNumeric>Input tokens</Th>
         <Th isNumeric>Output tokens</Th>

--- a/app/src/pages/request-logs/index.tsx
+++ b/app/src/pages/request-logs/index.tsx
@@ -8,17 +8,11 @@ import ActionButton from "~/components/requestLogs/ActionButton";
 import { useAppStore } from "~/state/store";
 import { RiFlaskLine } from "react-icons/ri";
 import { FiFilter } from "react-icons/fi";
-import { BsToggles } from "react-icons/bs";
 import LogFilters from "~/components/requestLogs/LogFilters/LogFilters";
-import { useTagNames } from "~/utils/hooks";
-import { StaticColumnKeys } from "~/state/columnVisiblitySlice";
+import ColumnVisiblityDropdown from "~/components/requestLogs/ColumnVisiblityDropdown";
 
 export default function LoggedCalls() {
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
-  const hiddenColumns = useAppStore((s) => s.columnVisibility.hiddenColumns);
-  const tagNames = useTagNames().data;
-
-  const totalColumns = Object.keys(StaticColumnKeys).length + (tagNames?.length ?? 0);
 
   const [filtersShown, setFiltersShown] = useState(true);
 
@@ -30,13 +24,7 @@ export default function LoggedCalls() {
         </Text>
         <Divider />
         <HStack w="full" justifyContent="flex-end">
-          <ActionButton
-            onClick={() => {
-              console.log("experimenting with these ids", selectedLogIds);
-            }}
-            label={`Show (${totalColumns - hiddenColumns.size}/${totalColumns})`}
-            icon={BsToggles}
-          />
+          <ColumnVisiblityDropdown />
           <ActionButton
             onClick={() => {
               setFiltersShown(!filtersShown);

--- a/app/src/pages/request-logs/index.tsx
+++ b/app/src/pages/request-logs/index.tsx
@@ -8,10 +8,17 @@ import ActionButton from "~/components/requestLogs/ActionButton";
 import { useAppStore } from "~/state/store";
 import { RiFlaskLine } from "react-icons/ri";
 import { FiFilter } from "react-icons/fi";
+import { BsToggles } from "react-icons/bs";
 import LogFilters from "~/components/requestLogs/LogFilters/LogFilters";
+import { useTagNames } from "~/utils/hooks";
+import { StaticColumnKeys } from "~/state/columnVisiblitySlice";
 
 export default function LoggedCalls() {
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
+  const hiddenColumns = useAppStore((s) => s.columnVisibility.hiddenColumns);
+  const tagNames = useTagNames().data;
+
+  const totalColumns = Object.keys(StaticColumnKeys).length + (tagNames?.length ?? 0);
 
   const [filtersShown, setFiltersShown] = useState(true);
 
@@ -23,6 +30,13 @@ export default function LoggedCalls() {
         </Text>
         <Divider />
         <HStack w="full" justifyContent="flex-end">
+          <ActionButton
+            onClick={() => {
+              console.log("experimenting with these ids", selectedLogIds);
+            }}
+            label={`Show (${totalColumns - hiddenColumns.size}/${totalColumns})`}
+            icon={BsToggles}
+          />
           <ActionButton
             onClick={() => {
               setFiltersShown(!filtersShown);

--- a/app/src/state/columnVisiblitySlice.ts
+++ b/app/src/state/columnVisiblitySlice.ts
@@ -14,29 +14,24 @@ export enum StaticColumnKeys {
 }
 
 export type ColumnVisibilitySlice = {
-  hiddenColumns: Set<string>;
+  visibleColumns: Set<string>;
   toggleColumnVisibility: (columnKey: string) => void;
-  showAllColumns: () => void;
-  hideColumns: (columnKeys: string[]) => void;
+  showAllColumns: (columnKeys: string[]) => void;
 };
 
 export const createColumnVisibilitySlice: SliceCreator<ColumnVisibilitySlice> = (set, get) => ({
-  hiddenColumns: new Set(),
-  allColumns: new Set(),
+  // initialize with all static columns visible
+  visibleColumns: new Set(Object.values(StaticColumnKeys)),
   toggleColumnVisibility: (columnKey: string) =>
     set((state) => {
-      if (state.columnVisibility.hiddenColumns.has(columnKey)) {
-        state.columnVisibility.hiddenColumns.delete(columnKey);
+      if (state.columnVisibility.visibleColumns.has(columnKey)) {
+        state.columnVisibility.visibleColumns.delete(columnKey);
       } else {
-        state.columnVisibility.hiddenColumns.add(columnKey);
+        state.columnVisibility.visibleColumns.add(columnKey);
       }
     }),
-  showAllColumns: () =>
+  showAllColumns: (columnKeys: string[]) =>
     set((state) => {
-      state.columnVisibility.hiddenColumns = new Set();
-    }),
-  hideColumns: (columnKeys: string[]) =>
-    set((state) => {
-      state.columnVisibility.hiddenColumns = new Set(columnKeys);
+      state.columnVisibility.visibleColumns = new Set(columnKeys);
     }),
 });

--- a/app/src/state/columnVisiblitySlice.ts
+++ b/app/src/state/columnVisiblitySlice.ts
@@ -1,0 +1,42 @@
+import { type SliceCreator } from "./store";
+
+export const comparators = ["=", "!=", "CONTAINS", "NOT_CONTAINS"] as const;
+
+export const defaultFilterableFields = ["Request", "Response", "Model", "Status Code"] as const;
+
+export enum StaticColumnKeys {
+  SENT_AT = "sentAt",
+  MODEL = "model",
+  DURATION = "duration",
+  INPUT_TOKENS = "inputTokens",
+  OUTPUT_TOKENS = "outputTokens",
+  STATUS_CODE = "statusCode",
+}
+
+export type ColumnVisibilitySlice = {
+  hiddenColumns: Set<string>;
+  toggleColumnVisibility: (columnKey: string) => void;
+  showAllColumns: () => void;
+  hideColumns: (columnKeys: string[]) => void;
+};
+
+export const createColumnVisibilitySlice: SliceCreator<ColumnVisibilitySlice> = (set, get) => ({
+  hiddenColumns: new Set(),
+  allColumns: new Set(),
+  toggleColumnVisibility: (columnKey: string) =>
+    set((state) => {
+      if (state.columnVisibility.hiddenColumns.has(columnKey)) {
+        state.columnVisibility.hiddenColumns.delete(columnKey);
+      } else {
+        state.columnVisibility.hiddenColumns.add(columnKey);
+      }
+    }),
+  showAllColumns: () =>
+    set((state) => {
+      state.columnVisibility.hiddenColumns = new Set();
+    }),
+  hideColumns: (columnKeys: string[]) =>
+    set((state) => {
+      state.columnVisibility.hiddenColumns = new Set(columnKeys);
+    }),
+});

--- a/app/src/state/persist.ts
+++ b/app/src/state/persist.ts
@@ -21,4 +21,7 @@ export const persistOptions: PersistOptions<State, PersistedState> = {
     setItem: (key, value) => localStorage.setItem(key, SuperJSON.stringify(value)),
     removeItem: (key) => localStorage.removeItem(key),
   },
+  onRehydrateStorage: (state) => {
+    if (state) state.isRehydrated = true;
+  },
 };

--- a/app/src/state/persist.ts
+++ b/app/src/state/persist.ts
@@ -1,13 +1,28 @@
 import { type PersistOptions } from "zustand/middleware/persist";
 import { type State } from "./store";
+import SuperJSON from "superjson";
 
 export const stateToPersist = {
   selectedProjectId: null as string | null,
+  columnVisibility: {
+    hiddenColumns: new Set<string>(),
+  },
 };
 
 export const persistOptions: PersistOptions<State, typeof stateToPersist> = {
   name: "persisted-app-store",
   partialize: (state) => ({
     selectedProjectId: state.selectedProjectId,
+    columnVisibility: {
+      hiddenColumns: state.columnVisibility.hiddenColumns,
+    },
   }),
+  storage: {
+    getItem: (key) => {
+      const data = localStorage.getItem(key);
+      return data ? SuperJSON.parse(data) : null;
+    },
+    setItem: (key, value) => localStorage.setItem(key, SuperJSON.stringify(value)),
+    removeItem: (key) => localStorage.removeItem(key),
+  },
 };

--- a/app/src/state/persist.ts
+++ b/app/src/state/persist.ts
@@ -1,22 +1,18 @@
 import { type PersistOptions } from "zustand/middleware/persist";
 import { type State } from "./store";
 import SuperJSON from "superjson";
+import { merge, pick } from "lodash-es";
+import { type PartialDeep } from "type-fest";
 
-export const stateToPersist = {
-  selectedProjectId: null as string | null,
-  columnVisibility: {
-    hiddenColumns: new Set<string>(),
-  },
-};
+export type PersistedState = PartialDeep<State>;
 
-export const persistOptions: PersistOptions<State, typeof stateToPersist> = {
+export const persistOptions: PersistOptions<State, PersistedState> = {
   name: "persisted-app-store",
   partialize: (state) => ({
     selectedProjectId: state.selectedProjectId,
-    columnVisibility: {
-      hiddenColumns: state.columnVisibility.hiddenColumns,
-    },
+    columnVisibility: pick(state.columnVisibility, ["visibleColumns"]),
   }),
+  merge: (saved, state) => merge(state, saved),
   storage: {
     getItem: (key) => {
       const data = localStorage.getItem(key);

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -8,7 +8,7 @@ import {
   createVariantEditorSlice,
 } from "./sharedVariantEditor.slice";
 import { type APIClient } from "~/utils/api";
-import { persistOptions, type stateToPersist } from "./persist";
+import { PersistedState, persistOptions } from "./persist";
 import { type SelectedLogsSlice, createSelectedLogsSlice } from "./selectedLogsSlice";
 import { type LogFiltersSlice, createLogFiltersSlice } from "./logFiltersSlice";
 import { type ColumnVisibilitySlice, createColumnVisibilitySlice } from "./columnVisiblitySlice";
@@ -34,10 +34,7 @@ export type SliceCreator<T> = StateCreator<State, [["zustand/immer", never]], []
 export type SetFn = Parameters<SliceCreator<unknown>>[0];
 export type GetFn = Parameters<SliceCreator<unknown>>[1];
 
-const useBaseStore = create<
-  State,
-  [["zustand/persist", typeof stateToPersist], ["zustand/immer", never]]
->(
+const useBaseStore = create<State, [["zustand/persist", PersistedState], ["zustand/immer", never]]>(
   persist(
     immer((set, get, ...rest) => ({
       api: null,

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -11,6 +11,7 @@ import { type APIClient } from "~/utils/api";
 import { persistOptions, type stateToPersist } from "./persist";
 import { type SelectedLogsSlice, createSelectedLogsSlice } from "./selectedLogsSlice";
 import { type LogFiltersSlice, createLogFiltersSlice } from "./logFiltersSlice";
+import { type ColumnVisibilitySlice, createColumnVisibilitySlice } from "./columnVisiblitySlice";
 
 enableMapSet();
 
@@ -25,6 +26,7 @@ export type State = {
   setSelectedProjectId: (id: string) => void;
   selectedLogs: SelectedLogsSlice;
   logFilters: LogFiltersSlice;
+  columnVisibility: ColumnVisibilitySlice;
 };
 
 export type SliceCreator<T> = StateCreator<State, [["zustand/immer", never]], [], T>;
@@ -43,7 +45,6 @@ const useBaseStore = create<
         set((state) => {
           state.api = api;
         }),
-
       drawerOpen: false,
       openDrawer: () =>
         set((state) => {
@@ -61,6 +62,7 @@ const useBaseStore = create<
         }),
       selectedLogs: createSelectedLogsSlice(set, get, ...rest),
       logFilters: createLogFiltersSlice(set, get, ...rest),
+      columnVisibility: createColumnVisibilitySlice(set, get, ...rest),
     })),
     persistOptions,
   ),

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -11,11 +11,13 @@ import { type APIClient } from "~/utils/api";
 import { persistOptions, type stateToPersist } from "./persist";
 import { type SelectedLogsSlice, createSelectedLogsSlice } from "./selectedLogsSlice";
 import { type LogFiltersSlice, createLogFiltersSlice } from "./logFiltersSlice";
-import { type ColumnVisibilitySlice, createColumnVisibilitySlice } from "./columnVisiblitySlice";
+import { createColumnVisibilitySlice, type ColumnVisibilitySlice } from "./columnVisiblitySlice";
 
 enableMapSet();
 
 export type State = {
+  isRehydrated: boolean;
+  setIsRehydrated: (isRehydrated: boolean) => void;
   drawerOpen: boolean;
   openDrawer: () => void;
   closeDrawer: () => void;
@@ -40,6 +42,11 @@ const useBaseStore = create<
 >(
   persist(
     immer((set, get, ...rest) => ({
+      isRehydrated: false,
+      setIsRehydrated: (isRehydrated) =>
+        set((state) => {
+          state.isRehydrated = isRehydrated;
+        }),
       api: null,
       setApi: (api) =>
         set((state) => {

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -8,7 +8,7 @@ import {
   createVariantEditorSlice,
 } from "./sharedVariantEditor.slice";
 import { type APIClient } from "~/utils/api";
-import { PersistedState, persistOptions } from "./persist";
+import { type PersistedState, persistOptions } from "./persist";
 import { type SelectedLogsSlice, createSelectedLogsSlice } from "./selectedLogsSlice";
 import { type LogFiltersSlice, createLogFiltersSlice } from "./logFiltersSlice";
 import { createColumnVisibilitySlice, type ColumnVisibilitySlice } from "./columnVisiblitySlice";
@@ -17,7 +17,6 @@ enableMapSet();
 
 export type State = {
   isRehydrated: boolean;
-  setIsRehydrated: (isRehydrated: boolean) => void;
   drawerOpen: boolean;
   openDrawer: () => void;
   closeDrawer: () => void;
@@ -40,10 +39,6 @@ const useBaseStore = create<State, [["zustand/persist", PersistedState], ["zusta
   persist(
     immer((set, get, ...rest) => ({
       isRehydrated: false,
-      setIsRehydrated: (isRehydrated) =>
-        set((state) => {
-          state.isRehydrated = isRehydrated;
-        }),
       api: null,
       setApi: (api) =>
         set((state) => {

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -205,3 +205,12 @@ export const useTagNames = () => {
     { enabled: !!selectedProjectId },
   );
 };
+
+export const useIsClientRehydrated = () => {
+  const isRehydrated = useAppStore((state) => state.isRehydrated);
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+  return isRehydrated && isMounted;
+};


### PR DESCRIPTION
Allow the user to toggle which columns are shown in the request logs table, and persist that information to local storage through zustand.

## Changes
* Add `ColumnVisibilityDropdown`
* Add `useIsClientRehydrated`
* Persist zustand data with superjson

<img width="1537" alt="Screenshot 2023-08-21 at 10 26 07 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/46016267-4075-41bd-80dd-4462a66a6e6a">
