### PR TITLE
Avoid sending error when there are no fine-tunes for dataset

### DIFF
--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -82,11 +82,7 @@ export const fineTunesRouter = createTRPCRouter({
         .orderBy("ft.createdAt", "desc")
         .execute();
 
-      if (!fineTunes || fineTunes.length === 0)
-        throw new TRPCError({
-          message: "No fine tunes found for the given datasetId",
-          code: "NOT_FOUND",
-        });
+      if (!fineTunes || fineTunes.length === 0) return [];
 
       if (fineTunes[0]) await requireCanViewProject(fineTunes[0].projectId, ctx);
 


### PR DESCRIPTION
Previously we were throwing an error when querying fine-tunes for a dataset without any, but instead we should just return an empty array.

Fixes https://openpipe.sentry.io/issues/4552457862/?project=4505642011394048