### PR TITLE
Fix padding for mobile sign in

### DIFF
--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -105,7 +105,7 @@ const NavSidebar = () => {
           <NavSidebarOption>
             <HStack
               w="full"
-              p={4}
+              p={{ base: 2, md: 4 }}
               as={ChakraLink}
               justifyContent="start"
               onClick={() => {


### PR DESCRIPTION
Before:
<img width="439" alt="Screenshot 2023-08-23 at 12 36 54 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/794916be-0353-415c-94f6-f7b821d6b3ce">


After:
<img width="413" alt="Screenshot 2023-08-23 at 12 36 40 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/645132b5-7c06-4efa-badd-1e3f67f1d780">
