### PR TITLE
Add pruning rules

### DIFF
--- a/app/prisma/migrations/20230914232144_add_pruning_rule/migration.sql
+++ b/app/prisma/migrations/20230914232144_add_pruning_rule/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "PruningRule" (
+    "id" UUID NOT NULL,
+    "textToMatch" TEXT NOT NULL,
+    "tokensInText" INTEGER NOT NULL,
+    "datasetId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PruningRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PruningRuleMatch" (
+    "id" UUID NOT NULL,
+    "pruningRuleId" UUID NOT NULL,
+    "datasetEntryId" UUID NOT NULL,
+
+    CONSTRAINT "PruningRuleMatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PruningRule_datasetId_createdAt_id_idx" ON "PruningRule"("datasetId", "createdAt", "id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PruningRuleMatch_pruningRuleId_datasetEntryId_key" ON "PruningRuleMatch"("pruningRuleId", "datasetEntryId");
+
+-- AddForeignKey
+ALTER TABLE "PruningRule" ADD CONSTRAINT "PruningRule_datasetId_fkey" FOREIGN KEY ("datasetId") REFERENCES "Dataset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PruningRuleMatch" ADD CONSTRAINT "PruningRuleMatch_pruningRuleId_fkey" FOREIGN KEY ("pruningRuleId") REFERENCES "PruningRule"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PruningRuleMatch" ADD CONSTRAINT "PruningRuleMatch_datasetEntryId_fkey" FOREIGN KEY ("datasetEntryId") REFERENCES "DatasetEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -211,6 +211,7 @@ model Dataset {
     datasetEntries      DatasetEntry[]
     fineTunes           FineTune[]
     datasetFileUploads  DatasetFileUpload[]
+    pruningRules        PruningRule[]
     trainingRatio  Float @default(0.8)
 
     projectId String  @db.Uuid
@@ -235,7 +236,7 @@ model DatasetEntry {
     output       Json?
     inputTokens  Int
     outputTokens Int
-
+    matchedRules PruningRuleMatch[]
     type DatasetEntryType
 
     datasetId String   @db.Uuid
@@ -246,6 +247,32 @@ model DatasetEntry {
 
     @@index([datasetId, createdAt, id])
     @@index([datasetId, type])
+}
+
+model PruningRule {
+    id String @id @default(uuid()) @db.Uuid
+
+    textToMatch  String
+    tokensInText Int
+    matches      PruningRuleMatch[]
+
+    datasetId String  @db.Uuid
+    dataset   Dataset @relation(fields: [datasetId], references: [id], onDelete: Cascade)
+
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    @@index ([datasetId, createdAt, id])
+}
+
+model PruningRuleMatch {
+    id           String       @id @default(uuid()) @db.Uuid
+    pruningRuleId String      @db.Uuid
+    pruningRule   PruningRule @relation(fields: [pruningRuleId], references: [id], onDelete: Cascade)
+    datasetEntryId String     @db.Uuid
+    datasetEntry  DatasetEntry @relation(fields: [datasetEntryId], references: [id], onDelete: Cascade)
+
+    @@unique([pruningRuleId, datasetEntryId])
 }
 
 model Project {

--- a/app/src/components/datasets/DatasetConfigurationDrawer/DatasetConfigurationDrawer.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/DatasetConfigurationDrawer.tsx
@@ -31,12 +31,14 @@ export default function DatasetConfigurationDrawer({
           <Heading size="md">Dataset Settings</Heading>
         </DrawerHeader>
         <DrawerBody h="full" pb={4} bgColor="orange.50">
-          <VStack h="full" w="full" justifyContent="space-between">
-            <VStack w="full" alignItems="flex-start" spacing={16}>
+          <VStack minH="full" w="full" justifyContent="space-between">
+            <VStack w="full" alignItems="flex-start">
               <Text>
                 These settings will only affect the <b>{dataset?.name}</b> dataset.
               </Text>
-              <PruningRulesEditor />
+              <VStack w="full" alignItems="flex-start" py={16}>
+                <PruningRulesEditor />
+              </VStack>
             </VStack>
             <DeleteDatasetButton closeDrawer={disclosure.onClose} />
           </VStack>

--- a/app/src/components/datasets/DatasetConfigurationDrawer/DatasetConfigurationDrawer.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/DatasetConfigurationDrawer.tsx
@@ -7,28 +7,38 @@ import {
   DrawerOverlay,
   Heading,
   VStack,
+  Text,
   type UseDisclosureReturn,
 } from "@chakra-ui/react";
 
-import { DeleteButton } from "./DeleteButton";
+import { useDataset } from "~/utils/hooks";
+import { DeleteDatasetButton } from "./DeleteDatasetButton";
+import PruningRulesEditor from "./PruningRulesEditor";
 
 export default function DatasetConfigurationDrawer({
   disclosure,
 }: {
   disclosure: UseDisclosureReturn;
 }) {
+  const dataset = useDataset().data;
+
   return (
     <Drawer placement="right" size="md" {...disclosure}>
       <DrawerOverlay />
       <DrawerContent>
         <DrawerCloseButton />
-        <DrawerHeader>
-          <Heading size="md">Dataset Configuration</Heading>
+        <DrawerHeader bgColor="orange.50">
+          <Heading size="md">Dataset Settings</Heading>
         </DrawerHeader>
-        <DrawerBody h="full" pb={4}>
-          <VStack h="full" justifyContent="space-between">
-            <VStack spacing={6}></VStack>
-            <DeleteButton closeDrawer={disclosure.onClose} />
+        <DrawerBody h="full" pb={4} bgColor="orange.50">
+          <VStack h="full" w="full" justifyContent="space-between">
+            <VStack w="full" alignItems="flex-start" spacing={16}>
+              <Text>
+                These settings will only affect the <b>{dataset?.name}</b> dataset.
+              </Text>
+              <PruningRulesEditor />
+            </VStack>
+            <DeleteDatasetButton closeDrawer={disclosure.onClose} />
           </VStack>
         </DrawerBody>
       </DrawerContent>

--- a/app/src/components/datasets/DatasetConfigurationDrawer/DeleteDatasetButton.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/DeleteDatasetButton.tsx
@@ -5,7 +5,7 @@ import { BsTrash } from "react-icons/bs";
 import { useHandledAsyncCallback, useDataset } from "~/utils/hooks";
 import DeleteDatasetDialog from "./DeleteDatasetDialog";
 
-export const DeleteButton = ({ closeDrawer }: { closeDrawer: () => void }) => {
+export const DeleteDatasetButton = ({ closeDrawer }: { closeDrawer: () => void }) => {
   const dataset = useDataset();
   const router = useRouter();
 

--- a/app/src/components/datasets/DatasetConfigurationDrawer/DeletePruningRuleDialog.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/DeletePruningRuleDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 
 import { api, type RouterOutputs } from "~/utils/api";
-import { useHandledAsyncCallback } from "~/utils/hooks";
+import { useDataset, useHandledAsyncCallback } from "~/utils/hooks";
 
 const DeletePruningRuleDialog = ({
   rule,
@@ -20,6 +20,7 @@ const DeletePruningRuleDialog = ({
   rule: RouterOutputs["pruningRules"]["list"][0];
   disclosure: UseDisclosureReturn;
 }) => {
+  const dataset = useDataset().data;
   const cancelRef = useRef<HTMLButtonElement>(null);
 
   const mutation = api.pruningRules.delete.useMutation();
@@ -28,10 +29,12 @@ const DeletePruningRuleDialog = ({
   const [onDeleteConfirm, deletionInProgress] = useHandledAsyncCallback(async () => {
     if (!rule) return;
     await mutation.mutateAsync({ id: rule.id });
+
+    await utils.datasetEntries.list.invalidate({ datasetId: dataset?.id });
     await utils.pruningRules.list.invalidate();
 
     disclosure.onClose();
-  }, [mutation, rule, disclosure.onClose]);
+  }, [mutation, rule, disclosure.onClose, dataset?.id, utils]);
 
   return (
     <AlertDialog leastDestructiveRef={cancelRef} {...disclosure}>

--- a/app/src/components/datasets/DatasetConfigurationDrawer/DeletePruningRuleDialog.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/DeletePruningRuleDialog.tsx
@@ -9,44 +9,42 @@ import {
   AlertDialogFooter,
   Button,
 } from "@chakra-ui/react";
-import { api } from "~/utils/api";
 
+import { api, type RouterOutputs } from "~/utils/api";
 import { useHandledAsyncCallback } from "~/utils/hooks";
 
-const DeleteDatasetDialog = ({
-  datasetId,
-  onDelete,
+const DeletePruningRuleDialog = ({
+  rule,
   disclosure,
 }: {
-  datasetId?: string;
-  onDelete?: () => void;
+  rule: RouterOutputs["pruningRules"]["list"][0];
   disclosure: UseDisclosureReturn;
 }) => {
   const cancelRef = useRef<HTMLButtonElement>(null);
 
-  const mutation = api.datasets.delete.useMutation();
+  const mutation = api.pruningRules.delete.useMutation();
   const utils = api.useContext();
 
   const [onDeleteConfirm, deletionInProgress] = useHandledAsyncCallback(async () => {
-    if (!datasetId) return;
-    await mutation.mutateAsync({ id: datasetId });
-    await utils.datasets.list.invalidate();
-    onDelete?.();
+    if (!rule) return;
+    await mutation.mutateAsync({ id: rule.id });
+    await utils.pruningRules.list.invalidate();
 
     disclosure.onClose();
-  }, [mutation, datasetId, disclosure.onClose]);
+  }, [mutation, rule, disclosure.onClose]);
 
   return (
     <AlertDialog leastDestructiveRef={cancelRef} {...disclosure}>
       <AlertDialogOverlay>
         <AlertDialogContent>
           <AlertDialogHeader fontSize="lg" fontWeight="bold">
-            Delete Dataset
+            Delete Pruning Rule
           </AlertDialogHeader>
 
           <AlertDialogBody>
-            If you delete this dataset all the associated dataset entries will be deleted as well.
-            Are you sure?
+            Are you sure you want to delete the following pruning rule? It currently has{" "}
+            <b>{rule._count.matches}</b> matches and removes approximately{" "}
+            <b>{rule.tokensInText}</b> tokens from each matching dataset entry.
           </AlertDialogBody>
 
           <AlertDialogFooter>
@@ -68,4 +66,4 @@ const DeleteDatasetDialog = ({
   );
 };
 
-export default DeleteDatasetDialog;
+export default DeletePruningRuleDialog;

--- a/app/src/components/datasets/DatasetConfigurationDrawer/EditablePruningRule.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/EditablePruningRule.tsx
@@ -67,7 +67,12 @@ const EditablePruningRule = ({ index, rule }: { index: number; rule: PruningRule
           </HStack>
           {editedTextToMatch !== rule.textToMatch && (
             <HStack>
-              <Button onClick={() => setEditedTextToMatch(rule.textToMatch)}>Reset</Button>
+              <Button
+                isDisabled={updatingRule}
+                onClick={() => setEditedTextToMatch(rule.textToMatch)}
+              >
+                Reset
+              </Button>
               <Button colorScheme="orange" isLoading={updatingRule} onClick={updateRule}>
                 Save
               </Button>

--- a/app/src/components/datasets/DatasetConfigurationDrawer/EditablePruningRule.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/EditablePruningRule.tsx
@@ -31,6 +31,7 @@ const EditablePruningRule = ({ index, rule }: { index: number; rule: PruningRule
       },
     });
 
+    await utils.datasetEntries.list.invalidate({ datasetId: dataset?.id });
     await utils.pruningRules.list.invalidate({ datasetId: dataset?.id });
   }, [updateRuleMutation, editedTextToMatch, rule, utils, dataset?.id]);
 

--- a/app/src/components/datasets/DatasetConfigurationDrawer/EditablePruningRule.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/EditablePruningRule.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from "react";
+import { VStack, HStack, Text, Button, IconButton, Icon, useDisclosure } from "@chakra-ui/react";
+import { BsTrash } from "react-icons/bs";
+
+import { useDataset, useHandledAsyncCallback } from "~/utils/hooks";
+import { api, type RouterOutputs } from "~/utils/api";
+import AutoResizeTextArea from "~/components/AutoResizeTextArea";
+import DeletePruningRuleDialog from "./DeletePruningRuleDialog";
+
+type PruningRule = RouterOutputs["pruningRules"]["list"][0];
+
+const EditablePruningRule = ({ index, rule }: { index: number; rule: PruningRule }) => {
+  const dataset = useDataset().data;
+  const [editedTextToMatch, setEditedTextToMatch] = useState<string>(rule.textToMatch);
+  const deletePruningRuleDisclosure = useDisclosure();
+
+  useEffect(() => {
+    setEditedTextToMatch(rule.textToMatch);
+  }, [rule.textToMatch]);
+
+  const utils = api.useContext();
+
+  const updateRuleMutation = api.pruningRules.update.useMutation();
+  const [updateRule, updatingRule] = useHandledAsyncCallback(async () => {
+    if (!editedTextToMatch || editedTextToMatch === rule.textToMatch) return;
+
+    await updateRuleMutation.mutateAsync({
+      id: rule.id,
+      updates: {
+        textToMatch: editedTextToMatch,
+      },
+    });
+
+    await utils.pruningRules.list.invalidate({ datasetId: dataset?.id });
+  }, [updateRuleMutation, editedTextToMatch, rule, utils, dataset?.id]);
+
+  return (
+    <>
+      <VStack w="full">
+        <HStack w="full" justifyContent="space-between">
+          <HStack>
+            <Text as="i">Rule #{index + 1}</Text>
+          </HStack>
+          <IconButton
+            aria-label="Delete rule"
+            icon={<Icon as={BsTrash} />}
+            onClick={() => deletePruningRuleDisclosure.onOpen()}
+            variant="ghost"
+            colorScheme="red"
+          />
+        </HStack>
+        <AutoResizeTextArea
+          value={editedTextToMatch}
+          onChange={(e) => setEditedTextToMatch(e.target.value)}
+          placeholder="Enter text to prune..."
+          bgColor="white"
+        />
+
+        <HStack w="full" h={10} justifyContent="space-between">
+          <HStack>
+            <Text fontSize="xs" fontWeight="bold">
+              {rule.tokensInText} tokens
+            </Text>
+            <Text fontSize="xs" fontWeight="bold">
+              {rule._count.matches} matches
+            </Text>
+          </HStack>
+          {editedTextToMatch !== rule.textToMatch && (
+            <HStack>
+              <Button onClick={() => setEditedTextToMatch(rule.textToMatch)}>Reset</Button>
+              <Button colorScheme="orange" isLoading={updatingRule} onClick={updateRule}>
+                Save
+              </Button>
+            </HStack>
+          )}
+        </HStack>
+      </VStack>
+      <DeletePruningRuleDialog rule={rule} disclosure={deletePruningRuleDisclosure} />
+    </>
+  );
+};
+
+export default EditablePruningRule;

--- a/app/src/components/datasets/DatasetConfigurationDrawer/PruningRuleCreator.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/PruningRuleCreator.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { VStack, HStack, Text, Button } from "@chakra-ui/react";
+
+import { api } from "~/utils/api";
+import { useHandledAsyncCallback, useDataset } from "~/utils/hooks";
+import AutoResizeTextArea from "~/components/AutoResizeTextArea";
+
+const PruningRuleCreator = ({ index }: { index: number }) => {
+  const dataset = useDataset().data;
+  const [showEditor, setShowEditor] = useState<boolean>(false);
+  const [editedTextToMatch, setEditedTextToMatch] = useState<string>("");
+
+  const utils = api.useContext();
+
+  const createRuleMutation = api.pruningRules.create.useMutation();
+  const [createRule, creatingRule] = useHandledAsyncCallback(async () => {
+    if (!dataset?.id) return;
+
+    await createRuleMutation.mutateAsync({
+      datasetId: dataset.id,
+      textToMatch: editedTextToMatch,
+    });
+
+    await utils.pruningRules.list.invalidate({ datasetId: dataset.id });
+    setShowEditor(false);
+  }, [createRuleMutation, editedTextToMatch, dataset?.id, utils]);
+
+  if (!showEditor) {
+    return (
+      <Button variant="outline" colorScheme="orange" w="full" onClick={() => setShowEditor(true)}>
+        Add New Rule
+      </Button>
+    );
+  }
+
+  return (
+    <VStack w="full">
+      <HStack w="full">
+        <Text as="i">Rule #{index + 1}</Text>
+      </HStack>
+      <AutoResizeTextArea
+        value={editedTextToMatch}
+        onChange={(e) => setEditedTextToMatch(e.target.value)}
+        placeholder="Enter text to prune..."
+        bgColor="white"
+      />
+      <HStack w="full" justifyContent="flex-end">
+        <Button onClick={() => setShowEditor(false)}>Cancel</Button>
+        <Button
+          isDisabled={!editedTextToMatch}
+          isLoading={creatingRule}
+          onClick={createRule}
+          colorScheme="orange"
+        >
+          Save
+        </Button>
+      </HStack>
+    </VStack>
+  );
+};
+
+export default PruningRuleCreator;

--- a/app/src/components/datasets/DatasetConfigurationDrawer/PruningRuleCreator.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/PruningRuleCreator.tsx
@@ -21,6 +21,7 @@ const PruningRuleCreator = ({ index }: { index: number }) => {
       textToMatch: editedTextToMatch,
     });
 
+    await utils.datasetEntries.list.invalidate({ datasetId: dataset?.id });
     await utils.pruningRules.list.invalidate({ datasetId: dataset.id });
     setShowEditor(false);
   }, [createRuleMutation, editedTextToMatch, dataset?.id, utils]);

--- a/app/src/components/datasets/DatasetConfigurationDrawer/PruningRulesEditor.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/PruningRulesEditor.tsx
@@ -1,0 +1,31 @@
+import { Divider, Heading, VStack, Text } from "@chakra-ui/react";
+
+import { usePruningRules } from "~/utils/hooks";
+import EditablePruningRule from "./EditablePruningRule";
+import PruningRuleCreator from "./PruningRuleCreator";
+
+const PruningRulesEditor = () => {
+  const pruningRules = usePruningRules().data;
+
+  return (
+    <VStack w="full" alignItems="flex-start">
+      <Heading size="md">Pruning Rules</Heading>{" "}
+      <Text pb={2}>
+        Use pruning rules to remove system messages and other redundant text from your prompt to
+        save on tokens. Text will be removed from your prompts sequentially, so make sure to order
+        your rules accordingly.
+      </Text>
+      <Divider w="full" />
+      {pruningRules &&
+        pruningRules.map((rule, index) => (
+          <>
+            <EditablePruningRule key={rule.id} index={index} rule={rule} />
+            <Divider key={`divider-${rule.id}`} w="full" />
+          </>
+        ))}
+      <PruningRuleCreator index={pruningRules?.length ?? 1} />
+    </VStack>
+  );
+};
+
+export default PruningRulesEditor;

--- a/app/src/components/datasets/DatasetEntriesTable/DatasetEntryEditorDrawer.tsx
+++ b/app/src/components/datasets/DatasetEntriesTable/DatasetEntryEditorDrawer.tsx
@@ -121,6 +121,7 @@ export default function DatasetDentryEditorDrawer({
                           newInputMessages.splice(i, 1);
                           setInputMessagesToSave(newInputMessages);
                         }}
+                        ruleMatches={datasetEntry?.matchedRules}
                       />
                     </>
                   );

--- a/app/src/components/datasets/DatasetEntriesTable/EditableMessage.tsx
+++ b/app/src/components/datasets/DatasetEntriesTable/EditableMessage.tsx
@@ -141,7 +141,7 @@ const EditableMessage = ({
           bgColor="white"
         />
       )}
-      {!isOutput && stringifiedMessageContent !== prunedMessageContent && (
+      {!isOutput && savedTokens && (
         <VStack w="full" alignItems="flex-start">
           <Button variant="unstyled" color="blue.600" onClick={() => setShowDiff(!showDiff)}>
             <HStack>
@@ -162,9 +162,7 @@ const EditableMessage = ({
                 newValue={prunedMessageContent}
                 splitView={false}
                 hideLineNumbers
-                disableWordDiff={true}
                 compareMethod={DiffMethod.CHARS}
-                // renderContent={highlightSyntax}
                 showDiffOnly={false}
               />
             </Box>

--- a/app/src/components/datasets/DatasetHeaderButtons.tsx
+++ b/app/src/components/datasets/DatasetHeaderButtons.tsx
@@ -12,7 +12,7 @@ export const DatasetHeaderButtons = ({ openDrawer }: { openDrawer: () => void })
       <Button variant={{ base: "solid", md: "ghost" }} onClick={openDrawer}>
         <HStack>
           <Icon as={BsGearFill} />
-          <Text>Configure</Text>
+          <Text>Settings</Text>
         </HStack>
       </Button>
     </HStack>

--- a/app/src/modelProviders/fine-tuned/getCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.ts
@@ -9,7 +9,7 @@ import {
 } from "openai/resources/chat";
 
 import { type CompletionResponse } from "../types";
-import { countLlamaChatTokens } from "~/utils/countTokens";
+import { countLlamaChatTokensInMessages } from "~/utils/countTokens";
 
 const ENABLE_STREAMING = false;
 
@@ -108,8 +108,8 @@ export async function getCompletion(
       };
     }
 
-    const promptTokens = countLlamaChatTokens(messages);
-    const completionTokens = countLlamaChatTokens([
+    const promptTokens = countLlamaChatTokensInMessages(messages);
+    const completionTokens = countLlamaChatTokensInMessages([
       parsedCompletion as ChatCompletion.Choice.Message,
     ]);
 

--- a/app/src/server/api/root.router.ts
+++ b/app/src/server/api/root.router.ts
@@ -11,6 +11,7 @@ import { dashboardRouter } from "./routers/dashboard.router";
 import { loggedCallsRouter } from "./routers/loggedCalls.router";
 import { datasetsRouter } from "./routers/datasets.router";
 import { datasetEntriesRouter } from "./routers/datasetEntries.router";
+import { pruningRulesRouter } from "./routers/pruningRules.router";
 import { fineTunesRouter } from "./routers/fineTunes.router";
 import { usersRouter } from "./routers/users.router";
 import { adminJobsRouter } from "./routers/adminJobs.router";
@@ -33,6 +34,7 @@ export const appRouter = createTRPCRouter({
   loggedCalls: loggedCallsRouter,
   datasets: datasetsRouter,
   datasetEntries: datasetEntriesRouter,
+  pruningRules: pruningRulesRouter,
   fineTunes: fineTunesRouter,
   users: usersRouter,
   adminJobs: adminJobsRouter,

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -91,6 +91,16 @@ export const datasetEntriesRouter = createTRPCRouter({
       where: { id: input.id },
       include: {
         dataset: true,
+        matchedRules: {
+          select: {
+            pruningRule: {
+              select: {
+                textToMatch: true,
+                tokensInText: true,
+              },
+            },
+          },
+        },
       },
     });
 

--- a/app/src/server/api/routers/pruningRules.router.ts
+++ b/app/src/server/api/routers/pruningRules.router.ts
@@ -1,0 +1,95 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { prisma } from "~/server/db";
+import { updatePruningRuleMatches } from "~/server/utils/updatePruningRuleMatches";
+import {
+  requireCanModifyProject,
+  requireCanViewProject,
+  requireCanModifyPruningRule,
+} from "~/utils/accessControl";
+import { countLlamaChatTokens } from "~/utils/countTokens";
+
+export const pruningRulesRouter = createTRPCRouter({
+  list: protectedProcedure
+    .input(z.object({ datasetId: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const dataset = await prisma.dataset.findUnique({
+        where: {
+          id: input.datasetId,
+        },
+        include: {
+          pruningRules: {
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            select: {
+              id: true,
+              textToMatch: true,
+              tokensInText: true,
+              _count: {
+                select: {
+                  matches: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      if (!dataset) throw new TRPCError({ code: "NOT_FOUND" });
+      const { projectId, pruningRules } = dataset;
+      await requireCanViewProject(projectId, ctx);
+
+      return pruningRules;
+    }),
+  update: protectedProcedure
+    .input(z.object({ id: z.string(), updates: z.object({ textToMatch: z.string() }) }))
+    .mutation(async ({ input, ctx }) => {
+      await requireCanModifyPruningRule(input.id, ctx);
+
+      const { datasetId, createdAt } = await prisma.pruningRule.update({
+        where: {
+          id: input.id,
+        },
+        data: {
+          textToMatch: input.updates.textToMatch,
+          tokensInText: countLlamaChatTokens(input.updates.textToMatch),
+        },
+      });
+
+      await updatePruningRuleMatches(datasetId, createdAt);
+    }),
+  create: protectedProcedure
+    .input(z.object({ datasetId: z.string(), textToMatch: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      const dataset = await prisma.dataset.findUnique({
+        where: {
+          id: input.datasetId,
+        },
+      });
+      if (!dataset) throw new TRPCError({ code: "NOT_FOUND" });
+      await requireCanModifyProject(dataset.projectId, ctx);
+
+      const { datasetId, createdAt } = await prisma.pruningRule.create({
+        data: {
+          textToMatch: input.textToMatch,
+          tokensInText: countLlamaChatTokens(input.textToMatch),
+          datasetId: input.datasetId,
+        },
+      });
+
+      await updatePruningRuleMatches(datasetId, createdAt);
+    }),
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      await requireCanModifyPruningRule(input.id, ctx);
+
+      const { datasetId, createdAt } = await prisma.pruningRule.delete({
+        where: {
+          id: input.id,
+        },
+      });
+
+      await updatePruningRuleMatches(datasetId, createdAt);
+    }),
+});

--- a/app/src/server/db.types.ts
+++ b/app/src/server/db.types.ts
@@ -117,7 +117,9 @@ export interface FineTune {
   id: string;
   slug: string;
   baseModel: string;
-  status: Generated<"AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING">;
+  status: Generated<
+    "AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING"
+  >;
   trainingStartedAt: Timestamp | null;
   trainingFinishedAt: Timestamp | null;
   deploymentStartedAt: Timestamp | null;

--- a/app/src/server/db.types.ts
+++ b/app/src/server/db.types.ts
@@ -18,8 +18,6 @@ export type JsonPrimitive = boolean | null | number | string;
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
-export type Numeric = ColumnType<string, string | number, string | number>;
-
 export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
 export interface _PrismaMigrations {
@@ -64,13 +62,33 @@ export interface Dataset {
   projectId: string;
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
+  trainingRatio: Generated<number>;
 }
 
 export interface DatasetEntry {
   id: string;
-  input: string;
-  output: string | null;
   datasetId: string;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Timestamp;
+  loggedCallId: string | null;
+  input: Generated<Json>;
+  inputTokens: number;
+  output: Json | null;
+  outputTokens: number;
+  type: "TEST" | "TRAIN";
+}
+
+export interface DatasetFileUpload {
+  id: string;
+  datasetId: string;
+  blobName: string;
+  fileName: string;
+  fileSize: number;
+  progress: Generated<number>;
+  status: Generated<"COMPLETE" | "DOWNLOADING" | "ERROR" | "PENDING" | "PROCESSING" | "SAVING">;
+  uploadedAt: Timestamp;
+  visible: Generated<boolean>;
+  errorMessage: string | null;
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
 }
@@ -92,6 +110,23 @@ export interface Experiment {
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
   projectId: string;
+  slug: Generated<string>;
+}
+
+export interface FineTune {
+  id: string;
+  slug: string;
+  baseModel: string;
+  status: Generated<"AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING">;
+  trainingStartedAt: Timestamp | null;
+  trainingFinishedAt: Timestamp | null;
+  deploymentStartedAt: Timestamp | null;
+  deploymentFinishedAt: Timestamp | null;
+  datasetId: string;
+  projectId: string;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Timestamp;
+  inferenceUrl: string | null;
 }
 
 export interface GraphileWorkerJobQueues {
@@ -156,7 +191,7 @@ export interface LoggedCallModelResponse {
   outputTokens: number | null;
   finishReason: string | null;
   completionId: string | null;
-  cost: Numeric | null;
+  cost: number | null;
   originalLoggedCallId: string;
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
@@ -228,6 +263,21 @@ export interface PromptVariant {
   model: string;
   promptConstructorVersion: number;
   modelProvider: string;
+}
+
+export interface PruningRule {
+  id: string;
+  textToMatch: string;
+  tokensInText: number;
+  datasetId: string;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Timestamp;
+}
+
+export interface PruningRuleMatch {
+  id: string;
+  pruningRuleId: string;
+  datasetEntryId: string;
 }
 
 export interface ScenarioVariantCell {
@@ -311,8 +361,10 @@ export interface DB {
   ApiKey: ApiKey;
   Dataset: Dataset;
   DatasetEntry: DatasetEntry;
+  DatasetFileUpload: DatasetFileUpload;
   Evaluation: Evaluation;
   Experiment: Experiment;
+  FineTune: FineTune;
   "graphile_worker.job_queues": GraphileWorkerJobQueues;
   "graphile_worker.jobs": GraphileWorkerJobs;
   "graphile_worker.known_crontabs": GraphileWorkerKnownCrontabs;
@@ -325,6 +377,8 @@ export interface DB {
   Project: Project;
   ProjectUser: ProjectUser;
   PromptVariant: PromptVariant;
+  PruningRule: PruningRule;
+  PruningRuleMatch: PruningRuleMatch;
   ScenarioVariantCell: ScenarioVariantCell;
   Session: Session;
   TemplateVariable: TemplateVariable;

--- a/app/src/server/tasks/importDatasetEntries.task.ts
+++ b/app/src/server/tasks/importDatasetEntries.task.ts
@@ -8,6 +8,7 @@ import {
   parseJSONL,
 } from "~/components/datasets/validateTrainingRows";
 import { formatEntriesFromTrainingRows } from "~/server/utils/createEntriesFromTrainingRows";
+import { updatePruningRuleMatches } from "../utils/updatePruningRuleMatches";
 
 export type ImportDatasetEntriesJob = {
   datasetFileUploadId: string;
@@ -123,6 +124,12 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>(
     await prisma.datasetEntry.createMany({
       data: datasetEntriesToCreate,
     });
+
+    await updatePruningRuleMatches(
+      datasetFileUpload.datasetId,
+      new Date(0),
+      datasetEntriesToCreate.map((entry) => entry.id),
+    );
 
     await prisma.datasetFileUpload.update({
       where: { id: datasetFileUploadId },

--- a/app/src/server/utils/createEntriesFromTrainingRows.ts
+++ b/app/src/server/utils/createEntriesFromTrainingRows.ts
@@ -7,7 +7,7 @@ import {
 
 import { prisma } from "~/server/db";
 import { type TrainingRow } from "~/components/datasets/validateTrainingRows";
-import { countLlamaChatTokens } from "~/utils/countTokens";
+import { countLlamaChatTokensInMessages } from "~/utils/countTokens";
 
 export const formatEntriesFromTrainingRows = async (
   datasetId: string,
@@ -47,7 +47,9 @@ export const formatEntriesFromTrainingRows = async (
     if (updateCallback && i % updateFrequency === 0) await updateCallback(i);
     let outputTokens = 0;
     if (row.output) {
-      outputTokens = countLlamaChatTokens([row.output as unknown as ChatCompletion.Choice.Message]);
+      outputTokens = countLlamaChatTokensInMessages([
+        row.output as unknown as ChatCompletion.Choice.Message,
+      ]);
     }
     // console.log("outputTokens", outputTokens);
     datasetEntriesToCreate.push({
@@ -57,7 +59,7 @@ export const formatEntriesFromTrainingRows = async (
         role: "assistant",
         content: "",
       },
-      inputTokens: countLlamaChatTokens(
+      inputTokens: countLlamaChatTokensInMessages(
         row.input as unknown as CreateChatCompletionRequestMessage[],
       ),
       outputTokens,

--- a/app/src/server/utils/createEntriesFromTrainingRows.ts
+++ b/app/src/server/utils/createEntriesFromTrainingRows.ts
@@ -4,10 +4,13 @@ import {
   type CreateChatCompletionRequestMessage,
   type ChatCompletion,
 } from "openai/resources/chat";
+import { v4 as uuidv4 } from "uuid";
 
 import { prisma } from "~/server/db";
 import { type TrainingRow } from "~/components/datasets/validateTrainingRows";
 import { countLlamaChatTokensInMessages } from "~/utils/countTokens";
+
+type CreateManyInput = Omit<Prisma.DatasetEntryCreateManyInput, "id"> & { id: string };
 
 export const formatEntriesFromTrainingRows = async (
   datasetId: string,
@@ -40,7 +43,7 @@ export const formatEntriesFromTrainingRows = async (
     ...Array(numTrainingToAdd).fill("TRAIN"),
     ...Array(numTestingToAdd).fill("TEST"),
   ]);
-  const datasetEntriesToCreate: Prisma.DatasetEntryCreateManyInput[] = [];
+  const datasetEntriesToCreate: CreateManyInput[] = [];
   let i = 0;
   for (const row of trainingRows) {
     // console.log(row);
@@ -53,6 +56,7 @@ export const formatEntriesFromTrainingRows = async (
     }
     // console.log("outputTokens", outputTokens);
     datasetEntriesToCreate.push({
+      id: uuidv4(),
       datasetId: datasetId,
       input: row.input as unknown as Prisma.InputJsonValue,
       output: (row.output as unknown as Prisma.InputJsonValue) ?? {

--- a/app/src/server/utils/updatePruningRuleMatches.test.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.test.ts
@@ -1,0 +1,123 @@
+import { expect, it } from "vitest";
+import { type Prisma } from "@prisma/client";
+import { type CreateChatCompletionRequestMessage } from "openai/resources/chat";
+import { v4 as uuidv4 } from "uuid";
+
+import { prisma } from "~/server/db";
+import { updatePruningRuleMatches } from "./updatePruningRuleMatches";
+
+const input1: CreateChatCompletionRequestMessage[] = [
+  {
+    role: "system",
+    content:
+      "The user is testing multiple scenarios against the same prompt. Attempt to generate a new scenario that is different from the others.",
+  },
+  {
+    role: "user",
+    content:
+      'Prompt constructor function:\n---\n/**\n * Use Javascript to define an OpenAI chat completion\n * (https://platform.openai.com/docs/api-reference/chat/create).\n *\n * You have access to the current scenario in the `scenario`\n * variable.\n */\n\ndefinePrompt("openai/ChatCompletion", {\n  model: "gpt-3.5-turbo-0613",\n  messages: [\n    {\n      role: "system",\n      content: `Write \'Start experimenting!\' in ${scenario.language}`,\n    },\n  ],\n});',
+  },
+  {
+    role: "assistant",
+    content: null,
+    function_call: { name: "add_scenario", arguments: '{"language":"English"}' },
+  },
+  {
+    role: "assistant",
+    content: null,
+    function_call: { name: "add_scenario", arguments: '{"language":"Spanish"}' },
+  },
+  {
+    role: "assistant",
+    content: null,
+    function_call: { name: "add_scenario", arguments: '{"language":"German"}' },
+  },
+];
+
+const createProject = async (datasetId: string) => {
+  return await prisma.project.create({
+    data: {
+      id: uuidv4(),
+      name: "test",
+      datasets: {
+        create: [
+          {
+            id: datasetId,
+            name: "test",
+          },
+        ],
+      },
+    },
+  });
+};
+
+const createDatasetEntry = async (
+  datasetId: string,
+  input: CreateChatCompletionRequestMessage[],
+) => {
+  return await prisma.datasetEntry.create({
+    data: {
+      input: input as unknown as Prisma.InputJsonValue,
+      output: {},
+      inputTokens: 0,
+      outputTokens: 0,
+      datasetId,
+      type: "TRAIN",
+    },
+  });
+};
+
+const createPruningRule = async (datasetId: string, textToMatch: string) => {
+  return await prisma.pruningRule.create({
+    data: {
+      datasetId,
+      textToMatch,
+      tokensInText: 0,
+    },
+  });
+};
+
+it("matches basic string", async () => {
+  const datasetId = uuidv4();
+  await createProject(datasetId);
+  // Create experiments concurrently
+  const [_, rule] = await Promise.all([
+    createDatasetEntry(datasetId, input1),
+    createPruningRule(datasetId, "The user is testing multiple scenarios against the same prompt"),
+  ]);
+
+  await updatePruningRuleMatches(datasetId, new Date(0));
+
+  // Make sure there are a total of 4 scenarios for exp2
+  expect(
+    await prisma.pruningRuleMatch.count({
+      where: {
+        pruningRuleId: rule.id,
+      },
+    }),
+  ).toBe(1);
+});
+
+it("matches string with newline", async () => {
+  const datasetId = uuidv4();
+  await createProject(datasetId);
+  // Create experiments concurrently
+  const [_, rule] = await Promise.all([
+    createDatasetEntry(datasetId, input1),
+    createPruningRule(
+      datasetId,
+      "Prompt constructor function:\n---\n/**\n * Use Javascript to define an OpenAI chat completion\n * (https://platform.openai.com/docs/api-reference/chat/create).\n *",
+    ),
+  ]);
+
+  await updatePruningRuleMatches(datasetId, new Date(0));
+
+  // Make sure there are a total of 4 scenarios for exp2
+  expect(
+    await prisma.pruningRuleMatch.count({
+      where: {
+        pruningRuleId: rule.id,
+      },
+    }),
+  ).toBe(1);
+});

--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -1,0 +1,57 @@
+import { sql, type RawBuilder } from "kysely";
+
+import { prisma, kysely } from "~/server/db";
+
+export const updatePruningRuleMatches = async (datasetId: string, createdAtCutoff: Date) => {
+  const allPruningRules = await prisma.pruningRule.findMany({
+    where: {
+      datasetId,
+    },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+
+  const pruningRulesToUpdate = allPruningRules.filter((pr) => pr.createdAt >= createdAtCutoff);
+  const numOmittedRules = allPruningRules.length - pruningRulesToUpdate.length;
+
+  await prisma.pruningRuleMatch.deleteMany({
+    where: {
+      pruningRuleId: {
+        in: pruningRulesToUpdate.map((pr) => pr.id),
+      },
+    },
+  });
+
+  for (let i = numOmittedRules; i < allPruningRules.length; i++) {
+    let prunedInput: RawBuilder<string> = sql`CAST("DatasetEntry"."input" AS TEXT)`;
+
+    // For each rule to update, find all the dataset entries with matching prompts, after previous rules have been applied
+    for (let j = 0; j < i; j++) {
+      prunedInput = sql`REPLACE(${prunedInput}, ${allPruningRules[j]?.textToMatch}, '')`;
+    }
+
+    console.log("rule number", i, "prunedInput", prunedInput);
+
+    const ruleTextToMatch = allPruningRules[i]?.textToMatch ?? "";
+
+    // Insert PruningRuleMatch entries based on a select statement
+    await kysely
+      .insertInto("PruningRuleMatch")
+      .columns(["id", "pruningRuleId", "datasetEntryId"])
+      .expression((eb) =>
+        eb
+          .selectFrom("DatasetEntry")
+          .where((eb) =>
+            eb.and([
+              eb(`DatasetEntry.datasetId`, "=", datasetId),
+              sql`${prunedInput} LIKE ${"%" + ruleTextToMatch + "%"}`,
+            ]),
+          )
+          .select(() => [
+            sql`uuid_generate_v4()`.as("id"),
+            sql`${allPruningRules[i]?.id}`.as("pruningRuleId"),
+            "DatasetEntry.id as datasetEntryId",
+          ]),
+      )
+      .execute();
+  }
+};

--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -26,12 +26,12 @@ export const updatePruningRuleMatches = async (datasetId: string, createdAtCutof
 
     // For each rule to update, find all the dataset entries with matching prompts, after previous rules have been applied
     for (let j = 0; j < i; j++) {
-      prunedInput = sql`REPLACE(${prunedInput}, ${allPruningRules[j]?.textToMatch}, '')`;
+      prunedInput = sql`REPLACE(${prunedInput}, ${escapeReplaceString(
+        allPruningRules[j]?.textToMatch,
+      )}, '')`;
     }
 
-    console.log("rule number", i, "prunedInput", prunedInput);
-
-    const ruleTextToMatch = allPruningRules[i]?.textToMatch ?? "";
+    const ruleTextToMatch = escapeLikeString(allPruningRules[i]?.textToMatch);
 
     // Insert PruningRuleMatch entries based on a select statement
     await kysely
@@ -55,3 +55,11 @@ export const updatePruningRuleMatches = async (datasetId: string, createdAtCutof
       .execute();
   }
 };
+
+function escapeReplaceString(input: string | undefined) {
+  return (input || "").replaceAll("\\", "\\").replaceAll("\n", "\\n").replaceAll('"', '\\"');
+}
+
+function escapeLikeString(input: string | undefined) {
+  return (input || "").replaceAll("\\", "\\\\").replaceAll("\n", "\\\\n").replaceAll('"', '\\\\"');
+}

--- a/app/src/utils/countTokens.ts
+++ b/app/src/utils/countTokens.ts
@@ -25,10 +25,14 @@ export const countOpenAIChatTokens = (
   }).usedTokens;
 };
 
-export const countLlamaChatTokens = (messages: ChatCompletion.Choice.Message[]) => {
+export const countLlamaChatTokensInMessages = (messages: ChatCompletion.Choice.Message[]) => {
   const stringToTokenize = messages
     .map((message) => message.content || JSON.stringify(message.function_call))
     .join("\n");
+  return countLlamaChatTokens(stringToTokenize);
+};
+
+export const countLlamaChatTokens = (stringToTokenize: string) => {
   const tokens = llamaTokenizer.encode(stringToTokenize);
   return tokens.length;
 };

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -231,6 +231,15 @@ export const useFineTunes = () => {
   );
 };
 
+export const usePruningRules = () => {
+  const selectedDataset = useDataset().data;
+
+  return api.pruningRules.list.useQuery(
+    { datasetId: selectedDataset?.id ?? "" },
+    { enabled: !!selectedDataset?.id },
+  );
+};
+
 export const useIsClientRehydrated = () => {
   const isRehydrated = useAppStore((state) => state.isRehydrated);
   const [isMounted, setIsMounted] = useState(false);


### PR DESCRIPTION
Users can now remove chunks of text from their dataset inputs, saving them tokens when training and getting inference.

## Changes
* Add `PruningRule` and `PruningRuleMatch` models
* Add UI for creating pruning rules
* Calculate matches every time a pruning rule is created
* Add UI to view difference in prompt messages before/after pruning rules

Pruning Rules:
<img width="1340" alt="Screenshot 2023-09-15 at 2 54 22 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/c1d0f1ab-7aa2-491c-9114-854385136b5e">

Pruned Message Diff:
<img width="1340" alt="Screenshot 2023-09-15 at 2 55 05 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/8459894b-e259-4d1a-8898-f4b167f7240d">
