### PR TITLE
Cancel request promise on timeout

### DIFF
--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {

--- a/client-libs/typescript/src/openai.ts
+++ b/client-libs/typescript/src/openai.ts
@@ -89,9 +89,8 @@ class WrappedCompletions extends openai.OpenAI.Chat.Completions {
       const opClientPromise = this.opClient.default.createChatCompletion({
         reqPayload: body,
       });
-      resp = withTimeout(
-        opClientPromise,
-        options?.timeout ?? this.openaiClient.timeout,
+      resp = withTimeout(opClientPromise, options?.timeout ?? this.openaiClient.timeout, () =>
+        opClientPromise.cancel(),
       ) as Core.APIPromise<ChatCompletion>;
     } else {
       resp = body.stream ? super.create(body, options) : super.create(body, options);

--- a/client-libs/typescript/src/shared.ts
+++ b/client-libs/typescript/src/shared.ts
@@ -30,10 +30,15 @@ export const getTags = (args: OpenPipeArgs["openpipe"]): Record<string, string> 
   "$sdk.version": pkg.version,
 });
 
-export const withTimeout = <T>(promise: Promise<T>, timeout: number): Promise<T> => {
+export const withTimeout = <T>(
+  promise: Promise<T>,
+  timeout: number,
+  onTimedOut?: () => void,
+): Promise<T> => {
   return new Promise((resolve, reject) => {
     // Set up the timeout
     const timeoutId = setTimeout(() => {
+      onTimedOut?.();
       reject(new APIConnectionTimeoutError({ message: "Request timed out" }));
     }, timeout);
 


### PR DESCRIPTION
This PR ensures that the original request is cancelled after `timeout` in the typescript SDK. Forgot this step in #274.