### PR TITLE
Honor openai timeout in typescript sdk

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -84,7 +84,7 @@
     "nextjs-routes": "^2.0.1",
     "nodemailer": "^6.9.4",
     "openai": "4.8.0",
-    "openpipe": "0.4.3",
+    "openpipe": "0.4.4",
     "openpipe-dev": "workspace:^",
     "pg": "^8.11.2",
     "pluralize": "^8.0.0",

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {

--- a/client-libs/typescript/src/openai.ts
+++ b/client-libs/typescript/src/openai.ts
@@ -13,7 +13,7 @@ import type {
 import { WrappedStream } from "./openai/streaming";
 import { DefaultService, OPClient } from "./codegen";
 import type { Stream } from "openai/streaming";
-import { OpenPipeArgs, OpenPipeMeta, type OpenPipeConfig, getTags } from "./shared";
+import { OpenPipeArgs, OpenPipeMeta, type OpenPipeConfig, getTags, withTimeout } from "./shared";
 
 export type ClientOptions = openai.ClientOptions & { openpipe?: OpenPipeConfig };
 export default class OpenAI extends openai.OpenAI {
@@ -50,10 +50,13 @@ class WrappedChat extends openai.OpenAI.Chat {
 }
 
 class WrappedCompletions extends openai.OpenAI.Chat.Completions {
+  // keep a reference to the original client so we can read options from it
+  openaiClient: openai.OpenAI;
   opClient?: OPClient;
 
   constructor(client: openai.OpenAI, opClient?: OPClient) {
     super(client);
+    this.openaiClient = client;
     this.opClient = opClient;
   }
 
@@ -79,13 +82,17 @@ class WrappedCompletions extends openai.OpenAI.Chat.Completions {
     body: ChatCompletionCreateParams,
     options?: Core.RequestOptions,
   ): Core.APIPromise<ChatCompletion | Stream<ChatCompletionChunk>> {
-    let resp;
+    let resp: Core.APIPromise<ChatCompletion | Stream<ChatCompletionChunk>>;
+
     if (body.model.startsWith("openpipe:")) {
-      // @ts-expect-error looks like OpenAI has added more client functionality
-      // we'll need to match. For now, we'll just ignore the type error.
-      resp = this.opClient?.default.createChatCompletion({
+      if (!this.opClient) throw new Error("OpenPipe client not set");
+      const opClientPromise = this.opClient.default.createChatCompletion({
         reqPayload: body,
-      }) as Core.APIPromise<ChatCompletion>;
+      });
+      resp = withTimeout(
+        opClientPromise,
+        options?.timeout ?? this.openaiClient.timeout,
+      ) as Core.APIPromise<ChatCompletion>;
     } else {
       resp = body.stream ? super.create(body, options) : super.create(body, options);
     }

--- a/client-libs/typescript/src/shared.ts
+++ b/client-libs/typescript/src/shared.ts
@@ -1,3 +1,4 @@
+import { APIConnectionTimeoutError } from "openai/error";
 import pkg from "../package.json";
 
 import { DefaultService } from "./codegen";
@@ -28,3 +29,22 @@ export const getTags = (args: OpenPipeArgs["openpipe"]): Record<string, string> 
   $sdk: "typescript",
   "$sdk.version": pkg.version,
 });
+
+export const withTimeout = <T>(promise: Promise<T>, timeout: number): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    // Set up the timeout
+    const timeoutId = setTimeout(() => {
+      reject(new APIConnectionTimeoutError({ message: "Request timed out" }));
+    }, timeout);
+
+    promise
+      .then((result) => {
+        clearTimeout(timeoutId);
+        resolve(result);
+      })
+      .catch((error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      });
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: 4.8.0
         version: 4.8.0(encoding@0.1.13)
       openpipe:
-        specifier: 0.4.3
-        version: 0.4.3
+        specifier: 0.4.4
+        version: 0.4.4
       openpipe-dev:
         specifier: workspace:^
         version: link:../client-libs/typescript
@@ -7905,8 +7905,8 @@ packages:
       oidc-token-hash: 5.0.3
     dev: false
 
-  /openpipe@0.4.3:
-    resolution: {integrity: sha512-GWvsOpbNmE83n2Ov/OEi3FEDn/dBv4pRspXZcVVZQn3SOmNMhFKlEbaUX5Mnzv+Me3KvA2j5xOSYkHguvKqCQw==}
+  /openpipe@0.4.4:
+    resolution: {integrity: sha512-L9Rqt7eBT9HWjflV87cHFQFnLTr/Ep09n5SYlJwbJpfBLjaIzpyKEsXNZ9PCPJnmZeoIFYyoT3ivkbtESdqebg==}
     dependencies:
       encoding: 0.1.13
       form-data: 4.0.0


### PR DESCRIPTION
Throw an error in the TypeScript SDK if the completion request takes longer than the amount of time specified in the [timeout](https://www.npmjs.com/package/openai#timeouts) field.

### Changes
* Add `withTimeout` function
* Query request or openai client-level timeout value
* Throw an error if the request takes longer than the configured timeout value
* Update package.json to version `0.4.4`