### PR TITLE
Fix pruning rules

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -155,7 +155,7 @@ const FormattedInputGridItem = ({
               pointerEvents="none"
             />
           )}
-          <HStack w="full" h={6} alignItems="flex-end" justifyContent="center" bgColor="white">
+          <HStack w="full" h={8} alignItems="flex-end" justifyContent="center" bgColor="white">
             <Button
               variant="link"
               colorScheme="gray"

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -110,9 +110,19 @@ const FormattedInputGridItem = ({
   const [innerContentHeight, setInnerContentHeight] = useState(0);
   useLayoutEffect(() => {
     if (inputRef.current) {
-      setInnerContentHeight(inputRef.current.getBoundingClientRect().height);
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          // Update the state with the new height
+          setInnerContentHeight(entry.contentRect.height);
+        }
+      });
+
+      // Start observing the element's size
+      resizeObserver.observe(inputRef.current);
+
+      return () => resizeObserver.disconnect();
     }
-  }, [maxOutputHeight]);
+  }, []);
 
   const [isExpanded, setIsExpanded] = useState(false);
   const expandable = innerContentHeight > maxOutputHeight + VERTICAL_PADDING;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -37,14 +37,12 @@ const EvaluationTable = () => {
   if (!entries) return null;
 
   return (
-    <VStack w="full" h="full" justifyContent="space-between" pl={8}>
+    <VStack w="full" h="full" justifyContent="space-between" px={8}>
       <HStack w="full" spacing={0}>
         <Card flex={1} minW="fit-content" variant="outline">
           <Grid
             display="grid"
-            gridTemplateColumns={
-              numOutputColumns ? `550px repeat(${numOutputColumns}, minmax(480px, 1fr))` : `1fr`
-            }
+            gridTemplateColumns={`minmax(550px, 1fr) repeat(${numOutputColumns}, 480px)`}
             sx={{
               "> *": {
                 borderColor: "gray.300",

--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -7,7 +7,11 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { kysely, prisma } from "~/server/db";
 import { trainFineTune } from "~/server/tasks/fineTuning/trainFineTune.task";
 import { CURRENT_PIPELINE_VERSION } from "~/types/shared.types";
-import { requireCanModifyProject, requireCanViewProject } from "~/utils/accessControl";
+import {
+  requireCanModifyProject,
+  requireCanViewProject,
+  requireNothing,
+} from "~/utils/accessControl";
 import { captureFineTuneCreation } from "~/utils/analytics/serverAnalytics";
 import { SUPPORTED_BASE_MODELS } from "~/utils/baseModels";
 import { error, success } from "~/utils/errorHandling/standardResponses";
@@ -82,7 +86,10 @@ export const fineTunesRouter = createTRPCRouter({
         .orderBy("ft.createdAt", "desc")
         .execute();
 
-      if (!fineTunes || fineTunes.length === 0) return [];
+      if (!fineTunes || fineTunes.length === 0) {
+        requireNothing(ctx);
+        return [];
+      }
 
       if (fineTunes[0]) await requireCanViewProject(fineTunes[0].projectId, ctx);
 

--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -39,7 +39,7 @@ export const updatePruningRuleMatches = async (
   });
 
   for (let i = numOmittedRules; i < allPruningRules.length; i++) {
-    let prunedInput: RawBuilder<string> = sql`CAST("DatasetEntry"."input" AS TEXT)`;
+    let prunedInput: RawBuilder<string> = sql`CAST("DatasetEntry"."messages" AS TEXT)`;
 
     // For each rule to update, find all the dataset entries with matching prompts, after previous rules have been applied
     for (let j = 0; j < i; j++) {


### PR DESCRIPTION
This PR updates pruning rules to attempt to modify the `messages` field on a dataset entry, instead of the `input` field. It also adds ACL on the `listForDataset` route when no fine-tunes are found.