### PR TITLE
Allow user to save OpenAI API key on a project

### DIFF
--- a/app/prisma/migrations/20231003010111_allow_openai_api_keys/migration.sql
+++ b/app/prisma/migrations/20231003010111_allow_openai_api_keys/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ApiKeyProvider" AS ENUM ('OPENPIPE', 'OPENAI');
+
+-- AlterTable
+ALTER TABLE "ApiKey" ADD COLUMN     "provider" "ApiKeyProvider" NOT NULL DEFAULT 'OPENPIPE';

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -426,11 +426,17 @@ model LoggedCallTag {
     @@index([projectId, name, value])
 }
 
+enum ApiKeyProvider {
+    OPENPIPE
+    OPENAI
+}
+
 model ApiKey {
     id String @id @default(uuid()) @db.Uuid
 
     name   String
     apiKey String @unique
+    provider ApiKeyProvider @default(OPENPIPE)
 
     projectId String  @db.Uuid
     project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)

--- a/app/src/components/projectSettings/OpenaiApiKeyDisplay.tsx
+++ b/app/src/components/projectSettings/OpenaiApiKeyDisplay.tsx
@@ -1,0 +1,53 @@
+import { HStack, Text, Button, Icon, useDisclosure } from "@chakra-ui/react";
+import { BsPlus } from "react-icons/bs";
+
+import { useSelectedProject } from "~/utils/hooks";
+import UpdateOpenaiApiKeyModal from "./UpdateOpenaiApiKeyModal";
+import RemoveOpenaiApiKeyDialog from "./RemoveOpenaiApiKeyDialog";
+
+const OpenaiApiKeyDisplay = () => {
+  const { data: selectedProject } = useSelectedProject();
+
+  const updateModalDisclosure = useDisclosure();
+  const removeModalDisclosure = useDisclosure();
+
+  return (
+    <>
+      {selectedProject?.condensedOpenAIKey ? (
+        <HStack>
+          <Text color="gray.500">SAVED KEY</Text>
+          <Text fontWeight="bold">{selectedProject.condensedOpenAIKey}</Text>
+          <Button
+            variant="unstyled"
+            textDecoration="underline"
+            color="gray.500"
+            px={1}
+            onClick={updateModalDisclosure.onOpen}
+          >
+            Update
+          </Button>
+          <Button
+            variant="unstyled"
+            textDecoration="underline"
+            color="gray.500"
+            px={1}
+            onClick={removeModalDisclosure.onOpen}
+          >
+            Remove
+          </Button>
+        </HStack>
+      ) : (
+        <Button onClick={updateModalDisclosure.onOpen}>
+          <HStack>
+            <Icon as={BsPlus} boxSize={6} mr={-1} />
+            <Text>Add a Key</Text>
+          </HStack>
+        </Button>
+      )}
+      <UpdateOpenaiApiKeyModal disclosure={updateModalDisclosure} />
+      <RemoveOpenaiApiKeyDialog disclosure={removeModalDisclosure} />
+    </>
+  );
+};
+
+export default OpenaiApiKeyDisplay;

--- a/app/src/components/projectSettings/RemoveOpenaiApiKeyDialog.tsx
+++ b/app/src/components/projectSettings/RemoveOpenaiApiKeyDialog.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  Text,
+  VStack,
+  type UseDisclosureReturn,
+} from "@chakra-ui/react";
+
+import { useRouter } from "next/router";
+import { useRef } from "react";
+import { api } from "~/utils/api";
+import { useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
+
+const RemoveOpenaiApiKeyDialog = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
+  const selectedProject = useSelectedProject();
+  const utils = api.useContext();
+  const router = useRouter();
+
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  const updateProjectMutation = api.projects.update.useMutation();
+
+  const [removeOpenaiApiKey, isRemoving] = useHandledAsyncCallback(async () => {
+    if (!selectedProject.data?.id) return;
+    await updateProjectMutation.mutateAsync({
+      id: selectedProject.data.id,
+      updates: { openaiApiKey: null },
+    });
+    await utils.projects.get.invalidate();
+    disclosure.onClose();
+  }, [updateProjectMutation, selectedProject, router, disclosure.onClose]);
+
+  return (
+    <AlertDialog leastDestructiveRef={cancelRef} {...disclosure}>
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Remove OpenAI API Key
+          </AlertDialogHeader>
+
+          <AlertDialogBody>
+            <VStack spacing={4} alignItems="flex-start">
+              <Text>
+                Are you sure you want to remove your existing OpenAI API key from the project?
+              </Text>
+              <Text>
+                Without a key, you will not be able to submit fine-tune jobs or run inference
+                against existing fine-tuned OpenAI models.
+              </Text>
+            </VStack>
+          </AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button ref={cancelRef} onClick={disclosure.onClose}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme="red"
+              onClick={removeOpenaiApiKey}
+              ml={3}
+              w={20}
+              isLoading={isRemoving}
+            >
+              Remove
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  );
+};
+
+export default RemoveOpenaiApiKeyDialog;

