### PR TITLE
Set default value for DatasetEntry input

### DIFF
--- a/app/prisma/migrations/20230905233758_revamp_dataset_entry/migration.sql
+++ b/app/prisma/migrations/20230905233758_revamp_dataset_entry/migration.sql
@@ -1,7 +1,6 @@
 /*
   Warnings:
 
-  - Added the required column `input` to the `DatasetEntry` table without a default value. This is not possible if the table is not empty.
   - Added the required column `inputTokens` to the `DatasetEntry` table without a default value. This is not possible if the table is not empty.
   - Added the required column `outputTokens` to the `DatasetEntry` table without a default value. This is not possible if the table is not empty.
   - Added the required column `type` to the `DatasetEntry` table without a default value. This is not possible if the table is not empty.
@@ -14,7 +13,7 @@ CREATE TYPE "DatasetEntryType" AS ENUM ('TRAIN', 'TEST');
 ALTER TABLE "Dataset" ADD COLUMN     "trainingRatio" DOUBLE PRECISION NOT NULL DEFAULT 0.8;
 
 -- AlterTable
-ALTER TABLE "DatasetEntry" ADD COLUMN     "input" JSONB NOT NULL,
+ALTER TABLE "DatasetEntry" ADD COLUMN     "input" JSONB NOT NULL DEFAULT '[]',
 ADD COLUMN     "inputTokens" INTEGER NOT NULL,
 ADD COLUMN     "output" JSONB,
 ADD COLUMN     "outputTokens" INTEGER NOT NULL,

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -202,7 +202,7 @@ model DatasetEntry {
     loggedCallId String @db.Uuid
     loggedCall   LoggedCall @relation(fields: [loggedCallId], references: [id], onDelete: Cascade)
 
-    input        Json
+    input        Json  @default("[]")
     output       Json?
     inputTokens  Int
     outputTokens Int


### PR DESCRIPTION
Fixes a bug for the few malformed dataset entries we've created while testing that prevented our database from properly migrating.