### PR TITLE
Ensure request is reported when async streaming loop is terminated

### DIFF
--- a/client-libs/python/pyproject.toml
+++ b/client-libs/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openpipe"
-version = "3.1.2"
+version = "3.2.0"
 description = "Python client library for the OpenPipe service"
 authors = ["Kyle Corbitt <kyle@openpipe.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Previously, one user who was asynchronously streaming completions from OpenAI found that their requests were not being reported. This change should result in requests being logged after the generator exits.

### Changes
* Update python version to `3.2.0`
* Move async reporting to finally block of generator