--- a/app/src/components/projectSettings/UpdateOpenaiApiKeyModal.tsx
+++ b/app/src/components/projectSettings/UpdateOpenaiApiKeyModal.tsx
@@ -1,0 +1,102 @@
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
+  type UseDisclosureReturn,
+} from "@chakra-ui/react";
+import { useState, useEffect } from "react";
+
+import { api } from "~/utils/api";
+import { useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
+import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
+
+const UpdateOpenaiApiKeyModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
+  const selectedProject = useSelectedProject().data;
+  const utils = api.useContext();
+
+  const [apiKey, setApiKey] = useState("");
+
+  useEffect(() => {
+    setApiKey("");
+  }, [disclosure.isOpen]);
+
+  const updateProjectMutation = api.projects.update.useMutation();
+
+  const [updateKey, isUpdating] = useHandledAsyncCallback(async () => {
+    if (!selectedProject?.id || !apiKey) return;
+    const resp = await updateProjectMutation.mutateAsync({
+      id: selectedProject.id,
+      updates: { openaiApiKey: apiKey },
+    });
+    if (maybeReportError(resp)) return;
+    await utils.projects.get.invalidate();
+    disclosure.onClose();
+  }, [updateProjectMutation, selectedProject?.id, apiKey, disclosure.onClose]);
+
+  return (
+    <Modal {...disclosure}>
+      <ModalOverlay />
+      <ModalContent w={1200}>
+        <ModalHeader>
+          <HStack>
+            <Text>Update OpenAI Key</Text>
+          </HStack>
+        </ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <VStack spacing={8} alignItems="flex-start">
+            <Text>
+              This key will be used to submit fine-tune jobs and run inference against fine-tuned
+              models in <b>{selectedProject?.name}</b>.
+            </Text>
+
+            <FormControl>
+              <FormLabel>OpenAI API Key</FormLabel>
+              <Input
+                placeholder="sk-..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey || e.shiftKey)) {
+                    e.preventDefault();
+                    e.currentTarget.blur();
+                    updateKey();
+                  }
+                }}
+              />
+            </FormControl>
+          </VStack>
+        </ModalBody>
+        <ModalFooter mt={4}>
+          <HStack>
+            <Button colorScheme="gray" onClick={disclosure.onClose} minW={24}>
+              <Text>Cancel</Text>
+            </Button>
+            <Button
+              colorScheme="orange"
+              onClick={updateKey}
+              minW={24}
+              isLoading={isUpdating}
+              isDisabled={!apiKey}
+            >
+              Save Key
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default UpdateOpenaiApiKeyModal;

--- a/app/src/pages/project/settings/index.tsx
+++ b/app/src/pages/project/settings/index.tsx
@@ -25,15 +25,11 @@ import { DeleteProjectDialog } from "~/components/projectSettings/DeleteProjectD
 import AutoResizeTextArea from "~/components/AutoResizeTextArea";
 import MemberTable from "~/components/projectSettings/MemberTable";
 import { InviteMemberModal } from "~/components/projectSettings/InviteMemberModal";
+import OpenaiApiKeyDisplay from "~/components/projectSettings/OpenaiApiKeyDisplay";
 
 export default function Settings() {
   const utils = api.useContext();
   const { data: selectedProject } = useSelectedProject();
-
-  const apiKey =
-    selectedProject?.apiKeys?.length && selectedProject?.apiKeys[0]
-      ? selectedProject?.apiKeys[0].apiKey
-      : "";
 
   const updateMutation = api.projects.update.useMutation();
   const [onSaveName] = useHandledAsyncCallback(async () => {
@@ -153,14 +149,24 @@ export default function Settings() {
                 your code.
               </Text>
             </VStack>
-            <CopiableCode code={apiKey} />
+            <CopiableCode code={selectedProject?.openpipeApiKey ?? ""} />
+            <Divider />
+            <VStack alignItems="flex-start">
+              <Subtitle>OpenAI API Key</Subtitle>
+              <Text fontSize="sm">
+                Add your OpenAI API key to fine-tune GPT-3.5 Turbo models through OpenPipe. This key
+                is not necessary to use OpenPipe with OpenAI base models such as GPT-4 or GPT-3.5
+                Turbo or fine-tuned Llama2 models.
+              </Text>
+            </VStack>
+            <OpenaiApiKeyDisplay />
             <Divider />
             {selectedProject?.personalProjectUserId ? (
               <VStack alignItems="flex-start">
                 <Subtitle>Personal Project</Subtitle>
                 <Text fontSize="sm">
-                  This project is {selectedProject?.personalProjectUser?.name}'s personal project.
-                  It cannot be deleted.
+                  This is {selectedProject?.personalProjectUser?.name}'s personal project. It cannot
+                  be deleted.
                 </Text>
               </VStack>
             ) : (


### PR DESCRIPTION
Users need to add their OpenAI keys to a project in order to fine-tune OpenAI models on that project and run inference on those models.

## Changes
* Add `ApiKeyProvider` enum with `OPENPIPE` and `OPENAI` values
* Send only condensed version of OpenAI API key to the client
* Allow user to create/update/delete OpenAI API key for their project

Section without key:
<img width="905" alt="Screenshot 2023-10-02 at 7 12 45 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/0e2072f5-8922-456e-9a12-8b9879a87777">


Section with key:
<img width="927" alt="Screenshot 2023-10-02 at 7 13 07 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/45486974-f106-47d4-a651-4d32f51a20dc">


Update modal:
<img width="680" alt="Screenshot 2023-10-02 at 7 13 16 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/7750ee4d-f16e-4469-9c19-75e8b722a2a4">


Remove modal:
<img width="656" alt="Screenshot 2023-10-02 at 7 13 25 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/a4575689-1c9e-4a45-88fb-ed19f33e0b75">
