### PR TITLE
Disable streaming for function calls

### DIFF
--- a/app/src/modelProviders/openai-ChatCompletion/getCompletion.ts
+++ b/app/src/modelProviders/openai-ChatCompletion/getCompletion.ts
@@ -14,7 +14,7 @@ export async function getCompletion(
   let finalCompletion: ChatCompletion | null = null;
 
   try {
-    if (onStream) {
+    if (onStream && !input.function_call) {
       const resp = await openai.chat.completions.create(
         {
           ...input,


### PR DESCRIPTION
Fixes bug that causes streamed function call responses to double up tokens

Before:
<img width="634" alt="Screenshot 2023-09-04 at 5 37 29 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/d780aa76-23a9-4a77-86be-f737084dd7dd">


After:
<img width="505" alt="Screenshot 2023-09-04 at 5 37 21 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/4db0bc4f-6dda-4a6e-8447-5f28a19735c3">
