### PR TITLE
Reword downloading status text

### DIFF
--- a/app/src/components/datasets/FileUploadsCard.tsx
+++ b/app/src/components/datasets/FileUploadsCard.tsx
@@ -135,7 +135,7 @@ const getStatusText = (status: FileUpload["status"]) => {
     case "PENDING":
       return "Pending";
     case "DOWNLOADING":
-      return "Downloading to Server";
+      return "Loading Data";
     case "PROCESSING":
       return "Processing";
     case "SAVING":

--- a/app/src/components/datasets/FileUploadsCard.tsx
+++ b/app/src/components/datasets/FileUploadsCard.tsx
@@ -106,7 +106,7 @@ const FileUploadRow = ({ fileUpload }: { fileUpload: FileUpload }) => {
       </HStack>
 
       {errorMessage ? (
-        <Text alignSelf="center" pt={2} color="red" fontSize="xs">
+        <Text alignSelf="center" pt={2}>
           {errorMessage}
         </Text>
       ) : (

--- a/app/src/components/datasets/FileUploadsCard.tsx
+++ b/app/src/components/datasets/FileUploadsCard.tsx
@@ -78,13 +78,13 @@ const FileUploadRow = ({ fileUpload }: { fileUpload: FileUpload }) => {
   const hideFileUploadsMutation = api.datasets.hideFileUploads.useMutation();
   const [hideFileUpload, hidingInProgress] = useHandledAsyncCallback(async () => {
     await hideFileUploadsMutation.mutateAsync({ fileUploadIds: [id] });
+    await utils.datasets.listFileUploads.invalidate();
   }, [id, hideFileUploadsMutation, utils]);
 
-  const [refreshDatasetEntries] = useHandledAsyncCallback(async () => {
-    await hideFileUploadsMutation.mutateAsync({ fileUploadIds: [id] });
-    await utils.datasets.listFileUploads.invalidate();
-    await utils.datasetEntries.list.invalidate();
-  }, [id, hideFileUploadsMutation, utils]);
+  useEffect(() => {
+    // Invalidate dataset entries list when upload is processed
+    if (status === "COMPLETE") void utils.datasetEntries.list.invalidate();
+  }, [status, utils]);
 
   return (
     <VStack w="full" alignItems="flex-start" p={4} borderBottomWidth={1}>
@@ -93,25 +93,16 @@ const FileUploadRow = ({ fileUpload }: { fileUpload: FileUpload }) => {
           <Text fontWeight="bold">{fileName}</Text>
           <Text fontSize="xs">({formatFileSize(fileSize, 2)})</Text>
         </VStack>
-
-        <HStack spacing={0}>
-          {status === "COMPLETE" ? (
-            <Button variant="ghost" onClick={refreshDatasetEntries} color="orange.400" size="xs">
-              Refresh Table
-            </Button>
-          ) : (
-            <IconButton
-              aria-label="Hide file upload"
-              as={BsX}
-              boxSize={6}
-              minW={0}
-              variant="ghost"
-              isLoading={hidingInProgress}
-              onClick={hideFileUpload}
-              cursor="pointer"
-            />
-          )}
-        </HStack>
+        <Button
+          aria-label="Hide file upload"
+          minW={0}
+          variant="ghost"
+          isLoading={hidingInProgress}
+          onClick={hideFileUpload}
+          size="xs"
+        >
+          HIDE
+        </Button>
       </HStack>
 
       {errorMessage ? (

--- a/app/src/components/datasets/FileUploadsCard.tsx
+++ b/app/src/components/datasets/FileUploadsCard.tsx
@@ -106,7 +106,7 @@ const FileUploadRow = ({ fileUpload }: { fileUpload: FileUpload }) => {
       </HStack>
 
       {errorMessage ? (
-        <Text alignSelf="center" pt={2}>
+        <Text alignSelf="center" pt={2} color="red" fontSize="xs">
           {errorMessage}
         </Text>
       ) : (

--- a/app/src/components/datasets/UploadDataButton.tsx
+++ b/app/src/components/datasets/UploadDataButton.tsx
@@ -136,7 +136,12 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
   }, [dataset, trainingRows, triggerFileDownloadMutation, file, utils]);
 
   return (
-    <Modal size={{ base: "xl", md: "2xl" }} {...disclosure}>
+    <Modal
+      size={{ base: "xl", md: "2xl" }}
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+      {...disclosure}
+    >
       <ModalOverlay />
       <ModalContent w={1200}>
         <ModalHeader>
@@ -144,7 +149,7 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
             <Text>Upload Training Logs</Text>
           </HStack>
         </ModalHeader>
-        <ModalCloseButton />
+        {!sendingInProgress && <ModalCloseButton />}
         <ModalBody maxW="unset" p={8}>
           <Box w="full" aspectRatio={1.5}>
             {validationError && (
@@ -231,23 +236,30 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
                     </>
                   )}
                 </VStack>
-                <Text
-                  as="span"
-                  textDecor="underline"
-                  color="gray.500"
-                  _hover={{ color: "orange.400" }}
-                  cursor="pointer"
-                  onClick={resetState}
-                >
-                  Change file
-                </Text>
+                {!sendingInProgress && (
+                  <Text
+                    as="span"
+                    textDecor="underline"
+                    color="gray.500"
+                    _hover={{ color: "orange.400" }}
+                    cursor="pointer"
+                    onClick={resetState}
+                  >
+                    Change file
+                  </Text>
+                )}
               </VStack>
             )}
           </Box>
         </ModalBody>
         <ModalFooter>
           <HStack>
-            <Button colorScheme="gray" onClick={disclosure.onClose} minW={24}>
+            <Button
+              colorScheme="gray"
+              isDisabled={sendingInProgress}
+              onClick={disclosure.onClose}
+              minW={24}
+            >
               Cancel
             </Button>
             <Button


### PR DESCRIPTION
Change wording on downloading status text. Disable closing the upload modal while uploading is in progress.

Before:
<img width="367" alt="Screenshot 2023-09-07 at 10 45 02 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/3e5ab9bd-7518-4e7d-a0ee-224a3abb76a7">

After:
<img width="351" alt="Screenshot 2023-09-07 at 10 42 57 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/624ae627-ebad-4ab6-9211-454e91569f33">


Modal while sending before:
![Screenshot 2023-09-07 at 10 12 02 AM](https://github.com/OpenPipe/OpenPipe/assets/41524992/1c9e06b0-a34a-4de2-abe4-50cc2b1b940e)


Modal while sending after:
![Screenshot 2023-09-07 at 10 11 04 AM](https://github.com/OpenPipe/OpenPipe/assets/41524992/92e3d265-7307-404e-8a19-25e52f3ac5cf)
