### PR TITLE
Allow 3.5 training and inference

### DIFF
--- a/app/prisma/migrations/20231004070942_add_openai_fields_to_fine_tune/migration.sql
+++ b/app/prisma/migrations/20231004070942_add_openai_fields_to_fine_tune/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "FineTune" ADD COLUMN     "openaiModelId" TEXT,
+ADD COLUMN     "openaiTrainingJobId" TEXT;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -566,9 +566,11 @@ model FineTune {
     // Keep a GPU instance running for this fine-tune at all times. Expensive.
     keepWarm Boolean @default(false)
 
-    modalTrainingJobId String?
-    huggingFaceModelId String?
-    pipelineVersion    Int
+    modalTrainingJobId  String?
+    huggingFaceModelId  String?
+    openaiTrainingJobId String?
+    openaiModelId       String?
+    pipelineVersion     Int
 }
 
 model FineTuneTestingEntry {

--- a/app/src/components/datasets/validateTrainingRows.ts
+++ b/app/src/components/datasets/validateTrainingRows.ts
@@ -5,6 +5,11 @@ export type TrainingRow = {
   output?: ChatCompletionMessageParam;
 };
 
+export type ContentChatCompletionMessage = Omit<ChatCompletionMessageParam, "function_call">;
+export type OpenaiTrainingRow = {
+  messages: ContentChatCompletionMessage[];
+};
+
 export const parseJSONL = (jsonlString: string): unknown[] => {
   const lines = jsonlString.trim().split("\n");
 

--- a/app/src/components/fineTunes/ContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/ContentTabs/General/General.tsx
@@ -43,11 +43,14 @@ const General = () => {
               <Text w={180}>Created At:</Text>
               <Text color="gray.500">{dayjs(createdAt).format("MMMM D h:mm A")}</Text>
             </HStack>
-            <HStack>
+            <HStack alignItems="flex-start">
               <Text w={180}>Status:</Text>
-              <Text fontWeight="bold" color={getStatusColor(fineTune.status)}>
-                {fineTune.status}
-              </Text>
+              <VStack alignItems="flex-start">
+                <Text fontWeight="bold" color={getStatusColor(fineTune.status)}>
+                  {fineTune.status}
+                </Text>
+                {fineTune.errorMessage && <Text color="gray.500">{fineTune.errorMessage}</Text>}
+              </VStack>
             </HStack>
           </VStack>
         </ContentCard>

--- a/app/src/components/fineTunes/ContentTabs/TestSet/TestSetRow.tsx
+++ b/app/src/components/fineTunes/ContentTabs/TestSet/TestSetRow.tsx
@@ -37,7 +37,7 @@ const TestSetRow = ({
     <Tr
       alignItems="flex-start"
       sx={{
-        td: { verticalAlign: "top" },
+        td: { verticalAlign: "top", wordBreak: "break-word" },
       }}
     >
       <Td>

--- a/app/src/modelProviders/fine-tuned/getCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.ts
@@ -132,13 +132,18 @@ export const pruneInputMessages = (messages: ChatCompletionMessage[], stringsToP
     }
   }
   messages = messages.filter((message) => message.content !== "" || message.function_call);
-  return JSON.stringify(messages);
+  return messages;
 };
+
+export const pruneInputMessagesStringified = (
+  messages: ChatCompletionMessage[],
+  stringsToPrune: string[],
+) => JSON.stringify(pruneInputMessages(messages, stringsToPrune));
 
 export const templatePrompt = (input: ChatCompletionCreateParams, stringsToPrune: string[]) => {
   const { messages } = input;
 
-  const prunedInput = pruneInputMessages(messages, stringsToPrune);
+  const prunedInput = pruneInputMessagesStringified(messages, stringsToPrune);
 
   return `### Instruction:\n${prunedInput}\n### Response:`;
 };

--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -139,13 +139,7 @@ export const v1ApiRouter = createOpenApiRouter({
 
           return await getCompletion(reqPayload.data, fineTune.inferenceUrls, stringsToPrune);
         } else if (fineTune.pipelineVersion === 1) {
-          if (!fineTune.huggingFaceModelId) {
-            throw new TRPCError({
-              message: "The model is not set up for inference",
-              code: "BAD_REQUEST",
-            });
-          }
-          return await getCompletion2(fineTune.huggingFaceModelId, reqPayload.data, stringsToPrune);
+          return await getCompletion2(fineTune, reqPayload.data, stringsToPrune);
         } else {
           throw new TRPCError({
             message: "The model is not set up for inference",

--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { prisma } from "~/server/db";
 import { trainFineTune } from "~/server/tasks/fineTuning/trainFineTune.task";
+import { trainOpenaiFineTune } from "~/server/tasks/fineTuning/trainOpenaiFineTune.task";
 import { requireCanViewProject, requireCanModifyProject } from "~/utils/accessControl";
 import { SUPPORTED_BASE_MODELS } from "~/utils/baseModels";
 import { error, success } from "~/utils/errorHandling/standardResponses";
@@ -164,8 +165,11 @@ export const fineTunesRouter = createTRPCRouter({
           }),
         ),
       );
-
-      await trainFineTune.enqueue({ fineTuneId: fineTune.id });
+      if (fineTune.baseModel === "GPT_3_5_TURBO") {
+        await trainOpenaiFineTune.enqueue({ fineTuneId: fineTune.id });
+      } else {
+        await trainFineTune.enqueue({ fineTuneId: fineTune.id });
+      }
 
       return success();
     }),

--- a/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
@@ -28,8 +28,6 @@ const runOnce = async () => {
           });
           if (!fineTune) return;
 
-          await startTestJobs(fineTune);
-
           await prisma.fineTune.update({
             where: { id: job.id },
             data: {
@@ -37,6 +35,8 @@ const runOnce = async () => {
               status: "DEPLOYED",
             },
           });
+
+          await startTestJobs(fineTune);
         } else if (resp.status === "error") {
           await prisma.fineTune.update({
             where: { id: job.id },

--- a/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
@@ -1,11 +1,7 @@
-import { type ChatCompletionMessage } from "openai/resources/chat";
-
 import { prisma } from "~/server/db";
 import defineTask from "../defineTask";
 import { trainingStatus } from "~/utils/modal";
-import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
-import { countLlamaChatTokens } from "~/utils/countTokens";
-import { queueGetTestResult } from "../getTestResult.task";
+import { startTestJobs } from "~/server/utils/startTestJobs";
 
 const runOnce = async () => {
   const trainingJobs = await prisma.fineTune.findMany({
@@ -31,32 +27,8 @@ const runOnce = async () => {
             where: { id: job.id },
           });
           if (!fineTune) return;
-          const stringsToPrune = await getStringsToPrune(fineTune.id);
-          const datasetEntries = await prisma.datasetEntry.findMany({
-            where: { datasetId: fineTune.datasetId, outdated: false, type: "TEST" },
-            select: { id: true, input: true },
-            orderBy: { sortKey: "desc" },
-          });
-          // create fineTuneTestEntry for each dataset entry
-          await prisma.fineTuneTestingEntry.createMany({
-            data: datasetEntries.map((entry) => {
-              const prunedInput = pruneInputMessages(
-                entry.input as unknown as ChatCompletionMessage[],
-                stringsToPrune,
-              );
-              const prunedInputTokens = countLlamaChatTokens(prunedInput);
-              return {
-                fineTuneId: fineTune.id,
-                datasetEntryId: entry.id,
-                prunedInputTokens,
-                prunedInput,
-              };
-            }),
-            skipDuplicates: true,
-          });
-          for (const entry of datasetEntries) {
-            await queueGetTestResult(fineTune.id, entry.id);
-          }
+
+          await startTestJobs(fineTune);
 
           await prisma.fineTune.update({
             where: { id: job.id },
@@ -71,6 +43,7 @@ const runOnce = async () => {
             data: {
               trainingFinishedAt: new Date(),
               status: "ERROR",
+              errorMessage: "Training job failed",
             },
           });
         }

--- a/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
@@ -1,0 +1,79 @@
+import OpenAI from "openai";
+
+import { prisma } from "~/server/db";
+import defineTask from "../defineTask";
+import { startTestJobs } from "~/server/utils/startTestJobs";
+
+const runOnce = async () => {
+  const trainingOpenaiFineTunes = await prisma.fineTune.findMany({
+    where: {
+      status: {
+        in: ["TRAINING"],
+      },
+      openaiTrainingJobId: {
+        not: null,
+      },
+    },
+    include: {
+      project: {
+        include: {
+          apiKeys: true,
+        },
+      },
+    },
+  });
+
+  await Promise.all(
+    trainingOpenaiFineTunes.map(async (fineTune) => {
+      if (!fineTune.openaiTrainingJobId) {
+        throw new Error("No openaiTrainingJobId");
+      }
+      try {
+        const openaiApiKey = fineTune.project.apiKeys.find((key) => key.provider === "OPENAI")
+          ?.apiKey;
+
+        if (!openaiApiKey) {
+          await prisma.fineTune.update({
+            where: { id: fineTune.id },
+            data: {
+              status: "ERROR",
+              errorMessage: "No OpenAI API key found",
+            },
+          });
+          return;
+        }
+
+        const openai = new OpenAI({ apiKey: openaiApiKey });
+
+        const resp = await openai.fineTuning.jobs.retrieve(fineTune.openaiTrainingJobId);
+
+        if (resp.status === "succeeded" && resp.fine_tuned_model) {
+          await prisma.fineTune.update({
+            where: { id: fineTune.id },
+            data: {
+              openaiModelId: resp.fine_tuned_model,
+              status: "DEPLOYED",
+            },
+          });
+          await startTestJobs(fineTune);
+        } else if (resp.status === "failed") {
+          await prisma.fineTune.update({
+            where: { id: fineTune.id },
+            data: {
+              trainingFinishedAt: new Date(),
+              status: "ERROR",
+              errorMessage: "Failed to train model",
+            },
+          });
+        }
+      } catch (e) {
+        console.error(`Failed to check training status for model ${fineTune.id}`, e);
+        return;
+      }
+    }),
+  );
+};
+
+export const checkOpenaiFineTuneStatus = defineTask("checkOpenaiFineTuneStatus", async () => {
+  await runOnce();
+});

--- a/app/src/server/tasks/fineTuning/trainFineTune.task.ts
+++ b/app/src/server/tasks/fineTuning/trainFineTune.task.ts
@@ -6,7 +6,7 @@ import {
   FUNCTION_ARGS_TAG,
   FUNCTION_CALL_TAG,
   getStringsToPrune,
-  pruneInputMessages,
+  pruneInputMessagesStringified,
 } from "~/modelProviders/fine-tuned/getCompletion";
 import { env } from "~/env.mjs";
 import { startTraining } from "~/utils/modal";
@@ -96,7 +96,7 @@ export const trainFineTune = defineTask<TrainFineTuneJob>("trainFineTune", async
 });
 
 const formatTrainingRow = (row: TrainingRow, stringsToPrune: string[]) => {
-  const instruction = pruneInputMessages(row.input, stringsToPrune);
+  const instruction = pruneInputMessagesStringified(row.input, stringsToPrune);
   let output: string;
   if (row.output?.function_call) {
     output = FUNCTION_CALL_TAG + row.output.function_call.name;

--- a/app/src/server/tasks/fineTuning/trainOpenaiFineTune.task.ts
+++ b/app/src/server/tasks/fineTuning/trainOpenaiFineTune.task.ts
@@ -1,0 +1,127 @@
+import OpenAI from "openai";
+import fs from "fs";
+
+import { prisma } from "~/server/db";
+import defineTask from "../defineTask";
+import {
+  type ContentChatCompletionMessage,
+  type OpenaiTrainingRow,
+} from "~/components/datasets/validateTrainingRows";
+import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
+
+export type TrainOpenaiFineTuneJob = {
+  fineTuneId: string;
+};
+
+export const trainOpenaiFineTune = defineTask<TrainOpenaiFineTuneJob>(
+  "trainOpenaiFineTune",
+  async (task) => {
+    const { fineTuneId } = task;
+    const fineTune = await prisma.fineTune.findUnique({
+      where: { id: fineTuneId },
+      include: {
+        trainingEntries: {
+          select: {
+            datasetEntry: {
+              select: {
+                input: true,
+                output: true,
+              },
+            },
+          },
+        },
+        project: {
+          select: {
+            apiKeys: true,
+          },
+        },
+      },
+    });
+    if (!fineTune) return;
+
+    const openaiApiKey = fineTune.project.apiKeys.find((key) => key.provider === "OPENAI")?.apiKey;
+
+    if (!openaiApiKey) {
+      await prisma.fineTune.update({
+        where: { id: fineTuneId },
+        data: {
+          status: "ERROR",
+          errorMessage: "No OpenAI API key found",
+        },
+      });
+      return;
+    }
+
+    await prisma.fineTune.update({
+      where: { id: fineTuneId },
+      data: {
+        status: "TRANSFERRING_TRAINING_DATA",
+      },
+    });
+
+    const stringsToPrune = await getStringsToPrune(fineTune.id);
+
+    const trainingEntries = fineTune.trainingEntries.map((entry) => ({
+      messages: [
+        ...pruneInputMessages(
+          entry.datasetEntry.input as unknown as ContentChatCompletionMessage[],
+          stringsToPrune,
+        ),
+        entry.datasetEntry.output,
+      ],
+    })) as unknown as OpenaiTrainingRow[];
+
+    const jsonlStr = trainingEntries.map((row) => JSON.stringify(row)).join("\n");
+
+    const openai = new OpenAI({ apiKey: openaiApiKey });
+
+    // write jsonlStr to temp file using fs
+    const tempDirPath = `/tmp/${fineTuneId}`;
+
+    const trainingFilePath = `${tempDirPath}/training.jsonl`;
+    // TODO: Include validation file
+
+    fs.mkdirSync(tempDirPath, { recursive: true });
+    fs.writeFileSync(trainingFilePath, jsonlStr);
+
+    try {
+      const trainingFile = await openai.files.create({
+        file: fs.createReadStream(trainingFilePath),
+        purpose: "fine-tune",
+      });
+
+      console.log("uploaded training file", trainingFile);
+
+      await prisma.fineTune.update({
+        where: { id: fineTuneId },
+        data: {
+          status: "TRAINING",
+          trainingStartedAt: new Date(),
+        },
+      });
+
+      const fineTuneJob = await openai.fineTuning.jobs.create({
+        training_file: trainingFile.id,
+        model: "gpt-3.5-turbo",
+      });
+
+      await prisma.fineTune.update({
+        where: { id: fineTuneId },
+        data: {
+          openaiTrainingJobId: fineTuneJob.id,
+        },
+      });
+    } catch (e) {
+      console.error("Failed to start openai training", e);
+      await prisma.fineTune.update({
+        where: { id: fineTuneId },
+        data: {
+          status: "ERROR",
+          errorMessage: (e as Error).message,
+        },
+      });
+    } finally {
+      fs.unlinkSync(trainingFilePath);
+    }
+  },
+);

--- a/app/src/server/tasks/worker.ts
+++ b/app/src/server/tasks/worker.ts
@@ -7,7 +7,9 @@ import { queryModel } from "./queryModel.task";
 import { runNewEval } from "./runNewEval.task";
 import { importDatasetEntries } from "./importDatasetEntries.task";
 import { trainFineTune } from "./fineTuning/trainFineTune.task";
+import { trainOpenaiFineTune } from "./fineTuning/trainOpenaiFineTune.task";
 import { checkFineTuneStatus } from "./fineTuning/checkFineTuneStatus.task";
+import { checkOpenaiFineTuneStatus } from "./fineTuning/checkOpenaiFineTuneStatus.task";
 import { getTestResult } from "./getTestResult.task";
 import type defineTask from "./defineTask";
 
@@ -18,7 +20,9 @@ const registeredTasks: ReturnType<typeof defineTask<any>>[] = [
   runNewEval,
   importDatasetEntries,
   trainFineTune,
+  trainOpenaiFineTune,
   checkFineTuneStatus,
+  checkOpenaiFineTuneStatus,
   getTestResult,
 ];
 
@@ -42,6 +46,15 @@ const runner = await run({
       // run once a minute for now
       pattern: "* * * * *",
       identifier: checkFineTuneStatus.task.identifier,
+      options: {
+        backfillPeriod: 1000 * 60,
+      },
+    },
+    {
+      task: checkOpenaiFineTuneStatus.task.identifier,
+      // run once a minute for now
+      pattern: "* * * * *",
+      identifier: checkOpenaiFineTuneStatus.task.identifier,
       options: {
         backfillPeriod: 1000 * 60,
       },

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -1,0 +1,41 @@
+import { type FineTune } from "@prisma/client";
+import { type ChatCompletionMessage } from "openai/resources/chat";
+
+import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
+import { prisma } from "../db";
+import { countLlamaChatTokens, countOpenAIChatTokens } from "~/utils/countTokens";
+import { queueGetTestResult } from "../tasks/getTestResult.task";
+
+export const startTestJobs = async (fineTune: FineTune) => {
+  const stringsToPrune = await getStringsToPrune(fineTune.id);
+  const datasetEntries = await prisma.datasetEntry.findMany({
+    where: { datasetId: fineTune.datasetId, outdated: false, type: "TEST" },
+    select: { id: true, input: true },
+    orderBy: { sortKey: "desc" },
+  });
+  // create fineTuneTestEntry for each dataset entry
+  await prisma.fineTuneTestingEntry.createMany({
+    data: datasetEntries.map((entry) => {
+      const prunedInput = pruneInputMessages(
+        entry.input as unknown as ChatCompletionMessage[],
+        stringsToPrune,
+      );
+      let prunedInputTokens;
+      if (fineTune.baseModel === "GPT_3_5_TURBO") {
+        prunedInputTokens = countOpenAIChatTokens("gpt-3.5-turbo-0613", prunedInput);
+      } else {
+        prunedInputTokens = countLlamaChatTokens(JSON.stringify(prunedInput));
+      }
+      return {
+        fineTuneId: fineTune.id,
+        datasetEntryId: entry.id,
+        prunedInputTokens,
+        prunedInput: JSON.stringify(prunedInput),
+      };
+    }),
+    skipDuplicates: true,
+  });
+  for (const entry of datasetEntries) {
+    await queueGetTestResult(fineTune.id, entry.id);
+  }
+};

--- a/app/src/utils/baseModels.ts
+++ b/app/src/utils/baseModels.ts
@@ -16,6 +16,6 @@ export const displayBaseModel = (baseModel: BaseModel) => {
     case "LLAMA2_70b":
       return "llama2-70b";
     case "GPT_3_5_TURBO":
-      return "gpt3-5-turbo";
+      return "gpt-3.5-turbo";
   }
 };


### PR DESCRIPTION
This PR includes code to train and run inference against a fine-tuned GPT 3.5 model.

### Changes
* Add `openaiTrainingJobId` and `openaiModelId` to FineTune
* Break `getCompletion2` into `getOpenaiCompletion` and `getLlamaCompletion`
* Add `TrainOpenaiFineTune` and `checkOpenaiFineTuneStatus` tasks
* Call `checkOpenaiFineTuneStatus` once a minute
* Move test starting code into `startTestJobs` file