### PR TITLE
Allow user to create dataset without any rows

### DIFF
--- a/app/src/components/datasets/NewDatasetButton.tsx
+++ b/app/src/components/datasets/NewDatasetButton.tsx
@@ -1,0 +1,39 @@
+import { HStack, Text, Button, Icon } from "@chakra-ui/react";
+import { BsPlus } from "react-icons/bs";
+import { useRouter } from "next/router";
+
+import { api } from "~/utils/api";
+import { useHandledAsyncCallback } from "~/utils/hooks";
+import { useAppStore } from "~/state/store";
+
+const NewDatasetButton = () => {
+  const router = useRouter();
+  const createDatasetMutation = api.datasets.create.useMutation();
+  const selectedProjectId = useAppStore((s) => s.selectedProjectId);
+  const utils = api.useContext();
+
+  const [createDataset, creationInProgress] = useHandledAsyncCallback(async () => {
+    if (!selectedProjectId) return;
+
+    const response = await createDatasetMutation.mutateAsync({
+      projectId: selectedProjectId,
+      name: "New Dataset",
+    });
+
+    const datasetId = response.payload;
+
+    await router.push({ pathname: "/datasets/[id]", query: { id: datasetId } });
+    await utils.datasets.list.invalidate();
+  }, [selectedProjectId, utils]);
+
+  return (
+    <Button colorScheme="blue" isLoading={creationInProgress} onClick={createDataset}>
+      <HStack spacing={0}>
+        <Icon as={BsPlus} boxSize={6} strokeWidth={0.8} />
+        <Text>New Dataset</Text>
+      </HStack>
+    </Button>
+  );
+};
+
+export default NewDatasetButton;

--- a/app/src/pages/datasets/index.tsx
+++ b/app/src/pages/datasets/index.tsx
@@ -1,14 +1,18 @@
-import { VStack, Text, Divider } from "@chakra-ui/react";
+import { VStack, HStack, Text, Divider } from "@chakra-ui/react";
 import AppShell from "~/components/nav/AppShell";
 import DatasetsTable from "~/components/datasets/DatasetsTable";
+import NewDatasetButton from "~/components/datasets/NewDatasetButton";
 
 export default function DatasetsPage() {
   return (
     <AppShell title="Datasets" requireAuth>
       <VStack w="full" py={8} px={8} spacing={4} alignItems="flex-start">
-        <Text fontSize="2xl" fontWeight="bold">
-          Datasets
-        </Text>
+        <HStack w="full" justifyContent="space-between">
+          <Text fontSize="2xl" fontWeight="bold">
+            Datasets
+          </Text>
+          <NewDatasetButton />
+        </HStack>
         <Divider />
         <DatasetsTable />
       </VStack>

--- a/app/src/server/api/routers/datasets.router.ts
+++ b/app/src/server/api/routers/datasets.router.ts
@@ -57,7 +57,7 @@ export const datasetsRouter = createTRPCRouter({
         },
       });
 
-      return success(dataset);
+      return success(dataset.id);
     }),
 
   update: protectedProcedure


### PR DESCRIPTION
Previously, datasets could only be created from request logs. This made it difficult for some of our customers to start and upload their own datasets, since not all of them are using our SDK. This change allows the user to create an empty dataset.

Before:
<img width="1531" alt="Screenshot 2023-09-12 at 2 49 36 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/0071786c-3934-4106-9b95-a0fbcb999e55">


After:
<img width="1531" alt="Screenshot 2023-09-12 at 2 48 53 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/9662d4a2-8b35-4c5c-b60a-e7a0f1b2bfb5">
