### PR TITLE
Add gpt-3.5-turbo comparison

### DIFF
--- a/app/prisma/migrations/20231017025245_/migration.sql
+++ b/app/prisma/migrations/20231017025245_/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[modelId,datasetEntryId]` on the table `FineTuneTestingEntry` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `modelId` to the `FineTuneTestingEntry` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "ComparisonModel" AS ENUM ('GPT_3_5_TURBO');
+
+-- DropIndex
+DROP INDEX "FineTuneTestingEntry_fineTuneId_datasetEntryId_key";
+
+-- AlterTable
+ALTER TABLE "Dataset" ADD COLUMN "enabledComparisonModels" "ComparisonModel"[] DEFAULT ARRAY[]::"ComparisonModel"[];
+
+-- AlterTable: Add modelId without NOT NULL constraint
+ALTER TABLE "FineTuneTestingEntry" ADD COLUMN "modelId" TEXT;
+
+-- Update modelId with the values from fineTuneId
+UPDATE "FineTuneTestingEntry" SET "modelId" = "fineTuneId";
+
+-- Alter the new column to add the NOT NULL constraint
+ALTER TABLE "FineTuneTestingEntry" ALTER COLUMN "modelId" SET NOT NULL;
+
+-- Alter fineTuneId column
+ALTER TABLE "FineTuneTestingEntry" ALTER COLUMN "fineTuneId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FineTuneTestingEntry_modelId_datasetEntryId_key" ON "FineTuneTestingEntry"("modelId", "datasetEntryId");

--- a/app/prisma/migrations/20231017193542_add_fine_tune_testing_entry_model_id/migration.sql
+++ b/app/prisma/migrations/20231017193542_add_fine_tune_testing_entry_model_id/migration.sql
@@ -3,6 +3,7 @@
 
   - A unique constraint covering the columns `[modelId,datasetEntryId]` on the table `FineTuneTestingEntry` will be added. If there are existing duplicate values, this will fail.
   - Added the required column `modelId` to the `FineTuneTestingEntry` table without a default value.
+  - You are about to drop the column `prunedInput` on the `FineTuneTestingEntry` table. All the data in the column will be lost.
 
 */
 -- CreateEnum
@@ -14,7 +15,11 @@ DROP INDEX "FineTuneTestingEntry_fineTuneId_datasetEntryId_key";
 -- AlterTable
 ALTER TABLE "Dataset" ADD COLUMN "enabledComparisonModels" "ComparisonModel"[] DEFAULT ARRAY[]::"ComparisonModel"[];
 
+-- AlterTable
 ALTER TABLE "FineTuneTestingEntry" ALTER COLUMN "prunedInputTokens" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "FineTuneTestingEntry" DROP COLUMN "prunedInput";
 
 -- AlterTable: Add modelId without NOT NULL constraint
 ALTER TABLE "FineTuneTestingEntry" ADD COLUMN "modelId" TEXT;

--- a/app/prisma/migrations/20231017193542_add_fine_tune_testing_entry_model_id/migration.sql
+++ b/app/prisma/migrations/20231017193542_add_fine_tune_testing_entry_model_id/migration.sql
@@ -2,7 +2,7 @@
   Warnings:
 
   - A unique constraint covering the columns `[modelId,datasetEntryId]` on the table `FineTuneTestingEntry` will be added. If there are existing duplicate values, this will fail.
-  - Added the required column `modelId` to the `FineTuneTestingEntry` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `modelId` to the `FineTuneTestingEntry` table without a default value.
 
 */
 -- CreateEnum
@@ -13,6 +13,8 @@ DROP INDEX "FineTuneTestingEntry_fineTuneId_datasetEntryId_key";
 
 -- AlterTable
 ALTER TABLE "Dataset" ADD COLUMN "enabledComparisonModels" "ComparisonModel"[] DEFAULT ARRAY[]::"ComparisonModel"[];
+
+ALTER TABLE "FineTuneTestingEntry" ALTER COLUMN "prunedInputTokens" DROP NOT NULL;
 
 -- AlterTable: Add modelId without NOT NULL constraint
 ALTER TABLE "FineTuneTestingEntry" ADD COLUMN "modelId" TEXT;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -599,7 +599,9 @@ model FineTuneTestingEntry {
     score        Float?
     errorMessage String?
 
+    // Used for querying both fine-tuned and comparison models
     modelId    String
+    // Duplicates the modelId field, but Prisma needs it to make the fineTune relation work
     fineTuneId String?   @db.Uuid
     fineTune   FineTune? @relation(fields: [fineTuneId], references: [id], onDelete: Cascade)
 

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -592,8 +592,6 @@ model FineTuneTestingEntry {
     cacheKey          String?
     prunedInputTokens Int?
 
-    // TODO: get rid of this, just calculate it on the fly
-    prunedInput  String
     outputTokens Int?
     output       Json?
     score        Float?

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -590,7 +590,7 @@ model FineTuneTestingEntry {
     id String @id @default(uuid()) @db.Uuid
 
     cacheKey          String?
-    prunedInputTokens Int
+    prunedInputTokens Int?
 
     // TODO: get rid of this, just calculate it on the fly
     prunedInput  String

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -206,12 +206,13 @@ model DatasetFileUpload {
 model Dataset {
     id String @id @default(uuid()) @db.Uuid
 
-    name               String
-    datasetEntries     DatasetEntry[]
-    fineTunes          FineTune[]
-    datasetFileUploads DatasetFileUpload[]
-    pruningRules       PruningRule[]
-    trainingRatio      Float               @default(0.8)
+    name                    String
+    datasetEntries          DatasetEntry[]
+    fineTunes               FineTune[]
+    datasetFileUploads      DatasetFileUpload[]
+    pruningRules            PruningRule[]
+    trainingRatio           Float               @default(0.8)
+    enabledComparisonModels ComparisonModel[]   @default([])
 
     projectId String  @db.Uuid
     project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
@@ -581,6 +582,10 @@ model FineTuneTrainingEntry {
     @@index([fineTuneId, createdAt, id])
 }
 
+enum ComparisonModel {
+    GPT_3_5_TURBO
+}
+
 model FineTuneTestingEntry {
     id String @id @default(uuid()) @db.Uuid
 
@@ -594,8 +599,9 @@ model FineTuneTestingEntry {
     score        Float?
     errorMessage String?
 
-    fineTuneId String   @db.Uuid
-    fineTune   FineTune @relation(fields: [fineTuneId], references: [id], onDelete: Cascade)
+    modelId    String
+    fineTuneId String?   @db.Uuid
+    fineTune   FineTune? @relation(fields: [fineTuneId], references: [id], onDelete: Cascade)
 
     datasetEntryId String       @db.Uuid
     datasetEntry   DatasetEntry @relation(fields: [datasetEntryId], references: [id], onDelete: Cascade)
@@ -603,7 +609,7 @@ model FineTuneTestingEntry {
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
-    @@unique([fineTuneId, datasetEntryId])
+    @@unique([modelId, datasetEntryId])
     @@index([cacheKey])
 }
 

--- a/app/scripts/copy-db.sh
+++ b/app/scripts/copy-db.sh
@@ -19,7 +19,7 @@ parse_connection_string() {
 
 # Function to check whether to dump the prod DB
 should_dump_prod_db() {
-    if [ ! -f "/tmp/openpipe-prod.db" ] || [ "$FORCE_DUMP" = "true" ]; then
+    if [ ! -f "$PROD_DUMP_FILE" ] || [ "$FORCE_DUMP" = "true" ]; then
         return 0  # Should dump the prod DB
     else
         return 1  # Should not dump the prod DB
@@ -33,7 +33,7 @@ dump_prod_db() {
     # Set the password as an environment variable
     export PGPASSWORD="$PASSWORD"
     
-    pg_dump -v -Fc -h "$HOST" -U "$DB_USERNAME" -d "$DB_NAME" > /tmp/openpipe-prod.dump
+    pg_dump -v -Fc -h "$HOST" -U "$DB_USERNAME" -d "$DB_NAME" > "$PROD_DUMP_FILE"
     
     # Unset the password environment variable
     unset PGPASSWORD
@@ -60,7 +60,7 @@ create_dev_db() {
 # Function to restore the dump to the dev database
 restore_to_dev_db() {
     report_progress "Restoring dump to dev database..."
-    pg_restore -v --no-owner --no-privileges -d openpipe-dev /tmp/openpipe-prod.dump
+    pg_restore -v --no-owner --no-privileges -d openpipe-dev "$PROD_DUMP_FILE"
 }
 
 # Main execution

--- a/app/scripts/repl.ts
+++ b/app/scripts/repl.ts
@@ -23,7 +23,7 @@ const fineTune = await prisma.fineTune.findUniqueOrThrow({
   where: { id: "fa64d94e-dbfd-4d68-8a8c-d55ec8994b54" },
 });
 
-await startTestJobs(fineTune);
+await startTestJobs(fineTune.datasetId, fineTune.id);
 
 // const outputs = await prisma.fineTuneTestingEntry.findMany({
 //   where: { fineTuneId: fineTune.id, output: { not: Prisma.AnyNull }, score: null },

--- a/app/src/components/ContentTabs.tsx
+++ b/app/src/components/ContentTabs.tsx
@@ -29,7 +29,7 @@ const ContentTabs = ({
 
   return (
     <>
-      <VStack w="full" alignItems="flex-start" spacing={0} {...headerProps}>
+      <VStack w="full" alignItems="flex-start" spacing={0} pb={8} {...headerProps}>
         <HStack position="relative">
           {tabs.map((tab) => (
             <TabHeader
@@ -54,9 +54,7 @@ const ContentTabs = ({
         </HStack>
         <Divider />
       </VStack>
-      <Box w="full" pt={8}>
-        {tabs.find((tab) => tab.key === activeTabKey)?.component}
-      </Box>
+      {tabs.find((tab) => tab.key === activeTabKey)?.component}
     </>
   );
 };

--- a/app/src/components/ContentTabs.tsx
+++ b/app/src/components/ContentTabs.tsx
@@ -6,11 +6,10 @@ import { useRouter, type NextRouter } from "next/router";
 const ContentTabs = ({
   tabs,
   headerProps,
-  ...props
 }: {
   tabs: { key: string; title: string; component: React.ReactElement }[];
   headerProps?: StackProps;
-} & StackProps) => {
+}) => {
   const [borderPosition, setBorderPosition] = useState({ left: "0", width: "0" });
   const headersRef = useRef<{ [key: string]: HTMLButtonElement }>({});
 
@@ -29,7 +28,7 @@ const ContentTabs = ({
   }, [activeTabKey]);
 
   return (
-    <VStack w="full" flex={1} {...props}>
+    <>
       <VStack w="full" alignItems="flex-start" spacing={0} {...headerProps}>
         <HStack position="relative">
           {tabs.map((tab) => (
@@ -58,7 +57,7 @@ const ContentTabs = ({
       <Box w="full" pt={8}>
         {tabs.find((tab) => tab.key === activeTabKey)?.component}
       </Box>
-    </VStack>
+    </>
   );
 };
 

--- a/app/src/components/datasets/DatasetContentTabs/DatasetContentTabs.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/DatasetContentTabs.tsx
@@ -31,7 +31,7 @@ const tabs = [
 ];
 
 const DatasetContentTabs = () => (
-  <ContentTabs tabs={tabs} headerProps={{ px: 8, position: "sticky", left: 0, right: 0 }} />
+  <ContentTabs tabs={tabs} headerProps={{ px: 8, position: "sticky", left: 0, right: 0, pt: 2 }} />
 );
 
 export default DatasetContentTabs;

--- a/app/src/components/datasets/DatasetContentTabs/DatasetContentTabs.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/DatasetContentTabs.tsx
@@ -30,6 +30,8 @@ const tabs = [
   },
 ];
 
-const DatasetContentTabs = () => <ContentTabs tabs={tabs} headerProps={{ px: 8 }} />;
+const DatasetContentTabs = () => (
+  <ContentTabs tabs={tabs} headerProps={{ px: 8, position: "sticky", left: 0, right: 0 }} />
+);
 
 export default DatasetContentTabs;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/AddComparisonModelDialog.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/AddComparisonModelDialog.tsx
@@ -18,7 +18,12 @@ import { type ComparisonModel } from "@prisma/client";
 import Link from "next/link";
 
 import { api } from "~/utils/api";
-import { useDataset, useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
+import {
+  useDataset,
+  useHandledAsyncCallback,
+  useSelectedProject,
+  useTestingEntries,
+} from "~/utils/hooks";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
 import { getComparisonModelName } from "~/utils/baseModels";
 
@@ -39,6 +44,7 @@ const AddComparisonModelDialog = ({
 
   const mutation = api.datasets.update.useMutation();
   const utils = api.useContext();
+  const entries = useTestingEntries().data;
 
   const [onUpdateConfirm, updateInProgress] = useHandledAsyncCallback(async () => {
     if (!dataset?.id || !modelId) return;
@@ -90,7 +96,10 @@ const AddComparisonModelDialog = ({
                 </Text>
               ) : (
                 <VStack>
-                  <Text>To confirm this change, please type the model's ID below.</Text>
+                  <Text>
+                    To confirm this change and run <b>{modelName}</b> against{" "}
+                    <b>{entries?.count || ""}</b> test entries, please type the model's ID below.
+                  </Text>
                   <Box bgColor="orange.100" w="full" p={2} borderRadius={4}>
                     <Text fontFamily="inconsolata">{modelName}</Text>
                   </Box>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/AddComparisonModelDialog.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/AddComparisonModelDialog.tsx
@@ -1,0 +1,128 @@
+import { useRef, useState, useEffect } from "react";
+import {
+  type UseDisclosureReturn,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  Button,
+  VStack,
+  Text,
+  Box,
+  Input,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import { type ComparisonModel } from "@prisma/client";
+import Link from "next/link";
+
+import { api } from "~/utils/api";
+import { useDataset, useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
+import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
+import { getComparisonModelName } from "~/utils/baseModels";
+
+const AddComparisonModelDialog = ({
+  modelId,
+  disclosure,
+  onClose,
+}: {
+  modelId: ComparisonModel | null;
+  disclosure: UseDisclosureReturn;
+  onClose: () => void;
+}) => {
+  const dataset = useDataset().data;
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  const selectedProject = useSelectedProject().data;
+  const needsMissingOpenaiKey = !selectedProject?.condensedOpenAIKey;
+
+  const mutation = api.datasets.update.useMutation();
+  const utils = api.useContext();
+
+  const [onUpdateConfirm, updateInProgress] = useHandledAsyncCallback(async () => {
+    if (!dataset?.id || !modelId) return;
+    const resp = await mutation.mutateAsync({
+      id: dataset.id,
+      updates: { enabledComparisonModels: [...dataset.enabledComparisonModels, modelId] },
+    });
+    if (maybeReportError(resp)) return;
+    await utils.datasetEntries.listTestingEntries.invalidate({ datasetId: dataset.id });
+    await utils.datasets.get.invalidate();
+
+    disclosure.onClose();
+  }, [mutation, dataset?.id, dataset?.enabledComparisonModels, modelId, disclosure.onClose]);
+
+  const [modelNameToConfirm, setModelNameToConfirm] = useState("");
+
+  useEffect(() => {
+    if (disclosure.isOpen) {
+      setModelNameToConfirm("");
+    }
+  }, [disclosure.isOpen, setModelNameToConfirm]);
+
+  if (!modelId) return null;
+
+  const modelName = getComparisonModelName(modelId);
+
+  return (
+    <AlertDialog leastDestructiveRef={cancelRef} {...disclosure} onClose={onClose}>
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Add Comparison Model
+          </AlertDialogHeader>
+
+          <AlertDialogBody>
+            <VStack spacing={4} alignItems="flex-start">
+              <Text>
+                All existing and future test entries will be evaluated against <b>{modelName}</b>.
+                The OpenAI token associated with this project will be used for these API calls.
+              </Text>
+
+              {needsMissingOpenaiKey ? (
+                <Text>
+                  To include this model, add your OpenAI API key on the{" "}
+                  <ChakraLink as={Link} href="/project/settings" target="_blank" color="blue.600">
+                    <Text as="span">project settings</Text>
+                  </ChakraLink>{" "}
+                  page.
+                </Text>
+              ) : (
+                <VStack>
+                  <Text>To confirm this change, please type the model's ID below.</Text>
+                  <Box bgColor="orange.100" w="full" p={2} borderRadius={4}>
+                    <Text fontFamily="inconsolata">{modelName}</Text>
+                  </Box>
+                  <Input
+                    isDisabled={needsMissingOpenaiKey}
+                    placeholder={modelName}
+                    value={modelNameToConfirm}
+                    onChange={(e) => setModelNameToConfirm(e.target.value)}
+                  />
+                </VStack>
+              )}
+            </VStack>
+          </AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button ref={cancelRef} isDisabled={updateInProgress} onClick={disclosure.onClose}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme="orange"
+              ml={3}
+              isDisabled={needsMissingOpenaiKey || modelNameToConfirm !== modelName}
+              isLoading={updateInProgress}
+              onClick={onUpdateConfirm}
+            >
+              Confirm
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  );
+};
+
+export default AddComparisonModelDialog;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Icon,
   Popover,
@@ -18,6 +18,8 @@ import { ComparisonModel } from "@prisma/client";
 import { useIsClientRehydrated, useTestingEntries } from "~/utils/hooks";
 import ActionButton from "~/components/ActionButton";
 import { useVisibleEvaluationColumns } from "./useVisibleEvaluationColumns";
+import { getComparisonModelName } from "~/utils/baseModels";
+import AddComparisonModelDialog from "./AddComparisonModelDialog";
 
 export const EMPTY_OUTPUT_COLUMNS_KEY = "empty";
 export const ORIGINAL_OUTPUT_COLUMN_KEY = "original";
@@ -31,6 +33,11 @@ const ColumnVisibilityDropdown = () => {
   );
 
   const popover = useDisclosure();
+  const addComparisonModelDialog = useDisclosure();
+
+  const [comparisonModelIdToAdd, setComparisonModelIdToAdd] = useState<ComparisonModel | null>(
+    null,
+  );
 
   const columnVisibilityOptions = useMemo(() => {
     const options: { label: string; key: string }[] = [
@@ -39,6 +46,12 @@ const ColumnVisibilityDropdown = () => {
         key: ORIGINAL_OUTPUT_COLUMN_KEY,
       },
     ];
+    for (const comparisonModel of entries?.enabledComparisonModels ?? []) {
+      options.push({
+        label: getComparisonModelName(comparisonModel),
+        key: comparisonModel,
+      });
+    }
     for (const slug of fineTuneSlugs ?? []) {
       options.push({
         label: slug,
@@ -46,7 +59,7 @@ const ColumnVisibilityDropdown = () => {
       });
     }
     return options;
-  }, [fineTuneSlugs]);
+  }, [entries?.enabledComparisonModels, fineTuneSlugs]);
 
   const toggleColumnVisibility = useCallback(
     (key: string) => {
@@ -79,67 +92,81 @@ const ColumnVisibilityDropdown = () => {
     : visibleColumns.length || columnVisibilityOptions.length;
 
   return (
-    <Popover
-      placement="bottom-start"
-      isOpen={popover.isOpen}
-      onOpen={popover.onOpen}
-      onClose={popover.onClose}
-    >
-      <PopoverTrigger>
-        <Box>
-          <ActionButton
-            label={`Show Models (${numVisibleColumns}/${columnVisibilityOptions.length})`}
-            icon={BsToggles}
-          />
-        </Box>
-      </PopoverTrigger>
-      <PopoverContent boxShadow="0 0 40px 4px rgba(0, 0, 0, 0.1);" minW={0} w="auto">
-        <VStack spacing={0} maxH={400} overflowY="auto">
-          {columnVisibilityOptions?.map((option, index) => (
-            <HStack
-              key={index}
-              as={Button}
-              onClick={() => toggleColumnVisibility(option.key)}
-              w="full"
-              minH={10}
-              variant="ghost"
-              justifyContent="space-between"
-              fontWeight="semibold"
-              borderRadius={0}
-              colorScheme="blue"
-              color="black"
-              fontSize="sm"
-              borderBottomWidth={1}
-            >
-              <Text mr={16}>{option.label}</Text>
-              <Box w={5}>
-                {(!visibleColumns.length || visibleColumns.includes(option.key)) && (
-                  <Icon as={BiCheck} color="blue.500" boxSize={5} />
-                )}
-              </Box>
-            </HStack>
-          ))}
-          {!entries?.enabledComparisonModels.includes(ComparisonModel.GPT_3_5_TURBO) && (
-            <HStack
-              as={Button}
-              w="full"
-              minH={10}
-              variant="ghost"
-              justifyContent="space-between"
-              fontWeight="semibold"
-              borderRadius={0}
-              colorScheme="orange"
-              color="black"
-              fontSize="sm"
-              borderBottomWidth={1}
-            >
-              <Text>Add gpt-3.5-turbo comparison</Text>
-              <Icon as={BsPlusSquare} color="orange.400" boxSize={5} />
-            </HStack>
-          )}
-        </VStack>
-      </PopoverContent>
-    </Popover>
+    <>
+      <Popover
+        placement="bottom-start"
+        isOpen={popover.isOpen}
+        onOpen={popover.onOpen}
+        onClose={popover.onClose}
+      >
+        <PopoverTrigger>
+          <Box>
+            <ActionButton
+              label={`Show Models (${numVisibleColumns}/${columnVisibilityOptions.length})`}
+              icon={BsToggles}
+            />
+          </Box>
+        </PopoverTrigger>
+        <PopoverContent boxShadow="0 0 40px 4px rgba(0, 0, 0, 0.1);" minW={0} w="auto">
+          <VStack spacing={0} maxH={400} overflowY="auto">
+            {columnVisibilityOptions?.map((option, index) => (
+              <HStack
+                key={index}
+                as={Button}
+                onClick={() => toggleColumnVisibility(option.key)}
+                w="full"
+                minH={10}
+                variant="ghost"
+                justifyContent="space-between"
+                fontWeight="semibold"
+                borderRadius={0}
+                colorScheme="blue"
+                color="black"
+                fontSize="sm"
+                borderBottomWidth={1}
+              >
+                <Text mr={16}>{option.label}</Text>
+                <Box w={5}>
+                  {(!visibleColumns.length || visibleColumns.includes(option.key)) && (
+                    <Icon as={BiCheck} color="blue.500" boxSize={5} />
+                  )}
+                </Box>
+              </HStack>
+            ))}
+            {!entries?.enabledComparisonModels.includes(ComparisonModel.GPT_3_5_TURBO) && (
+              <HStack
+                as={Button}
+                w="full"
+                minH={10}
+                variant="ghost"
+                justifyContent="space-between"
+                fontWeight="semibold"
+                borderRadius={0}
+                colorScheme="orange"
+                color="black"
+                fontSize="sm"
+                borderBottomWidth={1}
+                onClick={() => {
+                  setComparisonModelIdToAdd(ComparisonModel.GPT_3_5_TURBO);
+                  addComparisonModelDialog.onOpen();
+                }}
+              >
+                <Text mr={4}>Add gpt-3.5-turbo comparison</Text>
+                <Icon as={BsPlusSquare} color="orange.400" boxSize={5} />
+              </HStack>
+            )}
+          </VStack>
+        </PopoverContent>
+      </Popover>
+      <AddComparisonModelDialog
+        modelId={comparisonModelIdToAdd}
+        disclosure={addComparisonModelDialog}
+        onClose={() => {
+          addComparisonModelDialog.onClose();
+          setComparisonModelIdToAdd(null);
+        }}
+      />
+    </>
   );
 };
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
@@ -12,7 +12,8 @@ import {
   Box,
 } from "@chakra-ui/react";
 import { BiCheck } from "react-icons/bi";
-import { BsToggles } from "react-icons/bs";
+import { BsPlusSquare, BsToggles } from "react-icons/bs";
+import { ComparisonModel } from "@prisma/client";
 
 import { useIsClientRehydrated, useTestingEntries } from "~/utils/hooks";
 import ActionButton from "~/components/ActionButton";
@@ -118,6 +119,24 @@ const ColumnVisibilityDropdown = () => {
               </Box>
             </HStack>
           ))}
+          {!entries?.enabledComparisonModels.includes(ComparisonModel.GPT_3_5_TURBO) && (
+            <HStack
+              as={Button}
+              w="full"
+              minH={10}
+              variant="ghost"
+              justifyContent="space-between"
+              fontWeight="semibold"
+              borderRadius={0}
+              colorScheme="orange"
+              color="black"
+              fontSize="sm"
+              borderBottomWidth={1}
+            >
+              <Text>Add gpt-3.5-turbo comparison</Text>
+              <Icon as={BsPlusSquare} color="orange.400" boxSize={5} />
+            </HStack>
+          )}
         </VStack>
       </PopoverContent>
     </Popover>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -9,7 +9,7 @@ const Evaluation = () => {
       <Box alignSelf="flex-start" px={8}>
         <ColumnVisibilityDropdown />
       </Box>
-      <Box w="full" flex={1} id="box">
+      <Box w="full" flex={1}>
         <EvaluationTable />
       </Box>
     </VStack>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -1,18 +1,26 @@
-import { VStack, Box } from "@chakra-ui/react";
+import { HStack, Box } from "@chakra-ui/react";
 
 import EvaluationTable from "./EvaluationTable/EvaluationTable";
 import ColumnVisibilityDropdown from "./ColumnVisibilityDropdown";
 
 const Evaluation = () => {
   return (
-    <VStack h="full">
-      <Box alignSelf="flex-start" px={8}>
+    <>
+      <HStack
+        px={8}
+        position="sticky"
+        left={0}
+        w="full"
+        justifyContent="flex-start"
+        pb={4}
+        zIndex={5}
+      >
         <ColumnVisibilityDropdown />
-      </Box>
+      </HStack>
       <Box w="full" flex={1}>
         <EvaluationTable />
       </Box>
-    </VStack>
+    </>
   );
 };
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -6,14 +6,14 @@ import { FiChevronUp, FiChevronDown } from "react-icons/fi";
 
 import ColoredPercent from "~/components/ColoredPercent";
 import { type RouterOutputs } from "~/utils/api";
-import FineTuneHeader from "./FineTuneHeader";
+import ModelHeader from "./ModelHeader";
 
 export const TableHeader = ({
   showOriginalOutput,
-  visibleFineTuneIds,
+  visibleModelIds,
 }: {
   showOriginalOutput: boolean;
-  visibleFineTuneIds: string[];
+  visibleModelIds: string[];
 }) => {
   const sharedProps = {
     position: "sticky",
@@ -35,9 +35,9 @@ export const TableHeader = ({
           </Text>
         </GridItem>
       )}
-      {visibleFineTuneIds.map((fineTuneId) => (
-        <GridItem key={fineTuneId} sx={sharedProps} borderLeftWidth={1}>
-          <FineTuneHeader fineTuneId={fineTuneId} />
+      {visibleModelIds.map((modelId) => (
+        <GridItem key={modelId} sx={sharedProps} borderLeftWidth={1}>
+          <ModelHeader modelId={modelId} />
         </GridItem>
       ))}
     </>
@@ -51,18 +51,18 @@ const EvaluationRow = ({
   output,
   fineTuneEntries,
   showOriginalOutput,
-  visibleFineTuneIds,
+  visibleModelIds,
 }: {
   messages: TestingEntry["messages"];
   output: TestingEntry["output"];
   fineTuneEntries: TestingEntry["fineTuneTestDatasetEntries"];
   showOriginalOutput: boolean;
-  visibleFineTuneIds: string[];
+  visibleModelIds: string[];
 }) => {
-  const orderedFineTuneEntries = visibleFineTuneIds.map(
-    (fineTuneId) =>
-      fineTuneEntries.find((entry) => entry.fineTuneId === fineTuneId) || {
-        fineTuneId,
+  const orderedModelEntries = visibleModelIds.map(
+    (modelId) =>
+      fineTuneEntries.find((entry) => entry.modelId === modelId) || {
+        modelId,
         output: null,
         errorMessage: null,
         score: null,
@@ -85,9 +85,9 @@ const EvaluationRow = ({
       {showOriginalOutput && (
         <FormattedOutputGridItem output={output} onHeightUpdated={onHeightUpdated} />
       )}
-      {orderedFineTuneEntries.map((entry) => (
+      {orderedModelEntries.map((entry) => (
         <FormattedOutputGridItem
-          key={entry.fineTuneId}
+          key={entry.modelId}
           output={entry.output}
           errorMessage={entry.errorMessage}
           score={entry.score}

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -26,7 +26,11 @@ const EvaluationTable = () => {
     if (!entries?.enabledComparisonModels || !entries?.deployedFineTunes)
       return [showOriginalOutput, combinedColumnIds];
 
-    combinedColumnIds.push(...entries.enabledComparisonModels);
+    combinedColumnIds.push(
+      ...entries.enabledComparisonModels.filter(
+        (cm) => !visibleColumns.length || visibleColumns.includes(cm),
+      ),
+    );
     combinedColumnIds.push(
       ...entries.deployedFineTunes
         .filter((ft) => !visibleColumns.length || visibleColumns.includes(ft.slug))

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -48,7 +48,7 @@ const EvaluationTable = () => {
         <Card flex={1} minW="fit-content" variant="outline">
           <Grid
             display="grid"
-            gridTemplateColumns={`minmax(550px, 1fr) repeat(${numOutputColumns}, 480px)`}
+            gridTemplateColumns={`minmax(600px, 1fr) repeat(${numOutputColumns}, 480px)`}
             sx={{
               "> *": {
                 borderColor: "gray.300",

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -18,21 +18,23 @@ const EvaluationTable = () => {
 
   const { visibleColumns } = useVisibleEvaluationColumns();
 
-  const [showOriginalOutput, visibleFineTuneIds] = useMemo(() => {
+  const [showOriginalOutput, visibleModelIds] = useMemo(() => {
     const showOriginalOutput =
       !visibleColumns.length || visibleColumns.includes(ORIGINAL_OUTPUT_COLUMN_KEY);
     const combinedColumnIds: string[] = [];
 
-    if (!entries?.deployedFineTunes) return [showOriginalOutput, combinedColumnIds];
+    if (!entries?.enabledComparisonModels || !entries?.deployedFineTunes)
+      return [showOriginalOutput, combinedColumnIds];
 
-    return [
-      showOriginalOutput,
-      entries.deployedFineTunes
+    combinedColumnIds.push(...entries.enabledComparisonModels);
+    combinedColumnIds.push(
+      ...entries.deployedFineTunes
         .filter((ft) => !visibleColumns.length || visibleColumns.includes(ft.slug))
         .map((ft) => ft.id),
-    ];
-  }, [entries?.deployedFineTunes, visibleColumns]);
-  const numOutputColumns = visibleFineTuneIds.length + (showOriginalOutput ? 1 : 0);
+    );
+    return [showOriginalOutput, combinedColumnIds];
+  }, [entries?.enabledComparisonModels, entries?.deployedFineTunes, visibleColumns]);
+  const numOutputColumns = visibleModelIds.length + (showOriginalOutput ? 1 : 0);
 
   if (!entries) return null;
 
@@ -52,7 +54,7 @@ const EvaluationTable = () => {
           >
             <TableHeader
               showOriginalOutput={showOriginalOutput}
-              visibleFineTuneIds={visibleFineTuneIds}
+              visibleModelIds={visibleModelIds}
             />
             {entries.entries.map((entry) => (
               <EvaluationRow
@@ -61,7 +63,7 @@ const EvaluationTable = () => {
                 output={entry.output}
                 fineTuneEntries={entry.fineTuneTestDatasetEntries}
                 showOriginalOutput={showOriginalOutput}
-                visibleFineTuneIds={visibleFineTuneIds}
+                visibleModelIds={visibleModelIds}
               />
             ))}
           </Grid>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -13,12 +13,12 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
   const entries = useTestingEntries().data;
 
   useEffect(() => {
-    if (!stats?.countFinished || !entries?.count || stats?.countFinished < entries?.count) {
+    if (!stats?.finishedCount || !entries?.count || stats?.finishedCount < entries?.count) {
       setRefetchInterval(5000);
     } else {
       setRefetchInterval(0);
     }
-  }, [stats?.countFinished, entries?.count]);
+  }, [stats?.finishedCount, entries?.count]);
 
   if (!stats || !entries) return <GridItem />;
 
@@ -41,7 +41,7 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
       )}
 
       <HStack>
-        {stats.averageScore && (
+        {stats.averageScore !== null && (
           <>
             <ColoredPercent value={stats.averageScore} />
             <Tooltip
@@ -63,9 +63,9 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
           </>
         )}
 
-        {stats.countFinished < entries.count && (
+        {stats.finishedCount < entries.count && (
           <Text>
-            {stats.countFinished}/{entries.count}
+            {stats.finishedCount}/{entries.count}
           </Text>
         )}
       </HStack>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -4,11 +4,12 @@ import Link from "next/link";
 import { BsQuestionCircle } from "react-icons/bs";
 
 import ColoredPercent from "~/components/ColoredPercent";
-import { useFineTuneTestingStats, useTestingEntries } from "~/utils/hooks";
+import { useDataset, useModelTestingStats, useTestingEntries } from "~/utils/hooks";
 
-const FineTuneHeader = ({ fineTuneId }: { fineTuneId: string }) => {
+const ModelHeader = ({ modelId }: { modelId: string }) => {
   const [refetchInterval, setRefetchInterval] = useState(0);
-  const stats = useFineTuneTestingStats(fineTuneId, refetchInterval).data;
+  const dataset = useDataset().data;
+  const stats = useModelTestingStats(dataset?.id, modelId, refetchInterval).data;
   const entries = useTestingEntries().data;
 
   useEffect(() => {
@@ -23,15 +24,21 @@ const FineTuneHeader = ({ fineTuneId }: { fineTuneId: string }) => {
 
   return (
     <VStack alignItems="flex-start">
-      <Text
-        as={Link}
-        href={{ pathname: "/fine-tunes/[id]", query: { id: fineTuneId } }}
-        _hover={{ textDecoration: "underline" }}
-        fontWeight="bold"
-        color="gray.500"
-      >
-        openpipe:{stats.slug}
-      </Text>
+      {stats.isFineTune ? (
+        <Text
+          as={Link}
+          href={{ pathname: "/fine-tunes/[id]", query: { id: modelId } }}
+          _hover={{ textDecoration: "underline" }}
+          fontWeight="bold"
+          color="gray.500"
+        >
+          openpipe:{stats.slug}
+        </Text>
+      ) : (
+        <Text fontWeight="bold" color="gray.500">
+          {modelId}
+        </Text>
+      )}
 
       <HStack>
         {stats.averageScore && (
@@ -66,4 +73,4 @@ const FineTuneHeader = ({ fineTuneId }: { fineTuneId: string }) => {
   );
 };
 
-export default FineTuneHeader;
+export default ModelHeader;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -24,7 +24,11 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
 
   return (
     <VStack alignItems="flex-start">
-      {stats.isFineTune ? (
+      {stats.isComparisonModel ? (
+        <Text fontWeight="bold" color="gray.500">
+          {stats.slug}
+        </Text>
+      ) : (
         <Text
           as={Link}
           href={{ pathname: "/fine-tunes/[id]", query: { id: modelId } }}
@@ -33,10 +37,6 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
           color="gray.500"
         >
           openpipe:{stats.slug}
-        </Text>
-      ) : (
-        <Text fontWeight="bold" color="gray.500">
-          {modelId}
         </Text>
       )}
 

--- a/app/src/components/datasets/DatasetContentTabs/Models/Models.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Models/Models.tsx
@@ -60,7 +60,11 @@ const Models = () => {
             </HStack>
             <HStack>
               <Text w={180}>Test Set Performance</Text>
-              <ColoredPercent value={fineTune.averageScore} />
+              {fineTune.status === "DEPLOYED" ? (
+                <ColoredPercent value={fineTune.averageScore} />
+              ) : (
+                <Text color="gray.500">Pending</Text>
+              )}
               {fineTune.status === "DEPLOYED" && (
                 <ViewEvaluationButton datasetId={fineTune.datasetId} fineTuneSlug={fineTune.slug} />
               )}

--- a/app/src/components/datasets/DatasetContentTabs/Settings/DeleteDatasetDialog.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Settings/DeleteDatasetDialog.tsx
@@ -45,8 +45,8 @@ const DeleteDatasetDialog = ({
           </AlertDialogHeader>
 
           <AlertDialogBody>
-            If you delete this dataset all the associated dataset entries will be deleted as well.
-            Are you sure?
+            If you delete this dataset all the associated dataset entries and fine-tuned models will
+            be deleted as well. Are you sure?
           </AlertDialogBody>
 
           <AlertDialogFooter>

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -45,7 +45,11 @@ const General = () => {
             </HStack>
             <HStack>
               <Text w={180}>Test Set Performance</Text>
-              <ColoredPercent value={fineTune.averageScore} />
+              {fineTune.status === "DEPLOYED" ? (
+                <ColoredPercent value={fineTune.averageScore} />
+              ) : (
+                <Text color="gray.500">Pending</Text>
+              )}
               {fineTune.status === "DEPLOYED" && (
                 <ViewEvaluationButton datasetId={fineTune.datasetId} fineTuneSlug={fineTune.slug} />
               )}

--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -11,6 +11,7 @@ import {
   Flex,
   useBreakpointValue,
   Tooltip,
+  type BoxProps,
 } from "@chakra-ui/react";
 import Head from "next/head";
 import Link from "next/link";
@@ -149,11 +150,13 @@ export default function AppShell({
   title,
   requireAuth,
   requireBeta,
+  containerProps,
 }: {
   children: React.ReactNode;
   title?: string;
   requireAuth?: boolean;
   requireBeta?: boolean;
+  containerProps?: BoxProps;
 }) {
   const [vh, setVh] = useState("100vh"); // Default height to prevent flicker on initial render
   const router = useRouter();
@@ -193,7 +196,7 @@ export default function AppShell({
           <title>{title ? `${title} | OpenPipe` : "OpenPipe"}</title>
         </Head>
         <NavSidebar />
-        <Box h="100%" flex={1} overflowY="auto" bgColor="gray.50">
+        <Box h="100%" flex={1} overflowY="auto" bgColor="gray.50" {...containerProps}>
           {children}
         </Box>
       </Flex>

--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -148,6 +148,7 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
               <b>{sampleSize.toLocaleString()}</b> randomly chosen logs will be added to{" "}
               {createNewDataset ? "your new dataset" : <b>{selectedDatasetOption?.label}</b>}.
             </Text>
+            <Text>Note: Only logs with a status code of 200 will be included in the dataset.</Text>
             <VStack alignItems="flex-start" spacing={4}>
               <Flex
                 flexDir={{ base: "column", md: "row" }}

--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -144,7 +144,7 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
         <ModalBody maxW="unset">
           <VStack w="full" spacing={8} pt={4} alignItems="flex-start">
             <Text>
-              Of the <b>{totalNumLogsSelected.toLocaleString()}</b> you have selected,{" "}
+              Of the <b>{totalNumLogsSelected.toLocaleString()}</b> you have selected{" "}
               <b>{sampleSize.toLocaleString()}</b> randomly chosen logs will be added to{" "}
               {createNewDataset ? "your new dataset" : <b>{selectedDatasetOption?.label}</b>}.
             </Text>

--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-import OpenAI from "openai";
 import { type ChatCompletion, type ChatCompletionCreateParams } from "openai/resources/chat";
 import { v4 as uuidv4 } from "uuid";
 import { type FineTune } from "@prisma/client";
 
 import { getStringsToPrune, pruneInputMessages } from "./getCompletion";
-import { prisma } from "~/server/db";
 import { runInference } from "~/server/modal-rpc/clients";
 import { omit } from "lodash-es";
 import { deserializeChatOutput, serializeChatInput } from "./serializers";
+import { getOpenaiCompletion } from "~/server/utils/openai";
 
 export async function getCompletion2(
   fineTune: FineTune,
@@ -24,37 +23,6 @@ export async function getCompletion2(
   } else {
     return getModalCompletion(fineTune, prunedInput);
   }
-}
-
-export async function getOpenaiCompletion(
-  projectId: string,
-  modelId: string | null,
-  input: ChatCompletionCreateParams,
-): Promise<ChatCompletion> {
-  if (!modelId) throw new Error("No OpenAI model ID found");
-
-  const apiKeys = await prisma.apiKey.findMany({
-    where: { projectId: projectId },
-  });
-
-  const openaiApiKey = apiKeys.find((key) => key.provider === "OPENAI")?.apiKey;
-
-  if (!openaiApiKey) {
-    throw new Error("No OpenAI API key found");
-  }
-
-  const openai = new OpenAI({ apiKey: openaiApiKey });
-
-  const resp = await openai.chat.completions.create({
-    ...input,
-    model: modelId,
-    stream: false,
-  });
-
-  return {
-    ...resp,
-    model: input.model,
-  };
 }
 
 async function getModalCompletion(

--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -20,20 +20,21 @@ export async function getCompletion2(
   const prunedInput = { messages: prunedMessages, ...omit(input, "messages") };
 
   if (fineTune.baseModel === "GPT_3_5_TURBO") {
-    return getOpenaiCompletion(fineTune, prunedInput);
+    return getOpenaiCompletion(fineTune.projectId, fineTune.openaiModelId, prunedInput);
   } else {
     return getModalCompletion(fineTune, prunedInput);
   }
 }
 
-async function getOpenaiCompletion(
-  fineTune: FineTune,
+export async function getOpenaiCompletion(
+  projectId: string,
+  modelId: string | null,
   input: ChatCompletionCreateParams,
 ): Promise<ChatCompletion> {
-  if (!fineTune.openaiModelId) throw new Error("No OpenAI model ID found");
+  if (!modelId) throw new Error("No OpenAI model ID found");
 
   const apiKeys = await prisma.apiKey.findMany({
-    where: { projectId: fineTune.projectId },
+    where: { projectId: projectId },
   });
 
   const openaiApiKey = apiKeys.find((key) => key.provider === "OPENAI")?.apiKey;
@@ -46,7 +47,7 @@ async function getOpenaiCompletion(
 
   const resp = await openai.chat.completions.create({
     ...input,
-    model: fineTune.openaiModelId,
+    model: modelId,
     stream: false,
   });
 

--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -19,7 +19,14 @@ export async function getCompletion2(
   const prunedInput = { messages: prunedMessages, ...omit(input, "messages") };
 
   if (fineTune.baseModel === "GPT_3_5_TURBO") {
-    return getOpenaiCompletion(fineTune.projectId, fineTune.openaiModelId, prunedInput);
+    const model = fineTune.openaiModelId;
+
+    if (!model) throw new Error("No OpenAI model ID found");
+
+    return getOpenaiCompletion(fineTune.projectId, {
+      ...prunedInput,
+      model,
+    });
   } else {
     return getModalCompletion(fineTune, prunedInput);
   }

--- a/app/src/modelProviders/fine-tuned/getCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.ts
@@ -114,9 +114,10 @@ export async function getCompletion(
   };
 }
 
-export const getStringsToPrune = async (fineTuneId: string) => {
+// If model is not a fine-tune, this will return an empty array
+export const getStringsToPrune = async (modelId: string) => {
   const pruningRules = await prisma.pruningRule.findMany({
-    where: { fineTuneId },
+    where: { fineTuneId: modelId },
     select: { textToMatch: true },
     orderBy: [{ createdAt: "asc" }, { id: "asc" }],
   });

--- a/app/src/modelProviders/fine-tuned/getCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion.ts
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import { countLlamaChatTokens, countLlamaChatTokensInMessages } from "~/utils/countTokens";
 import { type CompletionResponse } from "../types";
 import { prisma } from "~/server/db";
+import { isComparisonModel } from "~/utils/baseModels";
 
 export async function getExperimentsCompletion(
   input: ChatCompletionCreateParams,
@@ -114,8 +115,10 @@ export async function getCompletion(
   };
 }
 
-// If model is not a fine-tune, this will return an empty array
+// If model is comparison model, this will return an empty array
 export const getStringsToPrune = async (modelId: string) => {
+  if (isComparisonModel(modelId)) return [];
+
   const pruningRules = await prisma.pruningRule.findMany({
     where: { fineTuneId: modelId },
     select: { textToMatch: true },

--- a/app/src/pages/datasets/[id]/[tab].tsx
+++ b/app/src/pages/datasets/[id]/[tab].tsx
@@ -51,8 +51,8 @@ export default function Dataset() {
   }
 
   return (
-    <AppShell title={dataset.data?.name}>
-      <VStack h="full">
+    <AppShell title={dataset.data?.name} containerProps={{ position: "relative" }}>
+      <VStack position="sticky" left={0} right={0} w="full">
         <BetaBanner />
         <PageHeaderContainer>
           <Breadcrumb>
@@ -84,8 +84,8 @@ export default function Dataset() {
             </BreadcrumbItem>
           </Breadcrumb>
         </PageHeaderContainer>
-        <DatasetContentTabs />
       </VStack>
+      <DatasetContentTabs />
       <FileUploadsCard />
     </AppShell>
   );

--- a/app/src/pages/datasets/[id]/[tab].tsx
+++ b/app/src/pages/datasets/[id]/[tab].tsx
@@ -1,13 +1,4 @@
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  Center,
-  Flex,
-  Icon,
-  Input,
-  VStack,
-  useDisclosure,
-} from "@chakra-ui/react";
+import { Breadcrumb, BreadcrumbItem, Center, Flex, Icon, Input, VStack } from "@chakra-ui/react";
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { AiOutlineDatabase } from "react-icons/ai";
@@ -27,7 +18,6 @@ export default function Dataset() {
 
   const dataset = useDataset();
 
-  const drawerDisclosure = useDisclosure();
   const [name, setName] = useState(dataset.data?.name || "");
   useEffect(() => {
     setName(dataset.data?.name || "");
@@ -42,7 +32,9 @@ export default function Dataset() {
     if (name && name !== dataset.data?.name && dataset.data?.id) {
       await updateMutation.mutateAsync({
         id: dataset.data.id,
-        name,
+        updates: {
+          name,
+        },
       });
       await Promise.all([utils.datasets.list.invalidate(), utils.datasets.get.invalidate()]);
     }

--- a/app/src/server/scripts/backfillTestingDatasets.ts
+++ b/app/src/server/scripts/backfillTestingDatasets.ts
@@ -42,7 +42,7 @@ let numEntries = 0;
 
 for (const entry of fineTune.dataset.datasetEntries) {
   await evaluateTestSetEntry.enqueue({
-    fineTuneId: fineTune.id,
+    modelId: fineTune.id,
     datasetEntryId: entry.id,
     skipCache: true,
   });

--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -10,10 +10,11 @@ import {
   getStringsToPrune,
 } from "~/modelProviders/fine-tuned/getCompletion";
 import { countLlamaChatTokens, countLlamaChatTokensInMessages } from "~/utils/countTokens";
-import { getCompletion2, getOpenaiCompletion } from "~/modelProviders/fine-tuned/getCompletion-2";
+import { getCompletion2 } from "~/modelProviders/fine-tuned/getCompletion-2";
 import { calculateEntryScore } from "../utils/calculateEntryScore";
 import { typedDatasetEntry } from "~/types/dbColumns.types";
 import { getComparisonModelName, isComparisonModel } from "~/utils/baseModels";
+import { getOpenaiCompletion } from "../utils/openai";
 
 export type EvaluateTestSetEntryJob = {
   modelId: string;
@@ -73,6 +74,8 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
     const cacheKey = hashObject({
       modelId,
       input: prunedMessages,
+      function_call: datasetEntry.function_call,
+      functions: datasetEntry.functions,
     } as JsonValue);
 
     if (!skipCache) {

--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -105,11 +105,7 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
     };
     try {
       if (isComparisonModel(modelId)) {
-        completion = await getOpenaiCompletion(
-          rawDatasetEntry.dataset.projectId,
-          getComparisonModelName(modelId as ComparisonModel),
-          input,
-        );
+        completion = await getOpenaiCompletion(rawDatasetEntry.dataset.projectId, input);
       } else if (fineTune && (fineTune.pipelineVersion === 1 || fineTune.pipelineVersion === 2)) {
         completion = await getCompletion2(fineTune, input);
       } else {

--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -1,6 +1,5 @@
 import { type ComparisonModel, type Prisma } from "@prisma/client";
 import { type JsonValue } from "type-fest";
-import { omit } from "lodash-es";
 
 import { prisma } from "~/server/db";
 import hashObject from "~/server/utils/hashObject";
@@ -47,7 +46,7 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
       });
     }
 
-    const datasetEntry = typedDatasetEntry(omit(rawDatasetEntry, "dataset"));
+    const datasetEntry = typedDatasetEntry(rawDatasetEntry);
 
     const existingTestEntry = await prisma.fineTuneTestingEntry.findUnique({
       where: { modelId_datasetEntryId: { modelId, datasetEntryId } },

--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -26,8 +26,6 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
   handler: async (task) => {
     const { modelId, datasetEntryId, skipCache } = task;
 
-    console.log("evaluating");
-
     const rawDatasetEntry = await prisma.datasetEntry.findUnique({
       where: { id: datasetEntryId },
       include: {
@@ -39,9 +37,7 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
       },
     });
 
-    console.log(0.1);
     if (!rawDatasetEntry?.dataset) return;
-    console.log(0.2);
 
     let fineTune;
     if (!isComparisonModel(modelId)) {
@@ -50,19 +46,13 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
       });
     }
 
-    // console.log("raw dataset entry", omit(rawDatasetEntry, "dataset"));
-
     const datasetEntry = typedDatasetEntry(omit(rawDatasetEntry, "dataset"));
 
     const existingTestEntry = await prisma.fineTuneTestingEntry.findUnique({
       where: { modelId_datasetEntryId: { modelId, datasetEntryId } },
     });
 
-    console.log(1);
-
     if (existingTestEntry?.output && !skipCache) return;
-
-    console.log(2);
 
     let prunedMessages = existingTestEntry?.prunedInput;
 
@@ -79,8 +69,6 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
         },
       });
     }
-
-    console.log(3);
 
     const cacheKey = hashObject({
       modelId,
@@ -106,8 +94,6 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
         return;
       }
     }
-
-    console.log(4);
 
     let completion;
     const input = {
@@ -137,8 +123,6 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
         return;
       }
 
-      console.log(5);
-
       const completionMessage = completion.choices[0]?.message;
       if (!completionMessage) throw new Error("No completion returned");
       let score;
@@ -159,9 +143,7 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
           errorMessage: null,
         },
       });
-      console.log(5.5);
     } catch (e) {
-      console.log(6);
       await prisma.fineTuneTestingEntry.update({
         where: { modelId_datasetEntryId: { modelId, datasetEntryId } },
         data: {

--- a/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
@@ -57,7 +57,7 @@ const runOnce = async () => {
             },
           });
           captureFineTuneTrainingFinished(fineTune.projectId, fineTune.slug, true);
-          await startTestJobs(fineTune);
+          await startTestJobs(fineTune.datasetId, fineTune.id);
         } else if (resp.status === "failed") {
           await prisma.fineTune.update({
             where: { id: fineTune.id },

--- a/app/src/server/tasks/importDatasetEntries.task.ts
+++ b/app/src/server/tasks/importDatasetEntries.task.ts
@@ -4,6 +4,7 @@ import { downloadBlobToString } from "~/utils/azure/server";
 import { prepareDatasetEntriesForImport } from "../utils/prepareDatasetEntriesForImport";
 import { updatePruningRuleMatches } from "../utils/updatePruningRuleMatches";
 import defineTask from "./defineTask";
+import { startDatasetTestJobs } from "../utils/startTestJobs";
 
 export type ImportDatasetEntriesJob = {
   datasetFileUploadId: string;
@@ -114,6 +115,8 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
       new Date(0),
       datasetEntriesToCreate.map((entry) => entry.id),
     );
+
+    await startDatasetTestJobs(datasetFileUpload.datasetId);
 
     await prisma.datasetFileUpload.update({
       where: { id: datasetFileUploadId },

--- a/app/src/server/utils/openai.ts
+++ b/app/src/server/utils/openai.ts
@@ -26,11 +26,8 @@ export const openai = new OpenAI(config);
 
 export async function getOpenaiCompletion(
   projectId: string,
-  modelId: string | null,
   input: ChatCompletionCreateParams,
 ): Promise<ChatCompletion> {
-  if (!modelId) throw new Error("No OpenAI model ID found");
-
   const apiKeys = await prisma.apiKey.findMany({
     where: { projectId: projectId },
   });
@@ -45,7 +42,6 @@ export async function getOpenaiCompletion(
 
   const resp = await openai.chat.completions.create({
     ...input,
-    model: modelId,
     stream: false,
   });
 

--- a/app/src/server/utils/openai.ts
+++ b/app/src/server/utils/openai.ts
@@ -1,8 +1,10 @@
 import fs from "fs";
 import path from "path";
 import OpenAI, { type ClientOptions } from "openpipe/openai";
+import { type ChatCompletion, type ChatCompletionCreateParams } from "openai/resources/chat";
 
 import { env } from "~/env.mjs";
+import { prisma } from "../db";
 
 let config: ClientOptions;
 
@@ -21,3 +23,34 @@ try {
 }
 
 export const openai = new OpenAI(config);
+
+export async function getOpenaiCompletion(
+  projectId: string,
+  modelId: string | null,
+  input: ChatCompletionCreateParams,
+): Promise<ChatCompletion> {
+  if (!modelId) throw new Error("No OpenAI model ID found");
+
+  const apiKeys = await prisma.apiKey.findMany({
+    where: { projectId: projectId },
+  });
+
+  const openaiApiKey = apiKeys.find((key) => key.provider === "OPENAI")?.apiKey;
+
+  if (!openaiApiKey) {
+    throw new Error("No OpenAI API key found");
+  }
+
+  const openai = new OpenAI({ apiKey: openaiApiKey });
+
+  const resp = await openai.chat.completions.create({
+    ...input,
+    model: modelId,
+    stream: false,
+  });
+
+  return {
+    ...resp,
+    model: input.model,
+  };
+}

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -23,7 +23,6 @@ export const startDatasetTestJobs = async (datasetId: string) => {
 };
 
 export const startTestJobs = async (datasetId: string, modelId: string) => {
-  const stringsToPrune = await getStringsToPrune(modelId);
   const datasetEntries = await prisma.datasetEntry.findMany({
     where: {
       datasetId,
@@ -37,17 +36,10 @@ export const startTestJobs = async (datasetId: string, modelId: string) => {
 
   // create fineTuneTestEntry for each dataset entry
   await prisma.fineTuneTestingEntry.createMany({
-    data: datasetEntries.map((entry) => {
-      const prunedInput = pruneInputMessages(
-        z.array(chatMessage).parse(entry.messages),
-        stringsToPrune,
-      );
-      return {
-        modelId,
-        datasetEntryId: entry.id,
-        prunedInput: JSON.stringify(prunedInput),
-      };
-    }),
+    data: datasetEntries.map((entry) => ({
+      modelId,
+      datasetEntryId: entry.id,
+    })),
     skipDuplicates: true,
   });
   for (const entry of datasetEntries) {

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -1,19 +1,41 @@
-import { type FineTune } from "@prisma/client";
-
 import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
 import { prisma } from "../db";
 import { countLlamaChatTokens, countOpenAIChatTokens } from "~/utils/countTokens";
 import { evaluateTestSetEntry } from "../tasks/evaluateTestSetEntry.task";
 import { z } from "zod";
 import { chatMessage } from "~/types/shared.types";
+import { BaseModel, ComparisonModel } from "@prisma/client";
 
-export const startTestJobs = async (fineTune: FineTune) => {
-  const stringsToPrune = await getStringsToPrune(fineTune.id);
-  const datasetEntries = await prisma.datasetEntry.findMany({
-    where: { datasetId: fineTune.datasetId, outdated: false, type: "TEST" },
-    select: { id: true, messages: true },
-    orderBy: { sortKey: "desc" },
+export const startDatasetTestJobs = async (datasetId: string) => {
+  const dataset = await prisma.dataset.findUnique({
+    where: { id: datasetId },
+    include: {
+      fineTunes: true,
+    },
   });
+  if (!dataset) return;
+  for (const fineTune of dataset.fineTunes) {
+    await startTestJobs(datasetId, fineTune.id);
+  }
+  for (const comparisonModel of dataset.enabledComparisonModels) {
+    await startTestJobs(datasetId, comparisonModel);
+  }
+};
+
+export const startTestJobs = async (datasetId: string, modelId: string) => {
+  const stringsToPrune = await getStringsToPrune(modelId);
+  const [datasetEntries, fineTune] = await prisma.$transaction([
+    prisma.datasetEntry.findMany({
+      where: { datasetId, outdated: false, type: "TEST" },
+      select: { id: true, messages: true },
+      orderBy: { sortKey: "desc" },
+    }),
+    prisma.fineTune.findUnique({
+      where: { id: modelId },
+      select: { baseModel: true },
+    }),
+  ]);
+  const baseModel = fineTune?.baseModel;
   // create fineTuneTestEntry for each dataset entry
   await prisma.fineTuneTestingEntry.createMany({
     data: datasetEntries.map((entry) => {
@@ -22,13 +44,13 @@ export const startTestJobs = async (fineTune: FineTune) => {
         stringsToPrune,
       );
       let prunedInputTokens;
-      if (fineTune.baseModel === "GPT_3_5_TURBO") {
+      if (baseModel === BaseModel.GPT_3_5_TURBO || modelId === ComparisonModel.GPT_3_5_TURBO) {
         prunedInputTokens = countOpenAIChatTokens("gpt-3.5-turbo-0613", prunedInput);
       } else {
         prunedInputTokens = countLlamaChatTokens(JSON.stringify(prunedInput));
       }
       return {
-        fineTuneId: fineTune.id,
+        modelId,
         datasetEntryId: entry.id,
         prunedInputTokens,
         prunedInput: JSON.stringify(prunedInput),
@@ -37,6 +59,6 @@ export const startTestJobs = async (fineTune: FineTune) => {
     skipDuplicates: true,
   });
   for (const entry of datasetEntries) {
-    await evaluateTestSetEntry.enqueue({ fineTuneId: fineTune.id, datasetEntryId: entry.id });
+    await evaluateTestSetEntry.enqueue({ modelId, datasetEntryId: entry.id });
   }
 };

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -1,8 +1,5 @@
-import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
 import { prisma } from "../db";
 import { evaluateTestSetEntry } from "../tasks/evaluateTestSetEntry.task";
-import { z } from "zod";
-import { chatMessage } from "~/types/shared.types";
 
 export const startDatasetTestJobs = async (datasetId: string) => {
   const dataset = await prisma.dataset.findUnique({

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -1,11 +1,8 @@
 import { getStringsToPrune, pruneInputMessages } from "~/modelProviders/fine-tuned/getCompletion";
 import { prisma } from "../db";
-import { countLlamaChatTokens, countOpenAIChatTokens } from "~/utils/countTokens";
 import { evaluateTestSetEntry } from "../tasks/evaluateTestSetEntry.task";
 import { z } from "zod";
 import { chatMessage } from "~/types/shared.types";
-import { BaseModel, ComparisonModel } from "@prisma/client";
-import { isComparisonModel } from "~/utils/baseModels";
 
 export const startDatasetTestJobs = async (datasetId: string) => {
   const dataset = await prisma.dataset.findUnique({
@@ -37,14 +34,7 @@ export const startTestJobs = async (datasetId: string, modelId: string) => {
     select: { id: true, messages: true },
     orderBy: { sortKey: "desc" },
   });
-  let fineTune;
-  if (!isComparisonModel(modelId)) {
-    fineTune = await prisma.fineTune.findUnique({
-      where: { id: modelId },
-      select: { baseModel: true },
-    });
-  }
-  const baseModel = fineTune?.baseModel;
+
   // create fineTuneTestEntry for each dataset entry
   await prisma.fineTuneTestingEntry.createMany({
     data: datasetEntries.map((entry) => {
@@ -52,16 +42,9 @@ export const startTestJobs = async (datasetId: string, modelId: string) => {
         z.array(chatMessage).parse(entry.messages),
         stringsToPrune,
       );
-      let prunedInputTokens;
-      if (baseModel === BaseModel.GPT_3_5_TURBO || modelId === ComparisonModel.GPT_3_5_TURBO) {
-        prunedInputTokens = countOpenAIChatTokens("gpt-3.5-turbo-0613", prunedInput);
-      } else {
-        prunedInputTokens = countLlamaChatTokens(JSON.stringify(prunedInput));
-      }
       return {
         modelId,
         datasetEntryId: entry.id,
-        prunedInputTokens,
         prunedInput: JSON.stringify(prunedInput),
       };
     }),

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -11,7 +11,9 @@ export const startDatasetTestJobs = async (datasetId: string) => {
   const dataset = await prisma.dataset.findUnique({
     where: { id: datasetId },
     include: {
-      fineTunes: true,
+      fineTunes: {
+        where: { status: "DEPLOYED" },
+      },
     },
   });
   if (!dataset) return;

--- a/app/src/types/kysely-codegen.types.ts
+++ b/app/src/types/kysely-codegen.types.ts
@@ -148,8 +148,7 @@ export interface FineTune {
 export interface FineTuneTestingEntry {
   id: string;
   cacheKey: string | null;
-  prunedInputTokens: number;
-  prunedInput: string;
+  prunedInputTokens: number | null;
   outputTokens: number | null;
   output: Json | null;
   errorMessage: string | null;

--- a/app/src/types/kysely-codegen.types.ts
+++ b/app/src/types/kysely-codegen.types.ts
@@ -64,6 +64,7 @@ export interface Dataset {
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
   trainingRatio: Generated<number>;
+  enabledComparisonModels: Generated<string[] | null>;
 }
 
 export interface DatasetEntry {
@@ -72,7 +73,7 @@ export interface DatasetEntry {
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
   loggedCallId: string | null;
-  input: Generated<Json>;
+  messages: Generated<Json>;
   inputTokens: number;
   output: Json | null;
   outputTokens: number;
@@ -81,6 +82,8 @@ export interface DatasetEntry {
   outdated: Generated<boolean>;
   sortKey: string;
   persistentId: string;
+  function_call: Json | null;
+  functions: Json | null;
 }
 
 export interface DatasetFileUpload {
@@ -150,11 +153,12 @@ export interface FineTuneTestingEntry {
   outputTokens: number | null;
   output: Json | null;
   errorMessage: string | null;
-  fineTuneId: string;
+  fineTuneId: string | null;
   datasetEntryId: string;
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;
   score: number | null;
+  modelId: string;
 }
 
 export interface FineTuneTrainingEntry {

--- a/app/src/utils/baseModels.ts
+++ b/app/src/utils/baseModels.ts
@@ -1,4 +1,4 @@
-import { BaseModel } from "@prisma/client";
+import { BaseModel, ComparisonModel } from "@prisma/client";
 
 export const SUPPORTED_BASE_MODELS = Object.values(BaseModel) as [BaseModel, ...BaseModel[]];
 
@@ -10,6 +10,13 @@ export const displayBaseModel = (baseModel: BaseModel) => {
       return "llama2-7b";
     case "LLAMA2_13b":
       return "llama2-13b";
+    case "GPT_3_5_TURBO":
+      return "gpt-3.5-turbo";
+  }
+};
+
+export const getComparisonModelName = (comparisonModel: ComparisonModel) => {
+  switch (comparisonModel) {
     case "GPT_3_5_TURBO":
       return "gpt-3.5-turbo";
   }

--- a/app/src/utils/baseModels.ts
+++ b/app/src/utils/baseModels.ts
@@ -21,6 +21,6 @@ export const isComparisonModel = (modelId: string) =>
 export const getComparisonModelName = (comparisonModel: ComparisonModel) => {
   switch (comparisonModel) {
     case "GPT_3_5_TURBO":
-      return "gpt-3.5-turbo";
+      return "gpt-3.5-turbo-0613";
   }
 };

--- a/app/src/utils/baseModels.ts
+++ b/app/src/utils/baseModels.ts
@@ -15,6 +15,9 @@ export const displayBaseModel = (baseModel: BaseModel) => {
   }
 };
 
+export const isComparisonModel = (modelId: string) =>
+  ComparisonModel[modelId as keyof typeof ComparisonModel] !== undefined;
+
 export const getComparisonModelName = (comparisonModel: ComparisonModel) => {
   switch (comparisonModel) {
     case "GPT_3_5_TURBO":

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -245,10 +245,14 @@ export const useTestingEntries = (refetchInterval?: number) => {
   );
 };
 
-export const useFineTuneTestingStats = (fineTuneId?: string, refetchInterval?: number) => {
-  return api.fineTunes.testingStats.useQuery(
-    { fineTuneId: fineTuneId ?? "" },
-    { enabled: !!fineTuneId, refetchInterval },
+export const useModelTestingStats = (
+  datasetId?: string,
+  modelId?: string,
+  refetchInterval?: number,
+) => {
+  return api.datasetEntries.testingStats.useQuery(
+    { datasetId: datasetId ?? "", modelId: modelId ?? "" },
+    { enabled: !!datasetId && !!modelId, refetchInterval },
   );
 };
 


### PR DESCRIPTION
Allow user to compare the performance of their models against gpt-3.5-turbo.

### Changes
* Index FineTuneTestingDatasetEntry by `modelId` instead of `fineTuneId`
* In general, allow comparison model id to be used in the same way `fineTuneId` was being used
* Kick off testing jobs when new dataset entries are added to a dataset