### PR TITLE
Calculate score for function outputs

### DIFF
--- a/app/prisma/migrations/20231004005048_add_score_to_fine_tune_testing_entry/migration.sql
+++ b/app/prisma/migrations/20231004005048_add_score_to_fine_tune_testing_entry/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "FineTuneTestingEntry" ADD COLUMN     "score" DOUBLE PRECISION;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -579,6 +579,7 @@ model FineTuneTestingEntry {
     prunedInput       String
     outputTokens      Int?
     output            Json?
+    score             Float?
     errorMessage      String?
 
     fineTuneId String   @db.Uuid

--- a/app/src/components/ColoredPercent.tsx
+++ b/app/src/components/ColoredPercent.tsx
@@ -1,0 +1,20 @@
+import { useToken, Text } from "@chakra-ui/react";
+import chroma from "chroma-js";
+
+const ColoredPercent = ({ value }: { value: number }) => {
+  const [passColor, neutralColor, failColor] = useToken("colors", [
+    "green.600",
+    "gray.600",
+    "red.600",
+  ]);
+
+  const scale = chroma.scale([failColor, neutralColor, passColor]).domain([0, 0.5, 1]);
+
+  return (
+    <Text color={scale(value).hex()} fontWeight="bold">
+      {(value * 100).toFixed(1)}%
+    </Text>
+  );
+};
+
+export default ColoredPercent;

--- a/app/src/components/OutputsTable/VariantStats.tsx
+++ b/app/src/components/OutputsTable/VariantStats.tsx
@@ -1,11 +1,12 @@
-import { HStack, Icon, Text, useToken } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { HStack, Icon, Text } from "@chakra-ui/react";
+import { BsCurrencyDollar } from "react-icons/bs";
+
 import { type PromptVariant } from "./types";
 import { cellPadding } from "./constants";
 import { api } from "~/utils/api";
-import chroma from "chroma-js";
-import { BsCurrencyDollar } from "react-icons/bs";
 import { CostTooltip } from "../tooltip/CostTooltip";
-import { useEffect, useState } from "react";
+import ColoredPercent from "../ColoredPercent";
 
 export default function VariantStats(props: { variant: PromptVariant }) {
   const [refetchInterval, setRefetchInterval] = useState(0);
@@ -34,14 +35,6 @@ export default function VariantStats(props: { variant: PromptVariant }) {
     [data.awaitingCompletions, data.awaitingEvals],
   );
 
-  const [passColor, neutralColor, failColor] = useToken("colors", [
-    "green.500",
-    "gray.500",
-    "red.500",
-  ]);
-
-  const scale = chroma.scale([failColor, neutralColor, passColor]).domain([0, 0.5, 1]);
-
   const showNumFinished = data.scenarioCount > 0 && data.scenarioCount !== data.finishedCount;
 
   return (
@@ -63,9 +56,7 @@ export default function VariantStats(props: { variant: PromptVariant }) {
           return (
             <HStack key={result.id}>
               <Text>{result.label}</Text>
-              <Text color={scale(passedFrac).hex()} fontWeight="bold">
-                {(passedFrac * 100).toFixed(1)}%
-              </Text>
+              <ColoredPercent value={passedFrac} />
             </HStack>
           );
         })}

--- a/app/src/components/fineTunes/ContentTabs/TestSet/TestSet.tsx
+++ b/app/src/components/fineTunes/ContentTabs/TestSet/TestSet.tsx
@@ -7,6 +7,7 @@ import ContentCard from "../ContentCard";
 import TestSetRow, { TableHeader } from "./TestSetRow";
 import TestSetPaginator from "./TestSetPaginator";
 import { useState } from "react";
+import ColoredPercent from "~/components/ColoredPercent";
 
 const TestSet = () => {
   const fineTune = useFineTune().data;
@@ -24,7 +25,7 @@ const TestSet = () => {
 
   if (!fineTune || !testingEntries) return null;
 
-  const { entries, count } = testingEntries;
+  const { entries, count, averageScore } = testingEntries;
 
   const isDeployed = fineTune.status === "DEPLOYED";
 
@@ -33,9 +34,10 @@ const TestSet = () => {
       <VStack w="full" alignItems="flex-start" spacing={4}>
         <ContentCard px={0} pb={0}>
           <HStack w="full" justifyContent="space-between" px={4}>
-            <Text fontWeight="bold" pb={2}>
-              Test Output ({count} rows)
-            </Text>
+            <HStack pb={2}>
+              <Text fontWeight="bold">Test Output ({count} rows)</Text>
+              {averageScore && <ColoredPercent value={averageScore} />}
+            </HStack>
             <Link href={{ pathname: "/datasets/[id]", query: { id: fineTune.datasetId } }}>
               <Text color="blue.600" px={2}>
                 View Dataset
@@ -54,6 +56,7 @@ const TestSet = () => {
                       output={entry.output}
                       outputTokens={entry.outputTokens}
                       datasetEntry={entry.datasetEntry}
+                      score={entry.score}
                     />
                   ))}
                 </Tbody>

--- a/app/src/components/fineTunes/ContentTabs/TestSet/TestSetRow.tsx
+++ b/app/src/components/fineTunes/ContentTabs/TestSet/TestSetRow.tsx
@@ -1,6 +1,7 @@
-import { Th, Td, Thead, Tr, Text, VStack } from "@chakra-ui/react";
+import { Th, Td, Thead, Tr, Text, VStack, HStack } from "@chakra-ui/react";
 import { type ChatCompletionMessage } from "openai/resources/chat";
 import SyntaxHighlighter from "react-syntax-highlighter";
+import ColoredPercent from "~/components/ColoredPercent";
 
 import { type RouterOutputs } from "~/utils/api";
 
@@ -22,12 +23,14 @@ const TestSetRow = ({
   prunedInput,
   output,
   datasetEntry: { output: originalOutput },
+  score,
   errorMessage,
 }: {
   prunedInput: TestingEntry["prunedInput"];
   output: TestingEntry["output"];
   outputTokens: number | null;
   datasetEntry: TestingEntry["datasetEntry"];
+  score: number | null;
   errorMessage?: string;
 }) => {
   return (
@@ -44,7 +47,7 @@ const TestSetRow = ({
         <FormattedOutput output={originalOutput} />
       </Td>
       <Td>
-        <FormattedOutput output={output} errorMessage={errorMessage} />
+        <FormattedOutput output={output} errorMessage={errorMessage} score={score} />
       </Td>
     </Tr>
   );
@@ -76,9 +79,11 @@ const FormattedInput = ({ prunedInput }: { prunedInput: TestingEntry["prunedInpu
 
 const FormattedOutput = ({
   output,
+  score,
   errorMessage,
 }: {
   output: TestingEntry["output"];
+  score?: number | null;
   errorMessage?: string | null;
 }) => {
   if (errorMessage) {
@@ -88,10 +93,16 @@ const FormattedOutput = ({
   if (!output) return <Text color="gray.500">Pending</Text>;
 
   const message = output as unknown as ChatCompletionMessage;
-  return <FormattedMessage message={message} />;
+  return <FormattedMessage message={message} score={score} />;
 };
 
-const FormattedMessage = ({ message }: { message: ChatCompletionMessage }) => {
+const FormattedMessage = ({
+  message,
+  score,
+}: {
+  message: ChatCompletionMessage;
+  score?: number | null;
+}) => {
   if (message.function_call) {
     // return JSON.parse(message.function_call)
     const { name, arguments: args } = message.function_call;
@@ -103,7 +114,10 @@ const FormattedMessage = ({ message }: { message: ChatCompletionMessage }) => {
     }
     return (
       <VStack alignItems="flex-start" whiteSpace="pre-wrap">
-        <Text fontWeight="bold">{name}</Text>
+        <HStack justifyContent="space-between" w="full">
+          <Text fontWeight="bold">{name}</Text>
+          {score && <ColoredPercent value={score} />}
+        </HStack>
         {args &&
           (parsedArgs ? (
             <SyntaxHighlighter

--- a/app/src/components/fineTunes/ContentTabs/TestSet/TestSetRow.tsx
+++ b/app/src/components/fineTunes/ContentTabs/TestSet/TestSetRow.tsx
@@ -116,7 +116,7 @@ const FormattedMessage = ({
       <VStack alignItems="flex-start" whiteSpace="pre-wrap">
         <HStack justifyContent="space-between" w="full">
           <Text fontWeight="bold">{name}</Text>
-          {score && <ColoredPercent value={score} />}
+          {score !== null && score !== undefined && <ColoredPercent value={score} />}
         </HStack>
         {args &&
           (parsedArgs ? (

--- a/app/src/server/scripts/backfillTestingDatasets.ts
+++ b/app/src/server/scripts/backfillTestingDatasets.ts
@@ -25,6 +25,9 @@ const fineTune = await prisma.fineTune.findUnique({
             outdated: false,
             type: "TEST",
           },
+          orderBy: {
+            sortKey: "desc",
+          },
         },
       },
     },
@@ -38,7 +41,7 @@ if (!fineTune) {
 let numEntries = 0;
 
 for (const entry of fineTune.dataset.datasetEntries) {
-  await queueGetTestResult(fineTune.id, entry.id);
+  await queueGetTestResult(fineTune.id, entry.id, true);
   numEntries++;
 }
 

--- a/app/src/server/utils/calculateEntryScore.test.ts
+++ b/app/src/server/utils/calculateEntryScore.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "vitest";
+import { type ChatCompletionMessageParam } from "openai/resources/chat";
+import { calculateEntryScore } from "./calculateEntryScore";
+
+const originalOutput1: ChatCompletionMessageParam = {
+  role: "assistant",
+  content: null,
+  function_call: {
+    name: "extract_credit_card_fields",
+    arguments: '{"last_payment_date": "2023-08-26"}',
+  },
+};
+
+const generatedOutput1: ChatCompletionMessageParam = {
+  role: "assistant",
+  content: null,
+  function_call: {
+    name: "extract_credit_card_fields",
+    arguments: '{"last_payment_date": "2023-08-26"}',
+  },
+};
+
+it("calculates 1 for perfect match", () => {
+  const score = calculateEntryScore(originalOutput1.function_call, generatedOutput1.function_call);
+
+  expect(score).toBe(1);
+});

--- a/app/src/server/utils/calculateEntryScore.ts
+++ b/app/src/server/utils/calculateEntryScore.ts
@@ -2,7 +2,7 @@ import { type ChatCompletionMessage } from "openai/resources/chat";
 
 // If function names don't match, return 0
 // If function names match and there are no args, return 1
-// If function names match and there are args, return .5 + (num matching args / num args) * .5
+// If function names match and there are args, return (num matching args / num args)
 export const calculateEntryScore = (
   originalFunctionCall: ChatCompletionMessage["function_call"],
   generatedFunctionCall: ChatCompletionMessage["function_call"],
@@ -34,7 +34,7 @@ export const calculateEntryScore = (
     const numMatchingArgs = Object.keys(parsedOriginalArgs).filter(
       (key) => parsedOriginalArgs?.[key] === parsedGeneratedArgs?.[key],
     ).length;
-    return 0.5 + (numMatchingArgs / numOriginalArgs) * 0.5;
+    return numMatchingArgs / numOriginalArgs;
   } catch (e) {
     return 0;
   }

--- a/app/src/server/utils/calculateEntryScore.ts
+++ b/app/src/server/utils/calculateEntryScore.ts
@@ -1,0 +1,37 @@
+import { type ChatCompletionMessage } from "openai/resources/chat";
+
+// If function names don't match, return 0
+// If function names match and there are no args, return 1
+// If function names match and there are args, return .5 + (num matching args / num args) * .5
+export const calculateEntryScore = (
+  originalFunctionCall: ChatCompletionMessage["function_call"],
+  generatedFunctionCall: ChatCompletionMessage["function_call"],
+) => {
+  if (
+    !originalFunctionCall ||
+    !generatedFunctionCall ||
+    originalFunctionCall.name !== generatedFunctionCall.name
+  )
+    return 0;
+  if (!originalFunctionCall.arguments) return 1;
+  let parsedOriginalArgs: Record<string, unknown> | undefined;
+  try {
+    parsedOriginalArgs = JSON.parse(originalFunctionCall.arguments);
+  } catch (e) {
+    // Original args were off, so we can't compare them
+    return 1;
+  }
+  if (!parsedOriginalArgs) return 1;
+  let parsedGeneratedArgs: Record<string, unknown> | undefined;
+  try {
+    parsedGeneratedArgs = JSON.parse(generatedFunctionCall.arguments);
+  } catch (e) {
+    return 0.5;
+  }
+  if (!parsedGeneratedArgs) return 0.5;
+  const numOriginalArgs = Object.keys(parsedOriginalArgs).length;
+  const numMatchingArgs = Object.keys(parsedOriginalArgs).filter(
+    (key) => parsedOriginalArgs?.[key] === parsedGeneratedArgs?.[key],
+  ).length;
+  return 0.5 + (numMatchingArgs / numOriginalArgs) * 0.5;
+};

--- a/app/src/server/utils/calculateEntryScore.ts
+++ b/app/src/server/utils/calculateEntryScore.ts
@@ -26,12 +26,16 @@ export const calculateEntryScore = (
   try {
     parsedGeneratedArgs = JSON.parse(generatedFunctionCall.arguments);
   } catch (e) {
-    return 0.5;
+    return 0;
   }
-  if (!parsedGeneratedArgs) return 0.5;
-  const numOriginalArgs = Object.keys(parsedOriginalArgs).length;
-  const numMatchingArgs = Object.keys(parsedOriginalArgs).filter(
-    (key) => parsedOriginalArgs?.[key] === parsedGeneratedArgs?.[key],
-  ).length;
-  return 0.5 + (numMatchingArgs / numOriginalArgs) * 0.5;
+  if (!parsedGeneratedArgs) return 0;
+  try {
+    const numOriginalArgs = Object.keys(parsedOriginalArgs).length;
+    const numMatchingArgs = Object.keys(parsedOriginalArgs).filter(
+      (key) => parsedOriginalArgs?.[key] === parsedGeneratedArgs?.[key],
+    ).length;
+    return 0.5 + (numMatchingArgs / numOriginalArgs) * 0.5;
+  } catch (e) {
+    return 0;
+  }
 };


### PR DESCRIPTION
For models that produce structured data, we now compare the function names and argument values to calculate a per-row score between 0 and 1. We also display the total score at the top of the test set.

### Changes
* Add `caculateEntryScore`, save score on testing entry in database
* Display per-row score and total score in test set tab
* Skip cache when re-running tests for a fine-tuned model

<img width="461" alt="Screenshot 2023-10-03 at 7 22 16 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/36096860-a06e-4a46-928e-67f8c2c0b27f">
