### PR TITLE
Prune text from prompts on the fly

### DIFF
--- a/app/src/components/datasets/DatasetConfigurationDrawer/PruningRuleCreator.tsx
+++ b/app/src/components/datasets/DatasetConfigurationDrawer/PruningRuleCreator.tsx
@@ -28,7 +28,13 @@ const PruningRuleCreator = ({ index }: { index: number }) => {
 
   if (!showEditor) {
     return (
-      <Button variant="outline" colorScheme="orange" w="full" onClick={() => setShowEditor(true)}>
+      <Button
+        variant="outline"
+        color="gray.500"
+        _hover={{ bgColor: "orange.100" }}
+        w="full"
+        onClick={() => setShowEditor(true)}
+      >
         Add New Rule
       </Button>
     );

--- a/app/src/components/datasets/FineTuneButton.tsx
+++ b/app/src/components/datasets/FineTuneButton.tsx
@@ -15,6 +15,8 @@ import {
   useDisclosure,
   type UseDisclosureReturn,
   Input,
+  InputGroup,
+  InputLeftAddon,
 } from "@chakra-ui/react";
 import { AiTwotoneThunderbolt } from "react-icons/ai";
 import humanId from "human-id";
@@ -105,19 +107,21 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
                 <Text fontWeight="bold" w={36}>
                   Model ID:
                 </Text>
-                <Input
-                  value={modelSlug}
-                  onChange={(e) => setModelSlug(e.target.value)}
-                  w={48}
-                  placeholder="unique-id"
-                  onKeyDown={(e) => {
-                    // If the user types anything other than a-z, A-Z, or 0-9, replace it with -
-                    if (!/[a-zA-Z0-9]/.test(e.key)) {
-                      e.preventDefault();
-                      setModelSlug((s) => s && `${s}-`);
-                    }
-                  }}
-                />
+                <InputGroup w={72}>
+                  <InputLeftAddon px={2}>openpipe:</InputLeftAddon>
+                  <Input
+                    value={modelSlug}
+                    onChange={(e) => setModelSlug(e.target.value)}
+                    placeholder="unique-id"
+                    onKeyDown={(e) => {
+                      // If the user types anything other than a-z, A-Z, or 0-9, replace it with -
+                      if (!/[a-zA-Z0-9]/.test(e.key)) {
+                        e.preventDefault();
+                        setModelSlug((s) => s && `${s}-`);
+                      }
+                    }}
+                  />
+                </InputGroup>
               </HStack>
               <HStack spacing={2}>
                 <Text fontWeight="bold" w={36}>
@@ -127,7 +131,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
                   options={SUPPORTED_BASE_MODELS}
                   selectedOption={selectedBaseModel}
                   onSelect={(option) => setSelectedBaseModel(option)}
-                  inputGroupProps={{ w: 48 }}
+                  inputGroupProps={{ w: 72 }}
                 />
               </HStack>
             </VStack>

--- a/app/src/components/fineTunes/FineTunesTable.tsx
+++ b/app/src/components/fineTunes/FineTunesTable.tsx
@@ -27,7 +27,7 @@ const FineTunesTable = ({}) => {
             {fineTunes.map((fineTune) => {
               return (
                 <Tr key={fineTune.id}>
-                  <Td>{fineTune.slug}</Td>
+                  <Td>openpipe:{fineTune.slug}</Td>
                   <Td>{dayjs(fineTune.createdAt).format("MMMM D h:mm A")}</Td>
                   <Td>{fineTune.baseModel}</Td>
                   <Td>{fineTune.dataset._count.datasetEntries}</Td>

--- a/app/src/modelProviders/fine-tuned/getCompletion.test.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.test.ts
@@ -1,7 +1,8 @@
 import "dotenv/config";
-import { it } from "vitest";
-import { getCompletion } from "./getCompletion";
+import { it, expect } from "vitest";
+import { getCompletion, templatePrompt } from "./getCompletion";
 import { type CompletionCreateParams } from "openai/resources/chat";
+import { escapeString } from "~/utils/pruningRules";
 
 it("gets a reasonable completion", async () => {
   const endpoint = process.env.GET_COMPLETION_TEST_ENDPOINT;
@@ -22,4 +23,28 @@ it("gets a reasonable completion", async () => {
 
   const completion = await getCompletion(inputData, endpoint, []);
   console.log(completion.choices[0]?.message?.content);
+});
+
+it("correctly templates the prompt", () => {
+  const input: CompletionCreateParams = {
+    model: "test-model",
+    messages: [
+      {
+        role: "user",
+        content:
+          'Prompt constructor function:\n---\n/**\n * Use Javascript to define an OpenAI chat completion\n * (https://platform.openai.com/docs/api-reference/chat/create).\n *\n * You have access to the current scenario in the `scenario`\n * variable.\n */\n\ndefinePrompt("openai/ChatCompletion", {\n  model: "gpt-3.5-turbo-0613",\n  messages: [\n    {\n      role: "system",\n      content: `Write \'Start experimenting!\' in ${scenario.language}`,\n    },\n  ],\n});',
+      },
+    ],
+  };
+
+  const stringsToPrune = [
+    "Prompt constructor function:\n---\n/**\n * Use Javascript to define an OpenAI chat completion\n *",
+  ];
+
+  if (stringsToPrune[0])
+    console.log(JSON.stringify(input.messages).includes(escapeString(stringsToPrune[0])));
+
+  const templatedPrompt = templatePrompt(input, stringsToPrune);
+  console.log(templatedPrompt);
+  expect(templatedPrompt.includes("Prompt constructor function")).toBe(false);
 });

--- a/app/src/modelProviders/fine-tuned/getCompletion.test.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.test.ts
@@ -20,6 +20,6 @@ it("gets a reasonable completion", async () => {
     ],
   };
 
-  const completion = await getCompletion(inputData, endpoint);
+  const completion = await getCompletion(inputData, endpoint, []);
   console.log(completion.choices[0]?.message?.content);
 });

--- a/app/src/modelProviders/fine-tuned/getCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.ts
@@ -3,6 +3,7 @@ import { type ChatCompletion, type CompletionCreateParams } from "openai/resourc
 import { v4 as uuidv4 } from "uuid";
 
 import { countLlamaChatTokensInMessages } from "~/utils/countTokens";
+import { escapeString } from "~/utils/pruningRules";
 
 export async function getCompletion(
   input: CompletionCreateParams,
@@ -81,12 +82,12 @@ export async function getCompletion(
   };
 }
 
-const templatePrompt = (input: CompletionCreateParams, stringsToPrune: string[]) => {
+export const templatePrompt = (input: CompletionCreateParams, stringsToPrune: string[]) => {
   const { messages } = input;
 
   let stringifedMessages = JSON.stringify(messages);
   for (const stringToPrune of stringsToPrune) {
-    stringifedMessages = stringifedMessages.replaceAll(stringToPrune, "");
+    stringifedMessages = stringifedMessages.replaceAll(escapeString(stringToPrune), "");
   }
 
   return `### Instruction:\n${stringifedMessages}\n### Response:`;

--- a/app/src/server/utils/updatePruningRuleMatches.test.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.test.ts
@@ -51,6 +51,8 @@ const createProject = async (datasetId: string) => {
   });
 };
 
+const datasetId = uuidv4();
+
 const createDatasetEntry = async (
   datasetId: string,
   input: CreateChatCompletionRequestMessage[],
@@ -78,7 +80,6 @@ const createPruningRule = async (datasetId: string, textToMatch: string) => {
 };
 
 it("matches basic string", async () => {
-  const datasetId = uuidv4();
   await createProject(datasetId);
   // Create experiments concurrently
   const [_, rule] = await Promise.all([
@@ -99,7 +100,6 @@ it("matches basic string", async () => {
 });
 
 it("matches string with newline", async () => {
-  const datasetId = uuidv4();
   await createProject(datasetId);
   // Create experiments concurrently
   const [_, rule] = await Promise.all([

--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -1,6 +1,7 @@
 import { sql, type RawBuilder, type Expression, type SqlBool } from "kysely";
 
 import { prisma, kysely } from "~/server/db";
+import { escapeString, escapeLikeString } from "~/utils/pruningRules";
 
 export const updatePruningRuleMatches = async (
   datasetId: string,
@@ -42,7 +43,7 @@ export const updatePruningRuleMatches = async (
 
     // For each rule to update, find all the dataset entries with matching prompts, after previous rules have been applied
     for (let j = 0; j < i; j++) {
-      prunedInput = sql`REPLACE(${prunedInput}, ${escapeReplaceString(
+      prunedInput = sql`REPLACE(${prunedInput}, ${escapeString(
         allPruningRules[j]?.textToMatch,
       )}, '')`;
     }
@@ -75,11 +76,3 @@ export const updatePruningRuleMatches = async (
       .execute();
   }
 };
-
-function escapeReplaceString(input: string | undefined) {
-  return (input || "").replaceAll("\\", "\\").replaceAll("\n", "\\n").replaceAll('"', '\\"');
-}
-
-function escapeLikeString(input: string | undefined) {
-  return (input || "").replaceAll("\\", "\\\\").replaceAll("\n", "\\\\n").replaceAll('"', '\\\\"');
-}

--- a/app/src/tests/helpers/setup.ts
+++ b/app/src/tests/helpers/setup.ts
@@ -5,7 +5,7 @@ import { kysely } from "~/server/db";
 
 // Reset all Prisma data
 const resetDb = async () => {
-  await sql`truncate "Experiment" cascade;`.execute(kysely);
+  await sql`truncate "Project" cascade;`.execute(kysely);
 };
 
 beforeEach(async () => {

--- a/app/src/utils/pruningRules.ts
+++ b/app/src/utils/pruningRules.ts
@@ -1,0 +1,8 @@
+export function escapeString(input: string | undefined) {
+  // Remove first and last character, which are quotes
+  return JSON.stringify(input || "").slice(1, -1);
+}
+
+export function escapeLikeString(input: string | undefined) {
+  return escapeString(escapeString(input || ""));
+}

--- a/client-libs/openapi.json
+++ b/client-libs/openapi.json
@@ -75,9 +75,9 @@
         }
       }
     },
-    "/completions": {
+    "/chat/completions": {
       "post": {
-        "operationId": "completions",
+        "operationId": "createChatCompletion",
         "description": "Create completion for a prompt",
         "security": [
           {

--- a/client-libs/python/openpipe/api_client/api/default/create_chat_completion.py
+++ b/client-libs/python/openpipe/api_client/api/default/create_chat_completion.py
@@ -5,13 +5,13 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.completions_json_body import CompletionsJsonBody
+from ...models.create_chat_completion_json_body import CreateChatCompletionJsonBody
 from ...types import Response
 
 
 def _get_kwargs(
     *,
-    json_body: CompletionsJsonBody,
+    json_body: CreateChatCompletionJsonBody,
 ) -> Dict[str, Any]:
     pass
 
@@ -19,7 +19,7 @@ def _get_kwargs(
 
     return {
         "method": "post",
-        "url": "/completions",
+        "url": "/chat/completions",
         "json": json_json_body,
     }
 
@@ -45,12 +45,12 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    json_body: CompletionsJsonBody,
+    json_body: CreateChatCompletionJsonBody,
 ) -> Response[Any]:
     """Create completion for a prompt
 
     Args:
-        json_body (CompletionsJsonBody):
+        json_body (CreateChatCompletionJsonBody):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -74,12 +74,12 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    json_body: CompletionsJsonBody,
+    json_body: CreateChatCompletionJsonBody,
 ) -> Response[Any]:
     """Create completion for a prompt
 
     Args:
-        json_body (CompletionsJsonBody):
+        json_body (CreateChatCompletionJsonBody):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/client-libs/python/openpipe/api_client/models/__init__.py
+++ b/client-libs/python/openpipe/api_client/models/__init__.py
@@ -3,7 +3,7 @@
 from .check_cache_json_body import CheckCacheJsonBody
 from .check_cache_json_body_tags import CheckCacheJsonBodyTags
 from .check_cache_response_200 import CheckCacheResponse200
-from .completions_json_body import CompletionsJsonBody
+from .create_chat_completion_json_body import CreateChatCompletionJsonBody
 from .local_testing_only_get_latest_logged_call_response_200 import LocalTestingOnlyGetLatestLoggedCallResponse200
 from .local_testing_only_get_latest_logged_call_response_200_model_response import (
     LocalTestingOnlyGetLatestLoggedCallResponse200ModelResponse,
@@ -21,7 +21,7 @@ __all__ = (
     "CheckCacheJsonBody",
     "CheckCacheJsonBodyTags",
     "CheckCacheResponse200",
-    "CompletionsJsonBody",
+    "CreateChatCompletionJsonBody",
     "LocalTestingOnlyGetLatestLoggedCallResponse200",
     "LocalTestingOnlyGetLatestLoggedCallResponse200ModelResponse",
     "LocalTestingOnlyGetLatestLoggedCallResponse200Tags",

--- a/client-libs/python/openpipe/api_client/models/create_chat_completion_json_body.py
+++ b/client-libs/python/openpipe/api_client/models/create_chat_completion_json_body.py
@@ -4,11 +4,11 @@ from attrs import define
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="CompletionsJsonBody")
+T = TypeVar("T", bound="CreateChatCompletionJsonBody")
 
 
 @define
-class CompletionsJsonBody:
+class CreateChatCompletionJsonBody:
     """
     Attributes:
         req_payload (Union[Unset, Any]): JSON-encoded request payload
@@ -31,8 +31,8 @@ class CompletionsJsonBody:
         d = src_dict.copy()
         req_payload = d.pop("reqPayload", UNSET)
 
-        completions_json_body = cls(
+        create_chat_completion_json_body = cls(
             req_payload=req_payload,
         )
 
-        return completions_json_body
+        return create_chat_completion_json_body

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -2,7 +2,7 @@
   "name": "openpipe-dev",
   "version": "0.4.1",
   "type": "module",
-  "description": "Metrics and auto-evaluation for LLM calls",
+  "description": "LLM metrics and inference",
   "scripts": {
     "build": "./build.sh",
     "build-update": "./build.sh && ./update-app.sh",

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Metrics and auto-evaluation for LLM calls",
   "scripts": {

--- a/client-libs/typescript/src/codegen/services/DefaultService.ts
+++ b/client-libs/typescript/src/codegen/services/DefaultService.ts
@@ -50,7 +50,7 @@ export class DefaultService {
      * @returns any Successful response
      * @throws ApiError
      */
-    public completions(
+    public createChatCompletion(
         requestBody: {
             /**
              * JSON-encoded request payload
@@ -60,7 +60,7 @@ export class DefaultService {
     ): CancelablePromise<any> {
         return this.httpRequest.request({
             method: 'POST',
-            url: '/completions',
+            url: '/chat/completions',
             body: requestBody,
             mediaType: 'application/json',
         });

--- a/client-libs/typescript/src/openai.ts
+++ b/client-libs/typescript/src/openai.ts
@@ -76,7 +76,7 @@ class WrappedCompletions extends openai.OpenAI.Chat.Completions {
   ): Promise<Core.APIResponse<ChatCompletion | Stream<ChatCompletionChunk>>> {
     let resp;
     if (body.model.startsWith("openpipe:")) {
-      resp = this.opClient?.default.completions({
+      resp = this.opClient?.default.createChatCompletion({
         reqPayload: body,
       }) as Promise<Core.APIResponse<ChatCompletion>>;
     } else {

--- a/client-libs/typescript/src/openai.ts
+++ b/client-libs/typescript/src/openai.ts
@@ -12,20 +12,6 @@ import { DefaultService, OPClient } from "./codegen";
 import { Stream } from "openai-beta/streaming";
 import { OpenPipeArgs, OpenPipeMeta, type OpenPipeConfig, getTags } from "./shared";
 
-const DEFAULT_MODELS = [
-  "gpt-4",
-  "gpt-4-0314",
-  "gpt-4-0613",
-  "gpt-4-32k",
-  "gpt-4-32k-0314",
-  "gpt-4-32k-0613",
-  "gpt-3.5-turbo",
-  "gpt-3.5-turbo-16k",
-  "gpt-3.5-turbo-0301",
-  "gpt-3.5-turbo-0613",
-  "gpt-3.5-turbo-16k-0613",
-];
-
 export type ClientOptions = openai.ClientOptions & { openpipe?: OpenPipeConfig };
 export default class OpenAI extends openai.OpenAI {
   public opClient?: OPClient;
@@ -89,12 +75,12 @@ class WrappedCompletions extends openai.OpenAI.Chat.Completions {
     options?: Core.RequestOptions,
   ): Promise<Core.APIResponse<ChatCompletion | Stream<ChatCompletionChunk>>> {
     let resp;
-    if (DEFAULT_MODELS.includes(body.model) || body.model.startsWith("ft:gpt-3.5-turbo")) {
-      resp = body.stream ? super.create(body, options) : super.create(body, options);
-    } else {
+    if (body.model.startsWith("openpipe:")) {
       resp = this.opClient?.default.completions({
         reqPayload: body,
       }) as Promise<Core.APIResponse<ChatCompletion>>;
+    } else {
+      resp = body.stream ? super.create(body, options) : super.create(body, options);
     }
 
     return resp;


### PR DESCRIPTION
We can reduce the number of tokens we send in requests to our models by applying the pruning rules of a fine-tuned models' original dataset to prompts on the fly.

## Changes
* Add `openpipe:` to displayed model slug, require it in sdk model name
* Release new version of typescript sdk
* Properly clear database before testing
* Parse content and function call strings from vllm