### PR TITLE
Add `beforeEnqueue` to task defs

### DIFF
--- a/app/scripts/repl.ts
+++ b/app/scripts/repl.ts
@@ -9,7 +9,7 @@ import { ChatCompletionCreateParams, ChatCompletionMessage } from "openai/resour
 import { calculateEntryScore } from "~/server/utils/calculateEntryScore";
 import { getCompletion2 } from "~/modelProviders/fine-tuned/getCompletion-2";
 import { pick } from "lodash-es";
-import { getTestResult } from "~/server/tasks/getTestResult.task";
+import { evaluateTestSetEntry } from "~/server/tasks/evaluateTestSetEntry.task";
 
 const setGlobal = (key: string, value: any) => {
   (global as any)[key] = value;

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -15,7 +15,7 @@ import hashObject from "~/server/utils/hashObject";
 import { type JsonValue } from "type-fest";
 import { formatEntriesFromTrainingRows } from "~/server/utils/createEntriesFromTrainingRows";
 import { updatePruningRuleMatches } from "~/server/utils/updatePruningRuleMatches";
-import { getTestResult } from "~/server/tasks/getTestResult.task";
+import { evaluateTestSetEntry } from "~/server/tasks/evaluateTestSetEntry.task";
 import { validatedChatInput, validatedChatOutput } from "~/modelProviders/fine-tuned/utils";
 import { truthyFilter } from "~/utils/utils";
 
@@ -362,7 +362,10 @@ export const datasetEntriesRouter = createTRPCRouter({
           },
         });
         for (const fineTune of fineTunes) {
-          await getTestResult.enqueue({ fineTuneId: fineTune.id, datasetEntryId: newEntry.id });
+          await evaluateTestSetEntry.enqueue({
+            fineTuneId: fineTune.id,
+            datasetEntryId: newEntry.id,
+          });
         }
       }
 

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -15,7 +15,7 @@ import hashObject from "~/server/utils/hashObject";
 import { type JsonValue } from "type-fest";
 import { formatEntriesFromTrainingRows } from "~/server/utils/createEntriesFromTrainingRows";
 import { updatePruningRuleMatches } from "~/server/utils/updatePruningRuleMatches";
-import { queueGetTestResult } from "~/server/tasks/getTestResult.task";
+import { getTestResult } from "~/server/tasks/getTestResult.task";
 import { validatedChatInput, validatedChatOutput } from "~/modelProviders/fine-tuned/utils";
 import { truthyFilter } from "~/utils/utils";
 
@@ -362,7 +362,7 @@ export const datasetEntriesRouter = createTRPCRouter({
           },
         });
         for (const fineTune of fineTunes) {
-          await queueGetTestResult(fineTune.id, newEntry.id);
+          await getTestResult.enqueue({ fineTuneId: fineTune.id, datasetEntryId: newEntry.id });
         }
       }
 

--- a/app/src/server/api/routers/datasets.router.ts
+++ b/app/src/server/api/routers/datasets.router.ts
@@ -5,7 +5,7 @@ import { prisma } from "~/server/db";
 import { requireCanModifyProject, requireCanViewProject } from "~/utils/accessControl";
 import { error, success } from "~/utils/errorHandling/standardResponses";
 import { generateBlobUploadUrl } from "~/utils/azure/server";
-import { queueImportDatasetEntries } from "~/server/tasks/importDatasetEntries.task";
+import { importDatasetEntries } from "~/server/tasks/importDatasetEntries.task";
 import { env } from "~/env.mjs";
 
 export const datasetsRouter = createTRPCRouter({
@@ -150,7 +150,7 @@ export const datasetsRouter = createTRPCRouter({
         },
       });
 
-      await queueImportDatasetEntries(id);
+      await importDatasetEntries.enqueue({ datasetFileUploadId: id });
     }),
   listFileUploads: protectedProcedure
     .input(z.object({ datasetId: z.string() }))

--- a/app/src/server/api/routers/evaluations.router.ts
+++ b/app/src/server/api/routers/evaluations.router.ts
@@ -2,7 +2,7 @@ import { EvalType } from "@prisma/client";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "~/server/api/trpc";
 import { prisma } from "~/server/db";
