### PR TITLE
Remove lodash-es dependency from client lib

### DIFF
--- a/client-libs/typescript/build.sh
+++ b/client-libs/typescript/build.sh
@@ -22,6 +22,9 @@ with open('dist/package.json', 'r') as file:
 # Change the names
 data['name'] = 'openpipe'
 
+# Copy all keys from publishConfig to root
+data.update(data['publishConfig'])
+
 # Write the changes back to the package.json file
 with open('dist/package.json', 'w') as file:
     json.dump(data, file, indent=2)

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {
@@ -36,9 +36,8 @@
   "dependencies": {
     "encoding": "^0.1.13",
     "form-data": "^4.0.0",
-    "lodash-es": "^4.17.21",
     "node-fetch": "^2.6.12",
-    "openai-beta": "npm:openai@4.0.0-beta.7",
+    "openai": "^4.8.0",
     "openai-legacy": "npm:openai@3.3.0"
   },
   "devDependencies": {

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -1,11 +1,11 @@
 import dotenv from "dotenv";
 import { expect, test } from "vitest";
 import OpenAI from "../openai";
-import {
+import type {
   ChatCompletion,
   CompletionCreateParams,
   CreateChatCompletionRequestMessage,
-} from "openai-beta/resources/chat/completions";
+} from "openai/resources/chat/completions";
 import { OPClient } from "../codegen";
 import mergeChunks from "./mergeChunks";
 import assert from "assert";
@@ -84,7 +84,7 @@ test("bad call streaming", async () => {
     await e.openpipe.reportingFinished;
     const lastLogged = await lastLoggedCall();
     expect(lastLogged?.modelResponse?.errorMessage).toEqual(
-      "The model `gpt-3.5-turbo-blaster` does not exist",
+      "404 The model `gpt-3.5-turbo-blaster` does not exist",
     );
     expect(lastLogged?.modelResponse?.statusCode).toEqual(404);
   }
@@ -103,7 +103,7 @@ test("bad call", async () => {
     await e.openpipe.reportingFinished;
     const lastLogged = await lastLoggedCall();
     expect(lastLogged?.modelResponse?.errorMessage).toEqual(
-      "The model `gpt-3.5-turbo-buster` does not exist",
+      "404 The model `gpt-3.5-turbo-buster` does not exist",
     );
     expect(lastLogged?.modelResponse?.statusCode).toEqual(404);
   }

--- a/client-libs/typescript/src/openai/mergeChunks.ts
+++ b/client-libs/typescript/src/openai/mergeChunks.ts
@@ -1,5 +1,15 @@
-import { ChatCompletion, ChatCompletionChunk } from "openai-beta/resources/chat";
-import { omit } from "lodash-es";
+import type { ChatCompletion, ChatCompletionChunk } from "openai/resources/chat";
+
+const omit = <T extends Record<string, unknown>, K extends keyof T>(
+  obj: T,
+  ...keys: K[]
+): Omit<T, K> => {
+  const ret = { ...obj };
+  for (const key of keys) {
+    delete ret[key];
+  }
+  return ret;
+};
 
 export default function mergeChunks(
   base: ChatCompletion | null,
@@ -18,14 +28,14 @@ export default function mergeChunks(
 
       if (choice.delta?.content)
         baseChoice.message.content =
-          ((baseChoice.message.content as string) ?? "") + (choice.delta.content ?? "");
+          (baseChoice.message.content ?? "") + (choice.delta.content ?? "");
       if (choice.delta?.function_call) {
-        const fnCall = baseChoice.message.function_call ?? {};
-        fnCall.name =
-          ((fnCall.name as string) ?? "") + ((choice.delta.function_call.name as string) ?? "");
-        fnCall.arguments =
-          ((fnCall.arguments as string) ?? "") +
-          ((choice.delta.function_call.arguments as string) ?? "");
+        const fnCall = baseChoice.message.function_call ?? {
+          name: "",
+          arguments: "",
+        };
+        fnCall.name = fnCall.name + (choice.delta.function_call.name ?? "");
+        fnCall.arguments = fnCall.arguments + (choice.delta.function_call.arguments ?? "");
       }
     } else {
       // @ts-expect-error the types are correctly telling us that finish_reason

--- a/client-libs/typescript/src/openai/streaming.ts
+++ b/client-libs/typescript/src/openai/streaming.ts
@@ -1,5 +1,5 @@
-import { ChatCompletion, ChatCompletionChunk } from "openai-beta/resources/chat";
-import { Stream } from "openai-beta/streaming";
+import type { ChatCompletion, ChatCompletionChunk } from "openai/resources/chat";
+import { Stream } from "openai/streaming";
 import { OpenPipeMeta } from "../shared";
 import mergeChunks from "./mergeChunks";
 
@@ -10,6 +10,7 @@ export class WrappedStream extends Stream<ChatCompletionChunk> {
   private report: (response: unknown) => Promise<void>;
 
   constructor(stream: Stream<ChatCompletionChunk>, report: (response: unknown) => Promise<void>) {
+    // @ts-expect-error - This is a private property but we need to access it
     super(stream.response, stream.controller);
     this.report = report;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,15 +390,12 @@ importers:
       form-data:
         specifier: ^4.0.0
         version: 4.0.0
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       node-fetch:
         specifier: ^2.6.12
         version: 2.6.12(encoding@0.1.13)
-      openai-beta:
-        specifier: npm:openai@4.0.0-beta.7
-        version: /openai@4.0.0-beta.7(encoding@0.1.13)
+      openai:
+        specifier: ^4.8.0
+        version: 4.8.0(encoding@0.1.13)
       openai-legacy:
         specifier: npm:openai@3.3.0
         version: /openai@3.3.0
@@ -7734,6 +7731,22 @@ packages:
 
   /openai@4.0.0-beta.7(encoding@0.1.13):
     resolution: {integrity: sha512-jHjwvpMuGkNxiQ3erwLZsOvPEhcVrMtwtfNeYmGCjhbdB+oStVw/7pIhIPkualu8rlhLwgMR7awknIaN3IQcOA==}
+    dependencies:
+      '@types/node': 18.16.0
+      '@types/node-fetch': 2.6.4
+      abort-controller: 3.0.0
+      agentkeepalive: 4.5.0
+      digest-fetch: 1.3.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.6.12(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /openai@4.8.0(encoding@0.1.13):
+    resolution: {integrity: sha512-CnLZvHi2x4pIoGAWCaj3jHi1a6NA4oFBL6mJDSXkIR5A/wv6lven7uL2gxMevjGBLA7OqYqis3Z2PMluiGauVw==}
+    hasBin: true
     dependencies:
       '@types/node': 18.16.0
       '@types/node-fetch': 2.6.4


### PR DESCRIPTION
It turns out that under some consumer configurations the lodash-es dep isn't able to load correctly. We aren't using it for much so I've just removed it entirely.

This PR also updates our OpenAI client library version. It turns out that this wasn't actually necessary, but it's probably good to stay on the latest version anyway.