### PR TITLE
Roll back beta barriers 

### DIFF
--- a/app/src/components/ActionButton.tsx
+++ b/app/src/components/ActionButton.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-
 import { Button, HStack, type ButtonProps, Icon, Text } from "@chakra-ui/react";
 import { type IconType } from "react-icons";
-import { useAppStore } from "~/state/store";
+
 import { BetaModal } from "./BetaModal";
+import { useIsMissingBetaAccess } from "~/utils/hooks";
 
 const ActionButton = ({
   icon,
@@ -19,12 +19,11 @@ const ActionButton = ({
   requireBeta?: boolean;
   onClick?: () => void;
 } & ButtonProps) => {
-  const flags = useAppStore((s) => s.featureFlags.featureFlags);
-  const flagsLoaded = useAppStore((s) => s.featureFlags.flagsLoaded);
+  const isMissingBetaAccess = useIsMissingBetaAccess();
 
   const [betaModalOpen, setBetaModalOpen] = useState(false);
 
-  const isBetaBlocked = requireBeta && flagsLoaded && !flags.betaAccess;
+  const isBetaBlocked = requireBeta && isMissingBetaAccess;
   return (
     <>
       <Button
@@ -41,9 +40,7 @@ const ActionButton = ({
         {...buttonProps}
       >
         <HStack spacing={1}>
-          {icon && (
-            <Icon as={icon} boxSize={iconBoxSize} color={requireBeta ? "orange.400" : undefined} />
-          )}
+          {icon && <Icon as={icon} boxSize={iconBoxSize} color="orange.400" />}
           <Text display={{ base: "none", md: "flex" }}>{label}</Text>
         </HStack>
       </Button>

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -25,6 +25,7 @@ const BetaBanner = () => {
       borderColor="gray.300"
       py={2}
       px={8}
+      display={{ base: "none", md: "flex" }}
     >
       <HStack>
         <Icon as={BsStars} color="orange.400" />

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -1,0 +1,53 @@
+import { HStack, Text, Icon, Button, Link } from "@chakra-ui/react";
+import { BsStars } from "react-icons/bs";
+import { useSession } from "next-auth/react";
+import { useIsMissingBetaAccess } from "~/utils/hooks";
+import { useAppStore } from "~/state/store";
+
+const BetaBanner = () => {
+  const session = useSession();
+
+  const isMissingBetaAccess = useIsMissingBetaAccess();
+  const betaBannerDismissed = useAppStore((state) => state.betaBannerDismissed);
+  const dismissBetaBanner = useAppStore((state) => state.dismissBetaBanner);
+
+  if (!isMissingBetaAccess || betaBannerDismissed) {
+    return null;
+  }
+
+  const email = session.data?.user.email ?? "";
+  return (
+    <HStack
+      w="full"
+      justifyContent="space-between"
+      bgColor="white"
+      borderBottom="1px solid"
+      borderColor="gray.300"
+      py={2}
+      px={8}
+    >
+      <HStack>
+        <Icon as={BsStars} color="orange.400" />
+        <Text>
+          Fine-tuning Llama2 models is currently in beta. To receive early access to beta-only
+          features,{" "}
+          <Link
+            href={`https://ax3nafkw0jp.typeform.com/to/ZNpYqvAc#email=${email}`}
+            target="_blank"
+            color="orange.400"
+          >
+            join the waitlist
+          </Link>
+          .
+        </Text>
+      </HStack>
+      <HStack>
+        <Button variant="outline" colorScheme="gray" onClick={dismissBetaBanner}>
+          Dismiss
+        </Button>
+      </HStack>
+    </HStack>
+  );
+};
+
+export default BetaBanner;

--- a/app/src/components/datasets/DeleteButton.tsx
+++ b/app/src/components/datasets/DeleteButton.tsx
@@ -35,7 +35,6 @@ const DeleteButton = () => {
         label="Delete"
         icon={BsTrash}
         isDisabled={selectedIds.size === 0}
-        requireBeta
       />
       <DeleteDatasetEntriesModal disclosure={disclosure} />
     </>

--- a/app/src/components/datasets/UploadDataButton.tsx
+++ b/app/src/components/datasets/UploadDataButton.tsx
@@ -36,7 +36,6 @@ const UploadDataButton = () => {
         label="Upload Data"
         icon={AiOutlineCloudUpload}
         iconBoxSize={4}
-        requireBeta
       />
       <UploadDataModal disclosure={disclosure} />
     </>

--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -25,7 +25,7 @@ import ProjectMenu from "./ProjectMenu";
 import NavSidebarOption from "./NavSidebarOption";
 import IconLink from "./IconLink";
 import { BetaModal } from "../BetaModal";
-import { useAppStore } from "~/state/store";
+import { useIsMissingBetaAccess } from "~/utils/hooks";
 
 const Divider = () => <Box h="1px" bgColor="gray.300" w="full" />;
 
@@ -187,8 +187,7 @@ export default function AppShell({
     }
   }, [requireAuth, user, authLoading]);
 
-  const flags = useAppStore((s) => s.featureFlags.featureFlags);
-  const flagsLoaded = useAppStore((s) => s.featureFlags.flagsLoaded);
+  const isMissingBetaAccess = useIsMissingBetaAccess();
 
   return (
     <>
@@ -201,7 +200,7 @@ export default function AppShell({
           {children}
         </Box>
       </Flex>
-      <BetaModal isOpen={!!requireBeta && flagsLoaded && !flags.betaAccess} onClose={router.back} />
+      <BetaModal isOpen={!!requireBeta && isMissingBetaAccess} onClose={router.back} />
     </>
   );
 }

--- a/app/src/components/projectSettings/UpdateOpenaiApiKeyModal.tsx
+++ b/app/src/components/projectSettings/UpdateOpenaiApiKeyModal.tsx
@@ -45,7 +45,7 @@ const UpdateOpenaiApiKeyModal = ({ disclosure }: { disclosure: UseDisclosureRetu
   }, [updateProjectMutation, selectedProject?.id, apiKey, disclosure.onClose]);
 
   return (
-    <Modal {...disclosure}>
+    <Modal size={{ base: "lg", md: "xl" }} {...disclosure}>
       <ModalOverlay />
       <ModalContent w={1200}>
         <ModalHeader>

--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -40,7 +40,6 @@ const AddToDatasetButton = () => {
         label="Add to Dataset"
         icon={FiPlusSquare}
         isDisabled={selectedLogIds.size === 0}
-        requireBeta
       />
       <AddToDatasetModal disclosure={disclosure} />
     </>

--- a/app/src/pages/datasets/[id].tsx
+++ b/app/src/pages/datasets/[id].tsx
@@ -29,6 +29,7 @@ import UploadDataButton from "~/components/datasets/UploadDataButton";
 // import DownloadButton from "~/components/datasets/DownloadButton";
 import DeleteButton from "~/components/datasets/DeleteButton";
 import FileUploadsCard from "~/components/datasets/FileUploadsCard";
+import BetaBanner from "~/components/BetaBanner";
 
 export default function Dataset() {
   const utils = api.useContext();
@@ -70,6 +71,7 @@ export default function Dataset() {
     <>
       <AppShell title={dataset.data?.name}>
         <VStack h="full" overflowY="scroll">
+          <BetaBanner />
           <PageHeaderContainer>
             <Breadcrumb>
               <BreadcrumbItem>

--- a/app/src/pages/fine-tunes/index.tsx
+++ b/app/src/pages/fine-tunes/index.tsx
@@ -5,7 +5,7 @@ import AppShell from "~/components/nav/AppShell";
 
 export default function FineTunes() {
   return (
-    <AppShell title="Fine Tunes" requireAuth requireBeta>
+    <AppShell title="Fine Tunes" requireAuth>
       <VStack px={8} py={8} alignItems="flex-start" spacing={4} w="full">
         <Text fontSize="2xl" fontWeight="bold">
           Fine Tunes

--- a/app/src/pages/fine-tunes/index.tsx
+++ b/app/src/pages/fine-tunes/index.tsx
@@ -1,4 +1,5 @@
 import { Text, VStack, Divider } from "@chakra-ui/react";
+import BetaBanner from "~/components/BetaBanner";
 import FineTunesTable from "~/components/fineTunes/FineTunesTable";
 
 import AppShell from "~/components/nav/AppShell";
@@ -6,6 +7,7 @@ import AppShell from "~/components/nav/AppShell";
 export default function FineTunes() {
   return (
     <AppShell title="Fine Tunes" requireAuth>
+      <BetaBanner />
       <VStack px={8} py={8} alignItems="flex-start" spacing={4} w="full">
         <Text fontSize="2xl" fontWeight="bold">
           Fine Tunes

--- a/app/src/state/persist.ts
+++ b/app/src/state/persist.ts
@@ -11,6 +11,7 @@ export const persistOptions: PersistOptions<State, PersistedState> = {
   partialize: (state) => ({
     selectedProjectId: state.selectedProjectId,
     columnVisibility: pick(state.columnVisibility, ["visibleColumns"]),
+    betaBannerDismissed: state.betaBannerDismissed,
   }),
   merge: (saved, state) => merge(state, saved),
   storage: {

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -28,6 +28,8 @@ export type State = {
   isRehydrated: boolean;
   api: APIClient | null;
   setApi: (api: APIClient) => void;
+  betaBannerDismissed: boolean;
+  dismissBetaBanner: () => void;
   sharedVariantEditor: SharedVariantEditorSlice;
   sharedArgumentsEditor: SharedArgumentsEditorSlice;
   selectedProjectId: string | null;
@@ -52,6 +54,11 @@ const useBaseStore = create<State, [["zustand/persist", PersistedState], ["zusta
       setApi: (api) =>
         set((state) => {
           state.api = api;
+        }),
+      betaBannerDismissed: false,
+      dismissBetaBanner: () =>
+        set((state) => {
+          state.betaBannerDismissed = true;
         }),
       sharedVariantEditor: createVariantEditorSlice(set, get, ...rest),
       sharedArgumentsEditor: createArgumentsEditorSlice(set, get, ...rest),

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -105,6 +105,14 @@ export const useElementDimensions = (): [RefObject<HTMLElement>, Dimensions | un
   return [ref, dimensions];
 };
 
+export const useIsMissingBetaAccess = () => {
+  const flags = useAppStore((s) => s.featureFlags.featureFlags);
+  const flagsLoaded = useAppStore((s) => s.featureFlags.flagsLoaded);
+
+  // If the flags haven't loaded yet, we can't say for sure that the user doesn't have beta access
+  return flagsLoaded && !flags?.betaAccess;
+};
+
 export const usePageParams = () => {
   const router = useRouter();
 


### PR DESCRIPTION
Ensure that OpenAI API key is set before attempting to fine-tune GPT 3.5. This PR also includes a roll-back of beta walls, so that everything except fine-tuning Llama2 models is now in GA.

### Changes
* Require OpenAI API key to fine-tune 3.5
* Allow non-beta users to create datasets and fine-tune GPT 3.5 models
* Add beta block in front of fine-tuning Llama2 models
* Add beta banner

Message requiring OpenAI API key to fine-tune 3.5:
![Screenshot 2023-10-06 at 6 40 24 PM](https://github.com/OpenPipe/OpenPipe/assets/41524992/609126c2-e70c-4a7f-bb07-fcda986245a5)


Message requiring beta access to fine-tune Llama2:
![Screenshot 2023-10-06 at 6 40 07 PM](https://github.com/OpenPipe/OpenPipe/assets/41524992/c0976981-060a-4a19-a0a0-c5359725ca11)

Beta banner:
![Screenshot 2023-10-06 at 6 39 47 PM](https://github.com/OpenPipe/OpenPipe/assets/41524992/cb0a02d3-e62b-470d-91a8-59db61d16b18)