### PR TITLE
Sample selected logs, avoid passing matching log ids in json

### DIFF
--- a/app/scripts/run-dev.ts
+++ b/app/scripts/run-dev.ts
@@ -1,6 +1,10 @@
-import { $, ExecaChildProcess } from "execa";
+import { $, type ExecaChildProcess } from "execa";
 import "dotenv/config";
-import humanId from "human-id";
+import HumanIdModule from "human-id";
+
+import { ensureDefaultExport } from "~/utils/utils";
+
+const humanId = ensureDefaultExport(HumanIdModule);
 
 const tunnelSubdomain =
   process.env.LOCAL_HOST_SUBDOMAIN ?? humanId({ separator: "-", capitalize: false });

--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -29,8 +29,7 @@ import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
 import { useRouter } from "next/router";
 
 const AddToDatasetButton = () => {
-  const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
-  const defaultToSelected = useAppStore((s) => s.selectedLogs.defaultToSelected);
+  const totalNumLogsSelected = useTotalNumLogsSelected();
 
   const disclosure = useDisclosure();
 
@@ -40,7 +39,7 @@ const AddToDatasetButton = () => {
         onClick={disclosure.onOpen}
         label="Add to Dataset"
         icon={FiPlusSquare}
-        isDisabled={selectedLogIds.size === 0 && !defaultToSelected}
+        isDisabled={!totalNumLogsSelected}
       />
       <AddToDatasetModal disclosure={disclosure} />
     </>

--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -20,7 +20,7 @@ import {
 } from "@chakra-ui/react";
 import { FiPlusSquare } from "react-icons/fi";
 
-import { useDatasets, useHandledAsyncCallback } from "~/utils/hooks";
+import { useDatasets, useHandledAsyncCallback, useTotalNumLogsSelected } from "~/utils/hooks";
 import { api } from "~/utils/api";
 import { useAppStore } from "~/state/store";
 import ActionButton from "../ActionButton";
@@ -30,6 +30,7 @@ import { useRouter } from "next/router";
 
 const AddToDatasetButton = () => {
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
+  const defaultToSelected = useAppStore((s) => s.selectedLogs.defaultToSelected);
 
   const disclosure = useDisclosure();
 
@@ -39,7 +40,7 @@ const AddToDatasetButton = () => {
         onClick={disclosure.onOpen}
         label="Add to Dataset"
         icon={FiPlusSquare}
-        isDisabled={selectedLogIds.size === 0}
+        isDisabled={selectedLogIds.size === 0 && !defaultToSelected}
       />
       <AddToDatasetModal disclosure={disclosure} />
     </>
@@ -51,7 +52,14 @@ export default AddToDatasetButton;
 const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const selectedProjectId = useAppStore((s) => s.selectedProjectId);
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
-  const clearSelectedLogIds = useAppStore((s) => s.selectedLogs.clearSelectedLogIds);
+  const deselectedLogIds = useAppStore((s) => s.selectedLogs.deselectedLogIds);
+  const defaultToSelected = useAppStore((s) => s.selectedLogs.defaultToSelected);
+  const resetLogSelection = useAppStore((s) => s.selectedLogs.resetLogSelection);
+  const filters = useAppStore((state) => state.logFilters.filters);
+
+  const totalNumLogsSelected = useTotalNumLogsSelected();
+  const maxSampleSize = Math.min(totalNumLogsSelected, 20000);
+
   const router = useRouter();
 
   const datasets = useDatasets().data;
@@ -64,23 +72,26 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
     [datasets],
   );
 
+  // Initialize to valid number to avoid invalid input border flash on first render
+  const [sampleSize, setSampleSize] = useState(1);
   const [selectedDatasetOption, setSelectedDatasetOption] = useState(existingDatasetOptions?.[0]);
   const [newDatasetName, setNewDatasetName] = useState("");
   const [createNewDataset, setCreateNewDataset] = useState(false);
 
   useEffect(() => {
     if (disclosure.isOpen) {
+      setSampleSize(maxSampleSize);
       setSelectedDatasetOption(existingDatasetOptions?.[0]);
       setCreateNewDataset(!existingDatasetOptions[0]?.id);
     }
-  }, [disclosure.isOpen, existingDatasetOptions]);
+  }, [disclosure.isOpen, existingDatasetOptions, maxSampleSize]);
 
   const createDatasetEntriesMutation = api.datasetEntries.create.useMutation();
 
   const [addToDataset, addingInProgress] = useHandledAsyncCallback(async () => {
     if (
       !selectedProjectId ||
-      !selectedLogIds.size ||
+      !totalNumLogsSelected ||
       !(createNewDataset ? newDatasetName : selectedDatasetOption?.id)
     )
       return;
@@ -88,7 +99,11 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
       ? { newDatasetParams: { projectId: selectedProjectId, name: newDatasetName } }
       : { datasetId: selectedDatasetOption?.id };
     const response = await createDatasetEntriesMutation.mutateAsync({
-      loggedCallIds: Array.from(selectedLogIds),
+      selectedLogIds: Array.from(selectedLogIds),
+      deselectedLogIds: Array.from(deselectedLogIds),
+      defaultToSelected,
+      sampleSize,
+      filters,
       ...datasetParams,
     });
 
@@ -99,15 +114,22 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
     await router.push({ pathname: "/datasets/[id]", query: { id: datasetId } });
 
     disclosure.onClose();
-    clearSelectedLogIds();
+    resetLogSelection();
   }, [
     selectedProjectId,
     selectedLogIds,
+    deselectedLogIds,
+    defaultToSelected,
+    totalNumLogsSelected,
+    resetLogSelection,
+    sampleSize,
     createNewDataset,
     selectedDatasetOption?.id,
     newDatasetName,
     router,
   ]);
+
+  const sampleSizeInvalid = sampleSize > maxSampleSize || sampleSize <= 0;
 
   return (
     <Modal size={{ base: "xl", md: "2xl" }} {...disclosure}>
@@ -123,10 +145,28 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
         <ModalBody maxW="unset">
           <VStack w="full" spacing={8} pt={4} alignItems="flex-start">
             <Text>
-              We'll add the <b>{selectedLogIds.size}</b> logs you have selected to the dataset you
-              choose.
+              Of the <b>{totalNumLogsSelected}</b> you have selected, <b>{sampleSize}</b> randomly
+              chosen logs will be added to{" "}
+              {createNewDataset ? "your new dataset" : <b>{selectedDatasetOption?.label}</b>}.
             </Text>
             <VStack alignItems="flex-start" spacing={4}>
+              <Flex
+                flexDir={{ base: "column", md: "row" }}
+                alignItems={{ base: "flex-start", md: "center" }}
+              >
+                <Text fontWeight="bold" w={48}>
+                  Sample Size:
+                </Text>
+                <Input
+                  w={48}
+                  type="number"
+                  value={sampleSize}
+                  onChange={(e) =>
+                    setSampleSize(parseInt(e.target.value.replace(/[^\d]/g, "") || "1"))
+                  }
+                  isInvalid={sampleSizeInvalid}
+                />
+              </Flex>
               {existingDatasetOptions?.length && selectedDatasetOption && (
                 <Flex
                   flexDir={{ base: "column", md: "row" }}
@@ -170,6 +210,11 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
                 </Flex>
               )}
             </VStack>
+            {sampleSizeInvalid && (
+              <Text color="red.500">
+                Sample size must be less than or equal to <b>{maxSampleSize}</b>.
+              </Text>
+            )}
           </VStack>
         </ModalBody>
         <ModalFooter>
@@ -182,6 +227,7 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
               onClick={addToDataset}
               isLoading={addingInProgress}
               minW={24}
+              isDisabled={sampleSizeInvalid}
             >
               Add
             </Button>

--- a/app/src/components/requestLogs/ExportButton.tsx
+++ b/app/src/components/requestLogs/ExportButton.tsx
@@ -37,6 +37,7 @@ const SUPPORTED_EXPORT_FORMATS = ["alpaca-finetune", "openai-fine-tune", "unform
 
 const ExportButton = () => {
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
+  const defaultToSelected = useAppStore((s) => s.selectedLogs.defaultToSelected);
 
   const disclosure = useDisclosure();
 
@@ -46,7 +47,7 @@ const ExportButton = () => {
         onClick={disclosure.onOpen}
         label="Export"
         icon={BiExport}
-        isDisabled={selectedLogIds.size === 0}
+        isDisabled={selectedLogIds.size === 0 && !defaultToSelected}
         requireBeta
       />
       <ExportLogsModal disclosure={disclosure} />
@@ -59,7 +60,7 @@ export default ExportButton;
 const ExportLogsModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const selectedProjectId = useAppStore((s) => s.selectedProjectId);
   const selectedLogIds = useAppStore((s) => s.selectedLogs.selectedLogIds);
-  const clearSelectedLogIds = useAppStore((s) => s.selectedLogs.clearSelectedLogIds);
+  const resetLogSelection = useAppStore((s) => s.selectedLogs.resetLogSelection);
 
   const [selectedExportFormat, setSelectedExportFormat] = useState(SUPPORTED_EXPORT_FORMATS[0]);
   const [testingSplit, setTestingSplit] = useState(10);
@@ -99,11 +100,12 @@ const ExportLogsModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
     document.body.removeChild(a);
 
     disclosure.onClose();
-    clearSelectedLogIds();
+    resetLogSelection();
   }, [
     exportLogsMutation,
     selectedProjectId,
     selectedLogIds,
+    resetLogSelection,
     testingSplit,
     selectedExportFormat,
     removeDuplicates,

--- a/app/src/server/api/routers/loggedCalls.router.ts
+++ b/app/src/server/api/routers/loggedCalls.router.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { type Expression, type SqlBool, sql, type RawBuilder } from "kysely";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
 import archiver from "archiver";
 import { WritableStreamBuffer } from "stream-buffers";
@@ -8,28 +7,9 @@ import { shuffle } from "lodash-es";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { kysely } from "~/server/db";
-import { comparators, defaultFilterableFields } from "~/state/logFiltersSlice";
 import { requireCanViewProject } from "~/utils/accessControl";
 import hashObject from "~/server/utils/hashObject";
-
-// create comparator type based off of comparators
-const comparatorToSqlExpression = (comparator: (typeof comparators)[number], value: string) => {
-  return (reference: RawBuilder<unknown>): Expression<SqlBool> => {
-    switch (comparator) {
-      case "=":
-        return sql`${reference} = ${value}`;
-      case "!=":
-        // Handle NULL values
-        return sql`${reference} IS DISTINCT FROM ${value}`;
-      case "CONTAINS":
-        return sql`${reference} LIKE ${"%" + value + "%"}`;
-      case "NOT_CONTAINS":
-        return sql`(${reference} NOT LIKE ${"%" + value + "%"} OR ${reference} IS NULL)`;
-      default:
-        throw new Error("Unknown comparator");
-    }
-  };
-};
+import { constructFiltersQuery, logFiltersSchema } from "~/server/utils/constructFiltersQuery";
 
 export const loggedCallsRouter = createTRPCRouter({
   list: protectedProcedure
@@ -38,13 +18,7 @@ export const loggedCallsRouter = createTRPCRouter({
         projectId: z.string(),
         page: z.number(),
         pageSize: z.number(),
-        filters: z.array(
-          z.object({
-            field: z.string(),
-            comparator: z.enum(comparators),
-            value: z.string(),
-          }),
-        ),
+        filters: logFiltersSchema,
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -52,58 +26,9 @@ export const loggedCallsRouter = createTRPCRouter({
 
       await requireCanViewProject(projectId, ctx);
 
-      const baseQuery = kysely
-        .selectFrom("LoggedCall as lc")
-        .leftJoin("LoggedCallModelResponse as lcmr", "lc.id", "lcmr.originalLoggedCallId")
-        .where((eb) => {
-          const wheres: Expression<SqlBool>[] = [eb("lc.projectId", "=", projectId)];
+      const baseQuery = constructFiltersQuery(input.filters, projectId);
 
-          for (const filter of input.filters) {
-            if (!filter.value) continue;
-            const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
-
-            if (filter.field === "Request") {
-              wheres.push(filterExpression(sql.raw(`lcmr."reqPayload"::text`)));
-            }
-            if (filter.field === "Response") {
-              wheres.push(filterExpression(sql.raw(`lcmr."respPayload"::text`)));
-            }
-            if (filter.field === "Model") {
-              wheres.push(filterExpression(sql.raw(`lc."model"`)));
-            }
-            if (filter.field === "Status Code") {
-              wheres.push(filterExpression(sql.raw(`lcmr."statusCode"::text`)));
-            }
-          }
-
-          return eb.and(wheres);
-        });
-
-      const tagFilters = input.filters.filter(
-        (filter) =>
-          !defaultFilterableFields.includes(
-            filter.field as (typeof defaultFilterableFields)[number],
-          ),
-      );
-
-      let updatedBaseQuery = baseQuery;
-
-      for (let i = 0; i < tagFilters.length; i++) {
-        const filter = tagFilters[i];
-        if (!filter?.value) continue;
-        const tableAlias = `lct${i}`;
-        const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
-
-        updatedBaseQuery = updatedBaseQuery
-          .leftJoin(`LoggedCallTag as ${tableAlias}`, (join) =>
-            join
-              .onRef("lc.id", "=", `${tableAlias}.loggedCallId`)
-              .on(`${tableAlias}.name`, "=", filter.field),
-          )
-          .where(filterExpression(sql.raw(`${tableAlias}.value`))) as unknown as typeof baseQuery;
-      }
-
-      const rawCalls = await updatedBaseQuery
+      const rawCalls = await baseQuery
         .select((eb) => [
           "lc.id as id",
           "lc.requestedAt as requestedAt",
@@ -159,11 +84,11 @@ export const loggedCallsRouter = createTRPCRouter({
         };
       });
 
-      const matchingLogIds = await updatedBaseQuery.select(["lc.id"]).execute();
+      const matchingLogIds = await baseQuery.select(["lc.id"]).execute();
 
       const count = matchingLogIds.length;
 
-      return { calls, count, matchingLogIds: matchingLogIds.map((log) => log.id) };
+      return { calls, count };
     }),
   getTagNames: protectedProcedure
     .input(z.object({ projectId: z.string() }))

--- a/app/src/server/api/routers/loggedCalls.router.ts
+++ b/app/src/server/api/routers/loggedCalls.router.ts
@@ -132,8 +132,6 @@ export const loggedCallsRouter = createTRPCRouter({
         .orderBy("lc.requestedAt", "desc")
         .execute();
 
-      console.log("num logged calls", loggedCallsFromDb.length);
-
       // Convert the database data into the desired format
       let formattedLoggedCalls: { instruction: JsonValue[]; output: JsonValue }[] =
         loggedCallsFromDb.map((call) => ({
@@ -142,8 +140,6 @@ export const loggedCallsRouter = createTRPCRouter({
           output: (call.respPayload as unknown as { choices: { message: unknown }[] }).choices[0]
             ?.message as JsonValue,
         }));
-
-      console.log("num logged calls after formatting", formattedLoggedCalls.length);
 
       if (input.removeDuplicates) {
         const deduplicatedLoggedCalls = [];
@@ -157,8 +153,6 @@ export const loggedCallsRouter = createTRPCRouter({
         }
         formattedLoggedCalls = deduplicatedLoggedCalls;
       }
-
-      console.log("num logged calls after deduplication", formattedLoggedCalls.length);
 
       // Remove duplicate messages from instructions
       const instructionMessageHashMap = new Map<string, number>();

--- a/app/src/server/utils/constructFiltersQuery.ts
+++ b/app/src/server/utils/constructFiltersQuery.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { type Expression, type SqlBool, sql, type RawBuilder } from "kysely";
+import { kysely } from "~/server/db";
+import { comparators, defaultFilterableFields } from "~/state/logFiltersSlice";
+
+export const logFiltersSchema = z.array(
+  z.object({
+    field: z.string(),
+    comparator: z.enum(comparators),
+    value: z.string(),
+  }),
+);
+
+// create comparator type based off of comparators
+const comparatorToSqlExpression = (comparator: (typeof comparators)[number], value: string) => {
+  return (reference: RawBuilder<unknown>): Expression<SqlBool> => {
+    switch (comparator) {
+      case "=":
+        return sql`${reference} = ${value}`;
+      case "!=":
+        // Handle NULL values
+        return sql`${reference} IS DISTINCT FROM ${value}`;
+      case "CONTAINS":
+        return sql`${reference} LIKE ${"%" + value + "%"}`;
+      case "NOT_CONTAINS":
+        return sql`(${reference} NOT LIKE ${"%" + value + "%"} OR ${reference} IS NULL)`;
+      default:
+        throw new Error("Unknown comparator");
+    }
+  };
+};
+
+export const constructFiltersQuery = (
+  filters: z.infer<typeof logFiltersSchema>,
+  projectId: string,
+) => {
+  const baseQuery = kysely
+    .selectFrom("LoggedCall as lc")
+    .leftJoin("LoggedCallModelResponse as lcmr", "lc.id", "lcmr.originalLoggedCallId")
+    .where((eb) => {
+      const wheres: Expression<SqlBool>[] = [eb("lc.projectId", "=", projectId)];
+
+      for (const filter of filters) {
+        if (!filter.value) continue;
+        const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+
+        if (filter.field === "Request") {
+          wheres.push(filterExpression(sql.raw(`lcmr."reqPayload"::text`)));
+        }
+        if (filter.field === "Response") {
+          wheres.push(filterExpression(sql.raw(`lcmr."respPayload"::text`)));
+        }
+        if (filter.field === "Model") {
+          wheres.push(filterExpression(sql.raw(`lc."model"`)));
+        }
+        if (filter.field === "Status Code") {
+          wheres.push(filterExpression(sql.raw(`lcmr."statusCode"::text`)));
+        }
+      }
+
+      return eb.and(wheres);
+    });
+
+  const tagFilters = filters.filter(
+    (filter) =>
+      !defaultFilterableFields.includes(filter.field as (typeof defaultFilterableFields)[number]),
+  );
+
+  let updatedBaseQuery = baseQuery;
+
+  for (let i = 0; i < tagFilters.length; i++) {
+    const filter = tagFilters[i];
+    if (!filter?.value) continue;
+    const tableAlias = `lct${i}`;
+    const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+
+    updatedBaseQuery = updatedBaseQuery
+      .leftJoin(`LoggedCallTag as ${tableAlias}`, (join) =>
+        join
+          .onRef("lc.id", "=", `${tableAlias}.loggedCallId`)
+          .on(`${tableAlias}.name`, "=", filter.field),
+      )
+      .where(filterExpression(sql.raw(`${tableAlias}.value`))) as unknown as typeof baseQuery;
+  }
+  return updatedBaseQuery;
+};

--- a/app/src/state/logFiltersSlice.ts
+++ b/app/src/state/logFiltersSlice.ts
@@ -1,3 +1,4 @@
+import { resetLogSelection } from "./selectedLogsSlice";
 import { type SliceCreator } from "./store";
 
 export const comparators = ["=", "!=", "CONTAINS", "NOT_CONTAINS"] as const;
@@ -24,19 +25,23 @@ export const createLogFiltersSlice: SliceCreator<LogFiltersSlice> = (set, get) =
   addFilter: (filter: LogFilter) =>
     set((state) => {
       state.logFilters.filters.push(filter);
+      resetLogSelection(state);
     }),
   updateFilter: (filter: LogFilter) =>
     set((state) => {
       const index = state.logFilters.filters.findIndex((f) => f.id === filter.id);
       state.logFilters.filters[index] = filter;
+      resetLogSelection(state);
     }),
   deleteFilter: (id: string) =>
     set((state) => {
       const index = state.logFilters.filters.findIndex((f) => f.id === id);
       state.logFilters.filters.splice(index, 1);
+      resetLogSelection(state);
     }),
   clearFilters: () =>
     set((state) => {
       state.logFilters.filters = [];
+      resetLogSelection(state);
     }),
 });

--- a/app/src/state/logFiltersSlice.ts
+++ b/app/src/state/logFiltersSlice.ts
@@ -16,7 +16,7 @@ export type LogFiltersSlice = {
   addFilter: (filter: LogFilter) => void;
   updateFilter: (filter: LogFilter) => void;
   deleteFilter: (id: string) => void;
-  clearSelectedLogIds: () => void;
+  clearFilters: () => void;
 };
 
 export const createLogFiltersSlice: SliceCreator<LogFiltersSlice> = (set, get) => ({
@@ -35,7 +35,7 @@ export const createLogFiltersSlice: SliceCreator<LogFiltersSlice> = (set, get) =
       const index = state.logFilters.filters.findIndex((f) => f.id === id);
       state.logFilters.filters.splice(index, 1);
     }),
-  clearSelectedLogIds: () =>
+  clearFilters: () =>
     set((state) => {
       state.logFilters.filters = [];
     }),

--- a/app/src/state/selectedLogsSlice.ts
+++ b/app/src/state/selectedLogsSlice.ts
@@ -59,13 +59,7 @@ export const createSelectedLogsSlice: SliceCreator<SelectedLogsSlice> = (set) =>
         if (state.selectedLogs.selectedLogIds.size) state.selectedLogs.selectedLogIds = new Set();
       }
     }),
-  resetLogSelection: () =>
-    set((state) => {
-      console.log("being executed");
-      state.selectedLogs.defaultToSelected = false;
-      state.selectedLogs.selectedLogIds = new Set();
-      state.selectedLogs.deselectedLogIds = new Set();
-    }),
+  resetLogSelection: () => set(resetLogSelection),
 });
 
 export const resetLogSelection = (state: State) => {

--- a/app/src/state/selectedLogsSlice.ts
+++ b/app/src/state/selectedLogsSlice.ts
@@ -3,9 +3,9 @@ import { type State, type SliceCreator } from "./store";
 export type SelectedLogsSlice = {
   matchingLogsCount: number;
   setMatchingLogsCount: (count: number) => void;
+  defaultToSelected: boolean;
   selectedLogIds: Set<string>;
   deselectedLogIds: Set<string>;
-  defaultToSelected: boolean;
   toggleSelectedLogId: (id: string) => void;
   toggleAllSelected: () => void;
   resetLogSelection: () => void;
@@ -17,9 +17,9 @@ export const createSelectedLogsSlice: SliceCreator<SelectedLogsSlice> = (set) =>
     set((state) => {
       state.selectedLogs.matchingLogsCount = count;
     }),
+  defaultToSelected: false,
   selectedLogIds: new Set(),
   deselectedLogIds: new Set(),
-  defaultToSelected: false,
   toggleSelectedLogId: (id: string) =>
     set((state) => {
       if (state.selectedLogs.defaultToSelected) {

--- a/app/src/state/selectedLogsSlice.ts
+++ b/app/src/state/selectedLogsSlice.ts
@@ -1,28 +1,75 @@
-import { type SliceCreator } from "./store";
+import { type State, type SliceCreator } from "./store";
 
 export type SelectedLogsSlice = {
+  matchingLogsCount: number;
+  setMatchingLogsCount: (count: number) => void;
   selectedLogIds: Set<string>;
+  deselectedLogIds: Set<string>;
+  defaultToSelected: boolean;
   toggleSelectedLogId: (id: string) => void;
-  addSelectedLogIds: (ids: string[]) => void;
-  clearSelectedLogIds: () => void;
+  toggleAllSelected: () => void;
+  resetLogSelection: () => void;
 };
 
 export const createSelectedLogsSlice: SliceCreator<SelectedLogsSlice> = (set) => ({
+  matchingLogsCount: 0,
+  setMatchingLogsCount: (count: number) =>
+    set((state) => {
+      state.selectedLogs.matchingLogsCount = count;
+    }),
   selectedLogIds: new Set(),
+  deselectedLogIds: new Set(),
+  defaultToSelected: false,
   toggleSelectedLogId: (id: string) =>
     set((state) => {
-      if (state.selectedLogs.selectedLogIds.has(id)) {
-        state.selectedLogs.selectedLogIds.delete(id);
+      if (state.selectedLogs.defaultToSelected) {
+        if (state.selectedLogs.deselectedLogIds.has(id)) {
+          state.selectedLogs.deselectedLogIds.delete(id);
+        } else {
+          state.selectedLogs.deselectedLogIds.add(id);
+        }
       } else {
-        state.selectedLogs.selectedLogIds.add(id);
+        if (state.selectedLogs.selectedLogIds.has(id)) {
+          state.selectedLogs.selectedLogIds.delete(id);
+        } else {
+          state.selectedLogs.selectedLogIds.add(id);
+        }
+      }
+      // Handle the case where all logs are selected or deselected one-by-one
+      if (state.selectedLogs.selectedLogIds.size === state.selectedLogs.matchingLogsCount) {
+        state.selectedLogs.defaultToSelected = true;
+        state.selectedLogs.selectedLogIds = new Set();
+      } else if (
+        state.selectedLogs.deselectedLogIds.size === state.selectedLogs.matchingLogsCount
+      ) {
+        state.selectedLogs.defaultToSelected = false;
+        state.selectedLogs.deselectedLogIds = new Set();
       }
     }),
-  addSelectedLogIds: (ids: string[]) =>
+  toggleAllSelected: () =>
     set((state) => {
-      state.selectedLogs.selectedLogIds = new Set([...state.selectedLogs.selectedLogIds, ...ids]);
+      if (state.selectedLogs.defaultToSelected) {
+        if (state.selectedLogs.deselectedLogIds.size) {
+          state.selectedLogs.deselectedLogIds = new Set();
+        } else {
+          state.selectedLogs.defaultToSelected = false;
+        }
+      } else {
+        state.selectedLogs.defaultToSelected = true;
+        if (state.selectedLogs.selectedLogIds.size) state.selectedLogs.selectedLogIds = new Set();
+      }
     }),
-  clearSelectedLogIds: () =>
+  resetLogSelection: () =>
     set((state) => {
+      console.log("being executed");
+      state.selectedLogs.defaultToSelected = false;
       state.selectedLogs.selectedLogIds = new Set();
+      state.selectedLogs.deselectedLogIds = new Set();
     }),
 });
+
+export const resetLogSelection = (state: State) => {
+  state.selectedLogs.defaultToSelected = false;
+  state.selectedLogs.selectedLogIds = new Set();
+  state.selectedLogs.deselectedLogIds = new Set();
+};

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -260,6 +260,7 @@ export const useLoggedCalls = (applyFilters = true) => {
   const selectedProjectId = useAppStore((state) => state.selectedProjectId);
   const { page, pageSize } = usePageParams();
   const filters = useAppStore((state) => state.logFilters.filters);
+  const setMatchingLogsCount = useAppStore((state) => state.selectedLogs.setMatchingLogsCount);
 
   const { data, isLoading, ...rest } = api.loggedCalls.list.useQuery(
     { projectId: selectedProjectId ?? "", page, pageSize, filters: applyFilters ? filters : [] },
@@ -272,10 +273,24 @@ export const useLoggedCalls = (applyFilters = true) => {
     // Prevent annoying flashes while logs are loading from the server
     if (!isLoading) {
       setStableData(data);
+      setMatchingLogsCount(data?.count ?? 0);
     }
-  }, [data, isLoading]);
+  }, [data, isLoading, setMatchingLogsCount]);
 
   return { data: stableData, isLoading, ...rest };
+};
+
+export const useTotalNumLogsSelected = () => {
+  const matchingCount = useAppStore((state) => state.selectedLogs.matchingLogsCount);
+  const defaultToSelected = useAppStore((state) => state.selectedLogs.defaultToSelected);
+  const selectedLogIds = useAppStore((state) => state.selectedLogs.selectedLogIds);
+  const deselectedLogIds = useAppStore((state) => state.selectedLogs.deselectedLogIds);
+
+  if (!matchingCount) return 0;
+  if (defaultToSelected) {
+    return matchingCount - deselectedLogIds.size;
+  }
+  return selectedLogIds.size;
 };
 
 export const useTagNames = () => {


### PR DESCRIPTION
This PR allows the user to sample a selection of selected logs instead of requiring them to create a dataset out of all of them. It also increases performance by avoiding passing matching log ids when querying logs and when creating dataset entries from them. Instead, we calculate which entries the user wants to modify based on `selectedLogIds`, `deselectedLogIds`, and `defaultToSelected` in the selected logs slice.

### Changes
* Add sampling, with 20000 row limit
* Move logic for querying selected logs to utils file, use for filtering logs when creating dataset entries
* Revamp logic in selected logs slice