### PR TITLE
Add support for Palm, Claude-2, Cohere, Replicate Llama2 CodeLlama, Ollama, (100+LLMs)

### DIFF
--- a/client-libs/python/openpipe/openai.py
+++ b/client-libs/python/openpipe/openai.py
@@ -1,4 +1,5 @@
 import openai as original_openai
+import litellm
 from openai.openai_object import OpenAIObject
 import time
 import inspect
@@ -29,7 +30,7 @@ class WrappedChatCompletion(original_openai.ChatCompletion):
         requested_at = int(time.time() * 1000)
 
         try:
-            chat_completion = original_openai.ChatCompletion.create(*args, **kwargs)
+            chat_completion = litellm.completion(*args, **kwargs)
 
             if inspect.isgenerator(chat_completion):
 
@@ -115,7 +116,7 @@ class WrappedChatCompletion(original_openai.ChatCompletion):
         requested_at = int(time.time() * 1000)
 
         try:
-            chat_completion = await original_openai.ChatCompletion.acreate(
+            chat_completion = await litellm.acompletion(
                 *args, **kwargs
             )
 

--- a/client-libs/python/pyproject.toml
+++ b/client-libs/python/pyproject.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/OpenPipe/OpenPipe"
 [tool.poetry.dependencies]
 python = "^3.9"
 openai = "^0.27.8"
+litellm = "^0.1.697"
 httpx = "^0.24.1"
 attrs = "^23.1.0"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```