### PR TITLE
Use multiple inference urls for a fine-tuned model

### DIFF
--- a/app/prisma/migrations/20230918235738_allow_multiple_inference_urls/migration.sql
+++ b/app/prisma/migrations/20230918235738_allow_multiple_inference_urls/migration.sql
@@ -1,0 +1,8 @@
+-- Step 1: Add the new column with a default value of an empty array
+ALTER TABLE "FineTune" ADD COLUMN "inferenceUrls" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- Step 2: Update the new column with data from the old column for rows where inferenceUrl is not NULL
+UPDATE "FineTune" SET "inferenceUrls" = ARRAY["inferenceUrl"] WHERE "inferenceUrl" IS NOT NULL;
+
+-- Step 3: Drop the old column
+ALTER TABLE "FineTune" DROP COLUMN "inferenceUrl";

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -522,7 +522,7 @@ model FineTune {
     trainingFinishedAt   DateTime?
     deploymentStartedAt  DateTime?
     deploymentFinishedAt DateTime?
-    inferenceUrl         String?
+    inferenceUrls        String[] @default([])
 
     datasetId String   @db.Uuid
     dataset    Dataset @relation(fields: [datasetId], references: [id], onDelete: Cascade)

--- a/app/src/modelProviders/fine-tuned/getCompletion.test.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.test.ts
@@ -21,7 +21,7 @@ it("gets a reasonable completion", async () => {
     ],
   };
 
-  const completion = await getCompletion(inputData, endpoint, []);
+  const completion = await getCompletion(inputData, [endpoint], []);
   console.log(completion.choices[0]?.message?.content);
 });
 

--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -134,7 +134,7 @@ export const v1ApiRouter = createOpenApiRouter({
           code: "FORBIDDEN",
         });
       }
-      if (!fineTune.inferenceUrl) {
+      if (!fineTune.inferenceUrls.length) {
         throw new TRPCError({
           message: "The model is not set up for inference",
           code: "BAD_REQUEST",
@@ -145,7 +145,7 @@ export const v1ApiRouter = createOpenApiRouter({
       try {
         completion = await getCompletion(
           reqPayload.data,
-          fineTune.inferenceUrl,
+          fineTune.inferenceUrls,
           fineTune.dataset.pruningRules.map((rule) => rule.textToMatch),
         );
       } catch (error: unknown) {

--- a/app/src/server/db.types.ts
+++ b/app/src/server/db.types.ts
@@ -117,7 +117,9 @@ export interface FineTune {
   id: string;
   slug: string;
   baseModel: string;
-  status: Generated<"AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING">;
+  status: Generated<
+    "AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING"
+  >;
   trainingStartedAt: Timestamp | null;
   trainingFinishedAt: Timestamp | null;
   deploymentStartedAt: Timestamp | null;

--- a/app/src/server/db.types.ts
+++ b/app/src/server/db.types.ts
@@ -117,9 +117,7 @@ export interface FineTune {
   id: string;
   slug: string;
   baseModel: string;
-  status: Generated<
-    "AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING"
-  >;
+  status: Generated<"AWAITING_DEPLOYMENT" | "DEPLOYED" | "DEPLOYING" | "ERROR" | "PENDING" | "TRAINING">;
   trainingStartedAt: Timestamp | null;
   trainingFinishedAt: Timestamp | null;
   deploymentStartedAt: Timestamp | null;
@@ -128,7 +126,7 @@ export interface FineTune {
   projectId: string;
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
-  inferenceUrl: string | null;
+  inferenceUrls: Generated<string[] | null>;
 }
 
 export interface GraphileWorkerJobQueues {


### PR DESCRIPTION
Spreading inference across multiple GPUs allows for increased peak load capacity.

## Changes
* Allow multiple inference URLs for a fine-tuned model
* Try a fallback inference URL if the first one is overloaded.