-import { queueRunNewEval } from "~/server/tasks/runNewEval.task";
+import { runNewEval } from "~/server/tasks/runNewEval.task";
 import { requireCanModifyExperiment, requireCanViewExperiment } from "~/utils/accessControl";
 
 export const evaluationsRouter = createTRPCRouter({
@@ -40,7 +40,7 @@ export const evaluationsRouter = createTRPCRouter({
         },
       });
 
-      await queueRunNewEval(input.experimentId);
+      await runNewEval.enqueue({ experimentId: input.experimentId });
     }),
 
   update: protectedProcedure
@@ -76,7 +76,7 @@ export const evaluationsRouter = createTRPCRouter({
       });
       // Re-run all evals. Other eval results will already be cached, so this
       // should only re-run the updated one.
-      await queueRunNewEval(experimentId);
+      await runNewEval.enqueue({ experimentId: experimentId });
     }),
 
   delete: protectedProcedure

--- a/app/src/server/scripts/backfillTestingDatasets.ts
+++ b/app/src/server/scripts/backfillTestingDatasets.ts
@@ -1,5 +1,5 @@
 import { prisma } from "~/server/db";
-import { getTestResult } from "../tasks/getTestResult.task";
+import { evaluateTestSetEntry } from "../tasks/evaluateTestSetEntry.task";
 
 if (!process.argv[2]) {
   console.error("please provide a fineTuneId");
@@ -41,7 +41,7 @@ if (!fineTune) {
 let numEntries = 0;
 
 for (const entry of fineTune.dataset.datasetEntries) {
-  await getTestResult.enqueue({
+  await evaluateTestSetEntry.enqueue({
     fineTuneId: fineTune.id,
     datasetEntryId: entry.id,
     skipCache: true,

--- a/app/src/server/scripts/backfillTestingDatasets.ts
+++ b/app/src/server/scripts/backfillTestingDatasets.ts
@@ -1,5 +1,5 @@
 import { prisma } from "~/server/db";
-import { queueGetTestResult } from "../tasks/getTestResult.task";
+import { getTestResult } from "../tasks/getTestResult.task";
 
 if (!process.argv[2]) {
   console.error("please provide a fineTuneId");
@@ -41,7 +41,11 @@ if (!fineTune) {
 let numEntries = 0;
 
 for (const entry of fineTune.dataset.datasetEntries) {
-  await queueGetTestResult(fineTune.id, entry.id, true);
+  await getTestResult.enqueue({
+    fineTuneId: fineTune.id,
+    datasetEntryId: entry.id,
+    skipCache: true,
+  });
   numEntries++;
 }
 

--- a/app/src/server/tasks/defineTask.ts
+++ b/app/src/server/tasks/defineTask.ts
@@ -1,4 +1,5 @@
 import { type Helpers, type Task, makeWorkerUtils, type TaskSpec } from "graphile-worker";
+import { merge } from "lodash-es";
 import { env } from "~/env.mjs";
 
 let workerUtilsPromise: ReturnType<typeof makeWorkerUtils> | null = null;
@@ -12,33 +13,38 @@ function workerUtils() {
   return workerUtilsPromise;
 }
 
-function defineTask<TPayload>(
-  taskIdentifier: string,
-  taskHandler: (payload: TPayload, helpers: Helpers) => Promise<void>,
-) {
+function defineTask<TPayload>(options: {
+  id: string;
+  handler: (payload: TPayload, helpers: Helpers) => Promise<void>;
+
+  // This is run in the caller's process before the task is enqueued. Ensure
+  // that nothing long-running happens here.
+  beforeEnqueue?: (payload: TPayload) => Promise<void>;
+
+  // Default values for things like `priority` and `maxAttempts`.
+  specDefaults?: TaskSpec;
+}) {
   const enqueue = async (payload: TPayload, spec?: TaskSpec) => {
-    // console.log("Enqueuing task", taskIdentifier, payload);
+    const mergedSpec = merge({}, options.specDefaults, spec);
+
+    await options.beforeEnqueue?.(payload);
 
     const utils = await workerUtils();
-    return await utils.addJob(taskIdentifier, payload, spec);
+    return await utils.addJob(options.id, payload, mergedSpec);
   };
 
   const handler = (payload: TPayload, helpers: Helpers) => {
-    helpers.logger.debug(`Running task ${taskIdentifier} with payload: ${JSON.stringify(payload)}`);
-    return taskHandler(payload, helpers);
+    helpers.logger.debug(`Running task ${options.id} with payload: ${JSON.stringify(payload)}`);
+    return options.handler(payload, helpers);
   };
 
   const task = {
-    identifier: taskIdentifier,
+    identifier: options.id,
     handler: handler as Task,
   };
 
   return {
-    runNow: async (payload: TPayload) => {
-      const utils = await workerUtils();
-
-      return taskHandler(payload, utils);
-    },
+    runNow: async (payload: TPayload) => options.handler(payload, await workerUtils()),
     enqueue,
     task,
   };

--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -15,14 +15,14 @@ import { getCompletion2 } from "~/modelProviders/fine-tuned/getCompletion-2";
 import { calculateEntryScore } from "../utils/calculateEntryScore";
 import { validatedChatInput } from "~/modelProviders/fine-tuned/utils";
 
-export type GetTestResultJob = {
+export type EvaluateTestSetEntryJob = {
   fineTuneId: string;
   datasetEntryId: string;
   skipCache?: boolean;
 };
 
-export const getTestResult = defineTask<GetTestResultJob>({
-  id: "getTestResult",
+export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
+  id: "evaluateTestSetEntry",
   handler: async (task) => {
     const { fineTuneId, datasetEntryId, skipCache } = task;
 

--- a/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
@@ -63,6 +63,9 @@ const runOnce = async () => {
   );
 };
 
-export const checkFineTuneStatus = defineTask("checkFineTuneStatus", async () => {
-  await runOnce();
+export const checkFineTuneStatus = defineTask({
+  id: "checkFineTuneStatus",
+  handler: async () => {
+    await runOnce();
+  },
 });

--- a/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
@@ -77,6 +77,9 @@ const runOnce = async () => {
   );
 };
 
-export const checkOpenaiFineTuneStatus = defineTask("checkOpenaiFineTuneStatus", async () => {
-  await runOnce();
+export const checkOpenaiFineTuneStatus = defineTask({
+  id: "checkOpenaiFineTuneStatus",
+  handler: async () => {
+    await runOnce();
+  },
 });

--- a/app/src/server/tasks/fineTuning/trainFineTune.task.ts
+++ b/app/src/server/tasks/fineTuning/trainFineTune.task.ts
@@ -17,18 +17,21 @@ export type TrainFineTuneJob = {
   fineTuneId: string;
 };
 
-export const trainFineTune = defineTask<TrainFineTuneJob>("trainFineTune", async (task) => {
-  const fineTune = await prisma.fineTune.findUnique({
-    where: { id: task.fineTuneId },
-  });
+export const trainFineTune = defineTask<TrainFineTuneJob>({
+  id: "trainFineTune",
+  handler: async (task) => {
+    const fineTune = await prisma.fineTune.findUnique({
+      where: { id: task.fineTuneId },
+    });
 
-  if (!fineTune) return;
+    if (!fineTune) return;
 
-  if (fineTune.baseModel === "GPT_3_5_TURBO") {
-    await trainOpenaiFineTune(fineTune.id);
-  } else {
-    await trainModalFineTune(fineTune.id);
-  }
+    if (fineTune.baseModel === "GPT_3_5_TURBO") {
+      await trainOpenaiFineTune(fineTune.id);
+    } else {
+      await trainModalFineTune(fineTune.id);
+    }
+  },
 });
 
 const trainModalFineTune = async (fineTuneId: string) => {

--- a/app/src/server/tasks/getTestResult.task.ts
+++ b/app/src/server/tasks/getTestResult.task.ts
@@ -18,81 +18,96 @@ import { validatedChatInput } from "~/modelProviders/fine-tuned/utils";
 export type GetTestResultJob = {
   fineTuneId: string;
   datasetEntryId: string;
-  skipCache: boolean;
+  skipCache?: boolean;
 };
 
-export const getTestResult = defineTask<GetTestResultJob>("getTestResult", async (task) => {
-  const { fineTuneId, datasetEntryId, skipCache } = task;
+export const getTestResult = defineTask<GetTestResultJob>({
+  id: "getTestResult",
+  handler: async (task) => {
+    const { fineTuneId, datasetEntryId, skipCache } = task;
 
-  const [fineTune, datasetEntry] = await prisma.$transaction([
-    prisma.fineTune.findUnique({
-      where: { id: fineTuneId },
-    }),
-    prisma.datasetEntry.findUnique({
-      where: { id: datasetEntryId },
-    }),
-  ]);
+    const [fineTune, datasetEntry] = await prisma.$transaction([
+      prisma.fineTune.findUnique({
+        where: { id: fineTuneId },
+      }),
+      prisma.datasetEntry.findUnique({
+        where: { id: datasetEntryId },
+      }),
+    ]);
 
-  if (!fineTune || !datasetEntry) return;
+    if (!fineTune || !datasetEntry) return;
 
-  const existingTestEntry = await prisma.fineTuneTestingEntry.findUnique({
-    where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
-  });
-
-  if (existingTestEntry?.output && !skipCache) return;
-
-  let prunedMessages = existingTestEntry?.prunedInput;
-
-  const stringsToPrune = await getStringsToPrune(fineTune.id);
-  if (!existingTestEntry) {
-    prunedMessages = pruneInputMessagesStringified(
-      datasetEntry.messages as unknown as ChatCompletionMessage[],
-      stringsToPrune,
-    );
-    await prisma.fineTuneTestingEntry.create({
-      data: {
-        fineTuneId,
-        datasetEntryId,
-        prunedInput: prunedMessages,
-        // TODO: need to count tokens based on the full input, not just messages
-        prunedInputTokens: countLlamaChatTokens(prunedMessages),
-      },
-    });
-  }
-
-  const cacheKey = hashObject({
-    fineTuneId,
-    input: prunedMessages,
-  } as JsonValue);
-
-  if (!skipCache) {
-    const matchingTestEntry = await prisma.fineTuneTestingEntry.findFirst({
-      where: {
-        cacheKey,
-      },
+    const existingTestEntry = await prisma.fineTuneTestingEntry.findUnique({
+      where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
     });
 
-    if (matchingTestEntry?.output) {
-      await prisma.fineTuneTestingEntry.update({
-        where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
+    if (existingTestEntry?.output && !skipCache) return;
+
+    let prunedMessages = existingTestEntry?.prunedInput;
+
+    const stringsToPrune = await getStringsToPrune(fineTune.id);
+    if (!existingTestEntry) {
+      prunedMessages = pruneInputMessagesStringified(
+        datasetEntry.messages as unknown as ChatCompletionMessage[],
+        stringsToPrune,
+      );
+      await prisma.fineTuneTestingEntry.create({
         data: {
-          output: matchingTestEntry.output,
-          outputTokens: matchingTestEntry.outputTokens,
-          errorMessage: null,
+          fineTuneId,
+          datasetEntryId,
+          prunedInput: prunedMessages,
+          // TODO: need to count tokens based on the full input, not just messages
+          prunedInputTokens: countLlamaChatTokens(prunedMessages),
         },
       });
-      return;
     }
-  }
 
-  let completion;
-  const input = {
-    model: `openpipe:${fineTune.slug}`,
-    ...validatedChatInput(datasetEntry),
-  };
-  try {
-    if (fineTune.pipelineVersion === 0) {
-      if (!fineTune.inferenceUrls.length) {
+    const cacheKey = hashObject({
+      fineTuneId,
+      input: prunedMessages,
+    } as JsonValue);
+
+    if (!skipCache) {
+      const matchingTestEntry = await prisma.fineTuneTestingEntry.findFirst({
+        where: {
+          cacheKey,
+        },
+      });
+
+      if (matchingTestEntry?.output) {
+        await prisma.fineTuneTestingEntry.update({
+          where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
+          data: {
+            output: matchingTestEntry.output,
+            outputTokens: matchingTestEntry.outputTokens,
+            errorMessage: null,
+          },
+        });
+        return;
+      }
+    }
+
+    let completion;
+    const input = {
+      model: `openpipe:${fineTune.slug}`,
+      ...validatedChatInput(datasetEntry),
+    };
+    try {
+      if (fineTune.pipelineVersion === 0) {
+        if (!fineTune.inferenceUrls.length) {
+          await prisma.fineTuneTestingEntry.update({
+            where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
+            data: {
+              errorMessage: "The model is not set up for inference",
+            },
+          });
+          return;
+        }
+
+        completion = await getCompletion(input, fineTune.inferenceUrls, stringsToPrune);
+      } else if (fineTune.pipelineVersion === 1 || fineTune.pipelineVersion === 2) {
+        completion = await getCompletion2(fineTune, input);
+      } else {
         await prisma.fineTuneTestingEntry.update({
           where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
           data: {
@@ -102,52 +117,35 @@ export const getTestResult = defineTask<GetTestResultJob>("getTestResult", async
         return;
       }
 
-      completion = await getCompletion(input, fineTune.inferenceUrls, stringsToPrune);
-    } else if (fineTune.pipelineVersion === 1 || fineTune.pipelineVersion === 2) {
-      completion = await getCompletion2(fineTune, input);
-    } else {
+      const completionMessage = completion.choices[0]?.message;
+      if (!completionMessage) throw new Error("No completion returned");
+      let score;
+      const originalOutput = datasetEntry.output as unknown as ChatCompletionMessage;
+      if (originalOutput.function_call) {
+        score = calculateEntryScore(originalOutput.function_call, completionMessage.function_call);
+      }
+      const outputTokens = countLlamaChatTokensInMessages([completionMessage]);
       await prisma.fineTuneTestingEntry.update({
         where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
         data: {
-          errorMessage: "The model is not set up for inference",
+          cacheKey,
+          output: completionMessage as unknown as Prisma.InputJsonValue,
+          outputTokens,
+          score,
+          errorMessage: null,
         },
       });
-      return;
+    } catch (e) {
+      await prisma.fineTuneTestingEntry.update({
+        where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
+        data: {
+          errorMessage: (e as Error).message,
+        },
+      });
+      throw e;
     }
-
-    const completionMessage = completion.choices[0]?.message;
-    if (!completionMessage) throw new Error("No completion returned");
-    let score;
-    const originalOutput = datasetEntry.output as unknown as ChatCompletionMessage;
-    if (originalOutput.function_call) {
-      score = calculateEntryScore(originalOutput.function_call, completionMessage.function_call);
-    }
-    const outputTokens = countLlamaChatTokensInMessages([completionMessage]);
-    await prisma.fineTuneTestingEntry.update({
-      where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
-      data: {
-        cacheKey,
-        output: completionMessage as unknown as Prisma.InputJsonValue,
-        outputTokens,
-        score,
-        errorMessage: null,
-      },
-    });
-  } catch (e) {
-    await prisma.fineTuneTestingEntry.update({
-      where: { fineTuneId_datasetEntryId: { fineTuneId, datasetEntryId } },
-      data: {
-        errorMessage: (e as Error).message,
-      },
-    });
-    throw e;
-  }
+  },
+  specDefaults: {
+    priority: 5,
+  },
 });
-
-export const queueGetTestResult = async (
-  fineTuneId: string,
-  datasetEntryId: string,
-  skipCache = false,
-) => {
-  await getTestResult.enqueue({ fineTuneId, datasetEntryId, skipCache }, { priority: 5 });
-};

--- a/app/src/server/tasks/importDatasetEntries.task.ts
+++ b/app/src/server/tasks/importDatasetEntries.task.ts
@@ -13,9 +13,9 @@ export type ImportDatasetEntriesJob = {
   datasetFileUploadId: string;
 };
 
-export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>(
-  "importDatasetEntries",
-  async (task) => {
+export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
+  id: "importDatasetEntries",
+  handler: async (task) => {
     const { datasetFileUploadId } = task;
     const datasetFileUpload = await prisma.datasetFileUpload.findUnique({
       where: { id: datasetFileUploadId },
@@ -136,20 +136,15 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>(
       },
     });
   },
-);
-
-export const queueImportDatasetEntries = async (datasetFileUploadId: string) => {
-  await Promise.all([
-    prisma.datasetFileUpload.update({
+  beforeEnqueue: async (task) => {
+    await prisma.datasetFileUpload.update({
       where: {
-        id: datasetFileUploadId,
+        id: task.datasetFileUploadId,
       },
       data: {
         errorMessage: null,
         status: "PENDING",
       },
-    }),
-
-    importDatasetEntries.enqueue({ datasetFileUploadId }),
-  ]);
-};
+    });
+  },
+});

--- a/app/src/server/tasks/queryModel.task.ts
+++ b/app/src/server/tasks/queryModel.task.ts
@@ -25,151 +25,154 @@ function calculateDelay(numPreviousTries: number): number {
   return baseDelay + jitter;
 }
 
-export const queryModel = defineTask<QueryModelJob>("queryModel", async (task) => {
-  const { cellId, stream, numPreviousTries } = task;
-  const cell = await prisma.scenarioVariantCell.findUnique({
-    where: { id: cellId },
-    include: { modelResponses: true },
-  });
-  if (!cell) {
-    return;
-  }
+export const queryModel = defineTask<QueryModelJob>({
+  id: "queryModel",
+  handler: async (task) => {
+    const { cellId, stream, numPreviousTries } = task;
+    const cell = await prisma.scenarioVariantCell.findUnique({
+      where: { id: cellId },
+      include: { modelResponses: true },
+    });
+    if (!cell) {
+      return;
+    }
 
-  // If cell is not pending, then some other job is already processing it
-  if (cell.retrievalStatus !== "PENDING") {
-    return;
-  }
-  await prisma.scenarioVariantCell.update({
-    where: { id: cellId },
-    data: {
-      retrievalStatus: "IN_PROGRESS",
-      jobStartedAt: new Date(),
-    },
-  });
-
-  const variant = await prisma.promptVariant.findUnique({
-    where: { id: cell.promptVariantId },
-  });
-  if (!variant) {
+    // If cell is not pending, then some other job is already processing it
+    if (cell.retrievalStatus !== "PENDING") {
+      return;
+    }
     await prisma.scenarioVariantCell.update({
       where: { id: cellId },
       data: {
-        errorMessage: "Prompt Variant not found",
-        retrievalStatus: "ERROR",
-      },
-    });
-    return;
-  }
-
-  const scenario = await prisma.testScenario.findUnique({
-    where: { id: cell.testScenarioId },
-  });
-  if (!scenario) {
-    await prisma.scenarioVariantCell.update({
-      where: { id: cellId },
-      data: {
-        errorMessage: "Scenario not found",
-        retrievalStatus: "ERROR",
-      },
-    });
-    return;
-  }
-
-  const prompt = await parsePromptConstructor(
-    variant.promptConstructor,
-    scenario.variableValues as JsonObject,
-  );
-
-  if ("error" in prompt) {
-    await prisma.scenarioVariantCell.update({
-      where: { id: cellId },
-      data: {
-        errorMessage: prompt.error,
-        retrievalStatus: "ERROR",
-      },
-    });
-    return;
-  }
-
-  const provider = modelProviders[prompt.modelProvider];
-
-  const onStream = stream
-    ? (partialOutput: (typeof provider)["_outputSchema"]) => {
-        wsConnection.emit("message", { channel: cell.id, payload: partialOutput });
-      }
-    : null;
-
-  const cacheKey = hashObject(prompt as JsonValue);
-
-  let modelResponse = await prisma.modelResponse.create({
-    data: {
-      cacheKey,
-      scenarioVariantCellId: cellId,
-      requestedAt: new Date(),
-    },
-  });
-  const response = await provider.getCompletion(prompt.modelInput, onStream);
-  if (response.type === "success") {
-    const usage = provider.getUsage(prompt.modelInput, response.value);
-    modelResponse = await prisma.modelResponse.update({
-      where: { id: modelResponse.id },
-      data: {
-        respPayload: response.value as Prisma.InputJsonObject,
-        statusCode: response.statusCode,
-        receivedAt: new Date(),
-        inputTokens: usage?.inputTokens,
-        outputTokens: usage?.outputTokens,
-        cost: usage?.cost,
+        retrievalStatus: "IN_PROGRESS",
+        jobStartedAt: new Date(),
       },
     });
 
-    await prisma.scenarioVariantCell.update({
-      where: { id: cellId },
-      data: {
-        retrievalStatus: "COMPLETE",
-      },
+    const variant = await prisma.promptVariant.findUnique({
+      where: { id: cell.promptVariantId },
     });
-
-    await runEvalsForOutput(variant.experimentId, scenario, modelResponse, prompt.modelProvider);
-  } else {
-    const shouldRetry = response.autoRetry && numPreviousTries < MAX_AUTO_RETRIES;
-    const delay = calculateDelay(numPreviousTries);
-    const retryTime = new Date(Date.now() + delay);
-
-    await prisma.modelResponse.update({
-      where: { id: modelResponse.id },
-      data: {
-        statusCode: response.statusCode,
-        errorMessage: response.message,
-        receivedAt: new Date(),
-        retryTime: shouldRetry ? retryTime : null,
-      },
-    });
-
-    if (shouldRetry) {
-      await queryModel.enqueue(
-        {
-          cellId,
-          stream,
-          numPreviousTries: numPreviousTries + 1,
-        },
-        { runAt: retryTime, jobKey: cellId, priority: 3 },
-      );
+    if (!variant) {
       await prisma.scenarioVariantCell.update({
         where: { id: cellId },
         data: {
-          retrievalStatus: "PENDING",
-        },
-      });
-    } else {
-      await prisma.scenarioVariantCell.update({
-        where: { id: cellId },
-        data: {
+          errorMessage: "Prompt Variant not found",
           retrievalStatus: "ERROR",
         },
       });
+      return;
     }
-  }
+
+    const scenario = await prisma.testScenario.findUnique({
+      where: { id: cell.testScenarioId },
+    });
+    if (!scenario) {
+      await prisma.scenarioVariantCell.update({
+        where: { id: cellId },
+        data: {
+          errorMessage: "Scenario not found",
+          retrievalStatus: "ERROR",
+        },
+      });
+      return;
+    }
+
+    const prompt = await parsePromptConstructor(
+      variant.promptConstructor,
+      scenario.variableValues as JsonObject,
+    );
+
+    if ("error" in prompt) {
+      await prisma.scenarioVariantCell.update({
+        where: { id: cellId },
+        data: {
+          errorMessage: prompt.error,
+          retrievalStatus: "ERROR",
+        },
+      });
+      return;
+    }
+
+    const provider = modelProviders[prompt.modelProvider];
+
+    const onStream = stream
+      ? (partialOutput: (typeof provider)["_outputSchema"]) => {
+          wsConnection.emit("message", { channel: cell.id, payload: partialOutput });
+        }
+      : null;
+
+    const cacheKey = hashObject(prompt as JsonValue);
+
+    let modelResponse = await prisma.modelResponse.create({
+      data: {
+        cacheKey,
+        scenarioVariantCellId: cellId,
+        requestedAt: new Date(),
+      },
+    });
+    const response = await provider.getCompletion(prompt.modelInput, onStream);
+    if (response.type === "success") {
+      const usage = provider.getUsage(prompt.modelInput, response.value);
+      modelResponse = await prisma.modelResponse.update({
+        where: { id: modelResponse.id },
+        data: {
+          respPayload: response.value as Prisma.InputJsonObject,
+          statusCode: response.statusCode,
+          receivedAt: new Date(),
+          inputTokens: usage?.inputTokens,
+          outputTokens: usage?.outputTokens,
+          cost: usage?.cost,
+        },
+      });
+
+      await prisma.scenarioVariantCell.update({
+        where: { id: cellId },
+        data: {
+          retrievalStatus: "COMPLETE",
+        },
+      });
+
+      await runEvalsForOutput(variant.experimentId, scenario, modelResponse, prompt.modelProvider);
+    } else {
+      const shouldRetry = response.autoRetry && numPreviousTries < MAX_AUTO_RETRIES;
+      const delay = calculateDelay(numPreviousTries);
+      const retryTime = new Date(Date.now() + delay);
+
+      await prisma.modelResponse.update({
+        where: { id: modelResponse.id },
+        data: {
+          statusCode: response.statusCode,
+          errorMessage: response.message,
+          receivedAt: new Date(),
+          retryTime: shouldRetry ? retryTime : null,
+        },
+      });
+
+      if (shouldRetry) {
+        await queryModel.enqueue(
+          {
+            cellId,
+            stream,
+            numPreviousTries: numPreviousTries + 1,
+          },
+          { runAt: retryTime, jobKey: cellId, priority: 3 },
+        );
+        await prisma.scenarioVariantCell.update({
+          where: { id: cellId },
+          data: {
+            retrievalStatus: "PENDING",
+          },
+        });
+      } else {
+        await prisma.scenarioVariantCell.update({
+          where: { id: cellId },
+          data: {
+            retrievalStatus: "ERROR",
+          },
+        });
+      }
+    }
+  },
 });
 
 export const queueQueryModel = async (

--- a/app/src/server/tasks/runNewEval.task.ts
+++ b/app/src/server/tasks/runNewEval.task.ts
@@ -6,12 +6,13 @@ export type RunNewEvalJob = {
 };
 
 // When a new eval is created, we want to run it on all existing outputs, but return the new eval first
-export const runNewEval = defineTask<RunNewEvalJob>("runNewEval", async (task) => {
-  const { experimentId } = task;
-  await runAllEvals(experimentId);
+export const runNewEval = defineTask<RunNewEvalJob>({
+  id: "runNewEval",
+  handler: async (task) => {
+    const { experimentId } = task;
+    await runAllEvals(experimentId);
+  },
+  specDefaults: {
+    priority: 4,
+  },
 });
-
-export const queueRunNewEval = async (experimentId: string) => {
-  // Evals are lower priority than completions
-  await runNewEval.enqueue({ experimentId }, { priority: 4 });
-};

--- a/app/src/server/tasks/test-tasks.ts
+++ b/app/src/server/tasks/test-tasks.ts
@@ -9,11 +9,14 @@ import "../../../sentry.server.config";
 export type TestTask = { i: number };
 
 // When a new eval is created, we want to run it on all existing outputs, but return the new eval first
-export const testTask = defineTask<TestTask>("testTask", (task) => {
-  console.log("ran task ", task.i);
+export const testTask = defineTask<TestTask>({
+  id: "testTask",
+  handler: (task) => {
+    console.log("ran task ", task.i);
 
-  void new Promise((_resolve, reject) => setTimeout(reject, 500));
-  return Promise.resolve();
+    void new Promise((_resolve, reject) => setTimeout(reject, 500));
+    return Promise.resolve();
+  },
 });
 
 const registeredTasks = [testTask];

--- a/app/src/server/tasks/worker.ts
+++ b/app/src/server/tasks/worker.ts
@@ -9,7 +9,7 @@ import { importDatasetEntries } from "./importDatasetEntries.task";
 import { trainFineTune } from "./fineTuning/trainFineTune.task";
 import { checkFineTuneStatus } from "./fineTuning/checkFineTuneStatus.task";
 import { checkOpenaiFineTuneStatus } from "./fineTuning/checkOpenaiFineTuneStatus.task";
-import { getTestResult } from "./getTestResult.task";
+import { evaluateTestSetEntry } from "./evaluateTestSetEntry.task";
 import type defineTask from "./defineTask";
 
 console.log("Starting worker");
@@ -25,7 +25,7 @@ const registeredTasks: ReturnType<typeof defineTask<any>>[] = [
   trainFineTune,
   checkFineTuneStatus,
   checkOpenaiFineTuneStatus,
-  getTestResult,
+  evaluateTestSetEntry,
 ];
 
 const taskList = registeredTasks.reduce((acc, task) => {

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -4,7 +4,7 @@ import { type ChatCompletionMessage } from "openai/resources/chat";
 import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
 import { prisma } from "../db";
 import { countLlamaChatTokens, countOpenAIChatTokens } from "~/utils/countTokens";
-import { getTestResult } from "../tasks/getTestResult.task";
+import { evaluateTestSetEntry } from "../tasks/evaluateTestSetEntry.task";
 
 export const startTestJobs = async (fineTune: FineTune) => {
   const stringsToPrune = await getStringsToPrune(fineTune.id);
@@ -36,6 +36,6 @@ export const startTestJobs = async (fineTune: FineTune) => {
     skipDuplicates: true,
   });
   for (const entry of datasetEntries) {
-    await getTestResult.enqueue({ fineTuneId: fineTune.id, datasetEntryId: entry.id });
+    await evaluateTestSetEntry.enqueue({ fineTuneId: fineTune.id, datasetEntryId: entry.id });
   }
 };

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -4,7 +4,7 @@ import { type ChatCompletionMessage } from "openai/resources/chat";
 import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
 import { prisma } from "../db";
 import { countLlamaChatTokens, countOpenAIChatTokens } from "~/utils/countTokens";
-import { queueGetTestResult } from "../tasks/getTestResult.task";
+import { getTestResult } from "../tasks/getTestResult.task";
 
 export const startTestJobs = async (fineTune: FineTune) => {
   const stringsToPrune = await getStringsToPrune(fineTune.id);
@@ -36,6 +36,6 @@ export const startTestJobs = async (fineTune: FineTune) => {
     skipDuplicates: true,
   });
   for (const entry of datasetEntries) {
-    await queueGetTestResult(fineTune.id, entry.id);
+    await getTestResult.enqueue({ fineTuneId: fineTune.id, datasetEntryId: entry.id });
   }
 };


### PR DESCRIPTION
Lets us simplify the common pattern where we always want to run something before a task is enqueued.