### PR TITLE
Remove openpipe object from config

### DIFF
--- a/app/src/server/utils/openai.ts
+++ b/app/src/server/utils/openai.ts
@@ -17,10 +17,6 @@ try {
   // Set a dummy key so it doesn't fail at build time
   config = {
     apiKey: env.OPENAI_API_KEY ?? "dummy-key",
-    openpipe: {
-      apiKey: env.OPENPIPE_API_KEY,
-      baseUrl: "http://localhost:3000/api/v1",
-    },
   };
 }
 

--- a/app/src/server/utils/openai.ts
+++ b/app/src/server/utils/openai.ts
@@ -20,6 +20,4 @@ try {
   };
 }
 
-// export const openai = env.OPENPIPE_API_KEY ? new OpenAI.OpenAI(config) : new OriginalOpenAI(config);
-
 export const openai = new OpenAI(config);


### PR DESCRIPTION
We now always default to reporting to our production servers, so users don't have to remember to set `OPENPIPE_BASE_URL` when running against our hosted instance.