### PR TITLE
Fix doc link layout on mobile

### DIFF
--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -116,8 +116,8 @@ const NavSidebar = () => {
       </VStack>
       <HStack
         w="full"
-        px={{ base: 2, md: 4 }}
-        py={{ base: 1, md: 2 }}
+        px={{ base: 3, md: 4 }}
+        py={{ base: 0, md: 1 }}
         as={ChakraLink}
         justifyContent="start"
         href="https://docs.openpipe.ai"
@@ -126,8 +126,8 @@ const NavSidebar = () => {
         spacing={1}
       >
         <Icon as={FaReadme} boxSize={4} mr={2} />
-        <Text fontWeight="bold" fontSize="sm">
-          Read the Docs
+        <Text fontWeight="bold" fontSize="sm" display={{ base: "none", md: "flex" }}>
+          Open Documentation
         </Text>
       </HStack>
       <Divider />


### PR DESCRIPTION
Before:
<img width="423" alt="Screenshot 2023-09-01 at 1 40 45 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/563f365d-9206-4e2a-af22-d3422742f095">


After:
<img width="427" alt="Screenshot 2023-09-01 at 1 40 28 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/9f4b6911-b0ed-45a8-835b-30f5840ce63b">
