### PR TITLE
Remove console.error after reporting fails

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -87,7 +87,7 @@
     "nextjs-routes": "^2.0.1",
     "nodemailer": "^6.9.4",
     "openai": "4.8.0",
-    "openpipe": "0.4.4",
+    "openpipe": "0.4.6",
     "openpipe-dev": "workspace:^",
     "pg": "^8.11.2",
     "pluralize": "^8.0.0",

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {

--- a/client-libs/typescript/src/openai.ts
+++ b/client-libs/typescript/src/openai.ts
@@ -64,9 +64,7 @@ class WrappedCompletions extends openai.OpenAI.Chat.Completions {
     try {
       this.opClient ? await this.opClient.default.report(args) : Promise.resolve();
     } catch (e) {
-      console.error(
-        "OpenPipe: we ran into an error when trying to report usage data back to our servers. Don't worry, your completion still went through as intended and we've logged this on our side for further review.",
-      );
+      // Ignore errors with reporting
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: 4.8.0
         version: 4.8.0(encoding@0.1.13)
       openpipe:
-        specifier: 0.4.4
-        version: 0.4.4
+        specifier: 0.4.6
+        version: 0.4.6
       openpipe-dev:
         specifier: workspace:^
         version: link:../client-libs/typescript
@@ -7921,8 +7921,8 @@ packages:
       oidc-token-hash: 5.0.3
     dev: false
 
-  /openpipe@0.4.4:
-    resolution: {integrity: sha512-L9Rqt7eBT9HWjflV87cHFQFnLTr/Ep09n5SYlJwbJpfBLjaIzpyKEsXNZ9PCPJnmZeoIFYyoT3ivkbtESdqebg==}
+  /openpipe@0.4.6:
+    resolution: {integrity: sha512-hqCgMVGx4BfwOVmymxswCorshf7Vrhl2mBKh2GmIEexu+gTKxyxIZe3YHXPXsfectLRUz1PJPs3eF2r3iUPtJw==}
     dependencies:
       encoding: 0.1.13
       form-data: 4.0.0


### PR DESCRIPTION
Getting a console.error in the logs made it seem as though inference might be failing when in reality only reporting was unable to be completed.