### PR TITLE
Allow user to sort test dataset entries by model accuracy

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/AddComparisonModelDialog.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/AddComparisonModelDialog.tsx
@@ -25,7 +25,7 @@ import {
   useTestingEntries,
 } from "~/utils/hooks";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
-import { getComparisonModelName } from "~/utils/baseModels";
+import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
 
 const AddComparisonModelDialog = ({
   modelId,
@@ -69,7 +69,7 @@ const AddComparisonModelDialog = ({
 
   if (!modelId) return null;
 
-  const modelName = getComparisonModelName(modelId);
+  const modelName = COMPARISON_MODEL_NAMES[modelId];
 
   return (
     <AlertDialog leastDestructiveRef={cancelRef} {...disclosure} onClose={onClose}>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
@@ -49,7 +49,7 @@ const ColumnVisibilityDropdown = () => {
     for (const comparisonModel of entries?.enabledComparisonModels ?? []) {
       options.push({
         label: COMPARISON_MODEL_NAMES[comparisonModel],
-        key: comparisonModel,
+        key: COMPARISON_MODEL_NAMES[comparisonModel],
       });
     }
     for (const slug of fineTuneSlugs ?? []) {
@@ -171,7 +171,7 @@ const ColumnVisibilityDropdown = () => {
         disclosure={addComparisonModelDialog}
         onClose={() => {
           addComparisonModelDialog.onClose();
-          ensureColumnShown(comparisonModelIdToAdd as string);
+          ensureColumnShown(COMPARISON_MODEL_NAMES[comparisonModelIdToAdd as ComparisonModel]);
           setComparisonModelIdToAdd(null);
         }}
       />

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
@@ -18,7 +18,7 @@ import { ComparisonModel } from "@prisma/client";
 import { useIsClientRehydrated, useTestingEntries } from "~/utils/hooks";
 import ActionButton from "~/components/ActionButton";
 import { useVisibleEvaluationColumns } from "./useVisibleEvaluationColumns";
-import { getComparisonModelName } from "~/utils/baseModels";
+import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
 import AddComparisonModelDialog from "./AddComparisonModelDialog";
 
 export const EMPTY_OUTPUT_COLUMNS_KEY = "empty";
@@ -48,7 +48,7 @@ const ColumnVisibilityDropdown = () => {
     ];
     for (const comparisonModel of entries?.enabledComparisonModels ?? []) {
       options.push({
-        label: getComparisonModelName(comparisonModel),
+        label: COMPARISON_MODEL_NAMES[comparisonModel],
         key: comparisonModel,
       });
     }

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -6,6 +6,7 @@ import EvaluationRow, { TableHeader } from "./EvaluationRow";
 import EvaluationPaginator from "./EvaluationPaginator";
 import { ORIGINAL_OUTPUT_COLUMN_KEY } from "../ColumnVisibilityDropdown";
 import { useVisibleEvaluationColumns } from "../useVisibleEvaluationColumns";
+import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
 
 const EvaluationTable = () => {
   const [refetchInterval, setRefetchInterval] = useState(0);
@@ -28,7 +29,7 @@ const EvaluationTable = () => {
 
     combinedColumnIds.push(
       ...entries.enabledComparisonModels.filter(
-        (cm) => !visibleColumns.length || visibleColumns.includes(cm),
+        (cm) => !visibleColumns.length || visibleColumns.includes(COMPARISON_MODEL_NAMES[cm]),
       ),
     );
     combinedColumnIds.push(

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -67,6 +67,7 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
                 spacing={0}
                 h={6}
                 cursor="pointer"
+                mb={1}
                 onClick={() => {
                   const modelSelected = sortModelSlug === stats.slug;
                   if (!modelSelected) {

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -1,17 +1,20 @@
 import { useState, useEffect } from "react";
-import { Text, VStack, HStack, Tooltip, Box, Icon, GridItem } from "@chakra-ui/react";
+import { Text, VStack, HStack, Tooltip, Box, GridItem, Icon } from "@chakra-ui/react";
 import Link from "next/link";
-import { BsQuestionCircle } from "react-icons/bs";
+import { BiSolidUpArrowAlt, BiSolidDownArrowAlt } from "react-icons/bi";
 
 import ColoredPercent from "~/components/ColoredPercent";
 import { useDataset, useModelTestingStats, useTestingEntries } from "~/utils/hooks";
 import { displayBaseModel } from "~/utils/baseModels";
+import { useTestEntrySortOrder } from "../useTestEntrySortOrder";
+import { SortOrder } from "~/types/shared.types";
 
 const ModelHeader = ({ modelId }: { modelId: string }) => {
   const [refetchInterval, setRefetchInterval] = useState(0);
   const dataset = useDataset().data;
   const stats = useModelTestingStats(dataset?.id, modelId, refetchInterval).data;
   const entries = useTestingEntries().data;
+  const { sortModelSlug, sortOrder, setSortCriteria } = useTestEntrySortOrder();
 
   useEffect(() => {
     if (!stats?.finishedCount || !entries?.count || stats?.finishedCount < entries?.count) {
@@ -25,26 +28,24 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
 
   return (
     <VStack alignItems="flex-start">
-      {stats.isComparisonModel ? (
-        <Text fontWeight="bold" color="gray.500">
-          {stats.slug}
-        </Text>
-      ) : (
-        <Text
-          as={Link}
-          href={{ pathname: "/fine-tunes/[id]", query: { id: modelId } }}
-          _hover={{ textDecoration: "underline" }}
-          fontWeight="bold"
-          color="gray.500"
-        >
-          openpipe:{stats.slug}
-        </Text>
-      )}
-
-      <HStack>
+      <HStack w="full" justifyContent="space-between">
+        {stats.isComparisonModel ? (
+          <Text fontWeight="bold" color="gray.500">
+            {stats.slug}
+          </Text>
+        ) : (
+          <Text
+            as={Link}
+            href={{ pathname: "/fine-tunes/[id]", query: { id: modelId } }}
+            _hover={{ textDecoration: "underline" }}
+            fontWeight="bold"
+            color="gray.500"
+          >
+            openpipe:{stats.slug}
+          </Text>
+        )}
         {stats.averageScore !== null && (
-          <>
-            <ColoredPercent value={stats.averageScore} />
+          <HStack spacing={1}>
             <Tooltip
               label={
                 <>
@@ -57,12 +58,53 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
               }
               aria-label="Help about accuracy"
             >
-              <Box lineHeight={0}>
-                <Icon as={BsQuestionCircle} color="gray.600" boxSize={4} />
+              <Box>
+                <ColoredPercent value={stats.averageScore} />
               </Box>
             </Tooltip>
-          </>
+            <Tooltip label={`Sort by ${stats.slug} accuracy`}>
+              <VStack
+                spacing={0}
+                h={6}
+                cursor="pointer"
+                onClick={() => {
+                  const modelSelected = sortModelSlug === stats.slug;
+                  if (!modelSelected) {
+                    setSortCriteria(stats.slug, SortOrder.DESC);
+                  } else if (sortOrder === SortOrder.DESC) {
+                    setSortCriteria(stats.slug, SortOrder.ASC);
+                  } else {
+                    setSortCriteria(null, null);
+                  }
+                }}
+              >
+                <Icon
+                  as={BiSolidUpArrowAlt}
+                  color={
+                    sortModelSlug === stats.slug && sortOrder === SortOrder.ASC
+                      ? "orange.400"
+                      : "gray.500"
+                  }
+                  boxSize={4}
+                  strokeWidth={2}
+                  mb={-1}
+                />
+                <Icon
+                  as={BiSolidDownArrowAlt}
+                  color={
+                    sortModelSlug === stats.slug && sortOrder === SortOrder.DESC
+                      ? "orange.400"
+                      : "gray.500"
+                  }
+                  boxSize={4}
+                  strokeWidth={2}
+                />
+              </VStack>
+            </Tooltip>
+          </HStack>
         )}
+      </HStack>
+      <HStack>
         {stats.baseModel && <Text color="gray.500">{displayBaseModel(stats.baseModel)}</Text>}
 
         {stats.finishedCount < entries.count && (

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Text, VStack, HStack, Tooltip, Box, GridItem, Icon } from "@chakra-ui/react";
 import Link from "next/link";
-import { BiSolidUpArrowAlt, BiSolidDownArrowAlt } from "react-icons/bi";
+import { BiSolidUpArrow, BiSolidDownArrow } from "react-icons/bi";
 
 import ColoredPercent from "~/components/ColoredPercent";
 import { useDataset, useModelTestingStats, useTestingEntries } from "~/utils/hooks";
@@ -67,7 +67,6 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
                 spacing={0}
                 h={6}
                 cursor="pointer"
-                mb={1}
                 onClick={() => {
                   const modelSelected = sortModelSlug === stats.slug;
                   if (!modelSelected) {
@@ -80,24 +79,23 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
                 }}
               >
                 <Icon
-                  as={BiSolidUpArrowAlt}
+                  as={BiSolidUpArrow}
                   color={
                     sortModelSlug === stats.slug && sortOrder === SortOrder.ASC
                       ? "orange.400"
-                      : "gray.500"
+                      : "gray.300"
                   }
-                  boxSize={4}
+                  boxSize={3}
                   strokeWidth={2}
-                  mb={-1}
                 />
                 <Icon
-                  as={BiSolidDownArrowAlt}
+                  as={BiSolidDownArrow}
                   color={
                     sortModelSlug === stats.slug && sortOrder === SortOrder.DESC
                       ? "orange.400"
-                      : "gray.500"
+                      : "gray.300"
                   }
-                  boxSize={4}
+                  boxSize={3}
                   strokeWidth={2}
                 />
               </VStack>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/useTestEntrySortOrder.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/useTestEntrySortOrder.tsx
@@ -1,0 +1,44 @@
+import { useRouter } from "next/router";
+
+import { type SortOrder } from "~/types/shared.types";
+
+const SORT_MODEL_KEY = "sortModel";
+const SORT_ORDER_KEY = "sortOrder";
+
+export const useTestEntrySortOrder = () => {
+  const router = useRouter();
+
+  // Extract the sort model and sort order from the URL query.
+  const sortModelSlug =
+    typeof router.query[SORT_MODEL_KEY] === "string" ? router.query[SORT_MODEL_KEY] : null;
+  const sortOrder =
+    typeof router.query[SORT_ORDER_KEY] === "string" ? router.query[SORT_ORDER_KEY] : null;
+
+  const setSortCriteria = (newSortModelSlug: string | null, newSortOrder: SortOrder | null) => {
+    // Form the updated query.
+    const updatedQuery = { ...router.query };
+
+    if (newSortModelSlug) {
+      updatedQuery[SORT_MODEL_KEY] = newSortModelSlug;
+    } else {
+      delete updatedQuery[SORT_MODEL_KEY];
+    }
+
+    if (newSortOrder) {
+      updatedQuery[SORT_ORDER_KEY] = newSortOrder;
+    } else {
+      delete updatedQuery[SORT_ORDER_KEY];
+    }
+
+    void router.push(
+      {
+        pathname: router.pathname,
+        query: updatedQuery,
+      },
+      undefined,
+      { shallow: true },
+    );
+  };
+
+  return { sortModelSlug, sortOrder, setSortCriteria };
+};

--- a/app/src/pages/fine-tunes/[id]/[tab].tsx
+++ b/app/src/pages/fine-tunes/[id]/[tab].tsx
@@ -26,7 +26,7 @@ export default function FineTune() {
   const { slug } = fineTune.data;
 
   return (
-    <AppShell title={`openpipe:${slug}`}>
+    <AppShell title={`openpipe:${slug}`} requireBeta>
       <VStack h="full" overflowY="scroll">
         <PageHeaderContainer>
           <Breadcrumb>

--- a/app/src/pages/fine-tunes/index.tsx
+++ b/app/src/pages/fine-tunes/index.tsx
@@ -6,7 +6,7 @@ import AppShell from "~/components/nav/AppShell";
 
 export default function FineTunes() {
   return (
-    <AppShell title="Fine Tunes" requireAuth>
+    <AppShell title="Fine Tunes" requireAuth requireBeta>
       <BetaBanner />
       <VStack px={8} py={8} alignItems="flex-start" spacing={4} w="full">
         <Text fontSize="2xl" fontWeight="bold">

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -577,6 +577,14 @@ export const datasetEntriesRouter = createTRPCRouter({
               .whereRef("ftte.datasetEntryId", "=", "de.id"),
           ).as("fineTuneTestDatasetEntries"),
         ])
+        .orderBy(() =>
+          sql.raw(
+            `CASE
+             WHEN sftte.score IS NULL THEN 1
+             ELSE 0
+           END`,
+          ),
+        )
         .orderBy("sftte.score", scoreSortOrder)
         .orderBy("de.sortKey", "desc")
         .offset((page - 1) * pageSize)

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -535,19 +535,15 @@ export const datasetEntriesRouter = createTRPCRouter({
       if (sort?.sortModelSlug && isComparisonModelName(sort?.sortModelSlug)) {
         sortModelId = getComparisonModel(sort?.sortModelSlug) ?? "";
       } else if (sort?.sortModelSlug) {
-        try {
-          const fineTune = await prisma.fineTune.findFirst({
-            where: {
-              slug: sort?.sortModelSlug,
-            },
-            select: {
-              id: true,
-            },
-          });
-          sortModelId = fineTune?.id ?? "";
-        } catch (e) {
-          // If the slug is malformed, do nothing
-        }
+        const fineTune = await prisma.fineTune.findFirst({
+          where: {
+            slug: sort?.sortModelSlug,
+          },
+          select: {
+            id: true,
+          },
+        });
+        sortModelId = fineTune?.id ?? "";
       }
 
       let scoreSortOrder: SortOrder = SortOrder.DESC;
@@ -586,29 +582,6 @@ export const datasetEntriesRouter = createTRPCRouter({
         .offset((page - 1) * pageSize)
         .limit(pageSize)
         .execute();
-
-      await prisma.datasetEntry.findMany({
-        where: {
-          datasetId,
-          outdated: false,
-          type: "TEST",
-        },
-        include: {
-          fineTuneTestDatasetEntries: {
-            select: {
-              modelId: true,
-              output: true,
-              score: true,
-              errorMessage: true,
-            },
-          },
-        },
-        orderBy: {
-          sortKey: "desc",
-        },
-        skip: (page - 1) * pageSize,
-        take: pageSize,
-      });
 
       const [count, deployedFineTunes] = await prisma.$transaction([
         prisma.datasetEntry.count({

--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -8,11 +8,7 @@ import { trainFineTune } from "~/server/tasks/fineTuning/trainFineTune.task";
 import { CURRENT_PIPELINE_VERSION } from "~/types/shared.types";
 import { requireCanModifyProject, requireCanViewProject } from "~/utils/accessControl";
 import { captureFineTuneCreation } from "~/utils/analytics/serverAnalytics";
-import {
-  COMPARISON_MODEL_NAMES,
-  SUPPORTED_BASE_MODELS,
-  isComparisonModelName,
-} from "~/utils/baseModels";
+import { SUPPORTED_BASE_MODELS, isComparisonModelName } from "~/utils/baseModels";
 import { error, success } from "~/utils/errorHandling/standardResponses";
 
 const BaseModelEnum = z.enum(SUPPORTED_BASE_MODELS);

--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -8,7 +8,11 @@ import { trainFineTune } from "~/server/tasks/fineTuning/trainFineTune.task";
 import { CURRENT_PIPELINE_VERSION } from "~/types/shared.types";
 import { requireCanModifyProject, requireCanViewProject } from "~/utils/accessControl";
 import { captureFineTuneCreation } from "~/utils/analytics/serverAnalytics";
-import { SUPPORTED_BASE_MODELS } from "~/utils/baseModels";
+import {
+  COMPARISON_MODEL_NAMES,
+  SUPPORTED_BASE_MODELS,
+  isComparisonModelName,
+} from "~/utils/baseModels";
 import { error, success } from "~/utils/errorHandling/standardResponses";
 
 const BaseModelEnum = z.enum(SUPPORTED_BASE_MODELS);
@@ -141,6 +145,10 @@ export const fineTunesRouter = createTRPCRouter({
       });
       await requireCanModifyProject(projectId, ctx);
 
+      if (isComparisonModelName(input.slug)) {
+        return error("Fine tune IDs cannot match any base model names");
+      }
+
       const existingFineTune = await prisma.fineTune.findFirst({
         where: {
           slug: input.slug,
@@ -260,6 +268,10 @@ export const fineTunesRouter = createTRPCRouter({
 
       if (!fineTune) return error("Fine tune not found");
       await requireCanModifyProject(fineTune.projectId, ctx);
+
+      if (isComparisonModelName(input.slug)) {
+        return error("Fine tune IDs cannot match any base model names");
+      }
 
       const existingFineTune = await prisma.fineTune.findFirst({
         where: {

--- a/app/src/server/scripts/backfillTestingDatasets.ts
+++ b/app/src/server/scripts/backfillTestingDatasets.ts
@@ -38,7 +38,8 @@ if (!fineTune) {
   console.error("no fine tune found");
   process.exit(1);
 }
-let numEntries = 0;
+
+console.log(`queueing ${fineTune.dataset.datasetEntries.length} fine tune testing entry jobs`);
 
 for (const entry of fineTune.dataset.datasetEntries) {
   await evaluateTestSetEntry.enqueue({
@@ -46,9 +47,6 @@ for (const entry of fineTune.dataset.datasetEntries) {
     datasetEntryId: entry.id,
     skipCache: true,
   });
-  numEntries++;
 }
-
-console.log(`queueing ${numEntries} fine tune testing entry jobs`);
 
 console.log("done");

--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -8,7 +8,7 @@ import { pruneInputMessages, getStringsToPrune } from "~/modelProviders/fine-tun
 import { getCompletion2 } from "~/modelProviders/fine-tuned/getCompletion-2";
 import { calculateEntryScore } from "../utils/calculateEntryScore";
 import { typedDatasetEntry } from "~/types/dbColumns.types";
-import { getComparisonModelName, isComparisonModel } from "~/utils/baseModels";
+import { COMPARISON_MODEL_NAMES, isComparisonModel } from "~/utils/baseModels";
 import { getOpenaiCompletion } from "../utils/openai";
 
 export type EvaluateTestSetEntryJob = {
@@ -93,7 +93,7 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
     const input = {
       model: fineTune
         ? `openpipe:${fineTune.slug}`
-        : getComparisonModelName(modelId as ComparisonModel),
+        : COMPARISON_MODEL_NAMES[modelId as ComparisonModel],
       messages: prunedMessages,
       function_call: datasetEntry.function_call ?? undefined,
       functions: datasetEntry.functions ?? undefined,

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -87,3 +87,8 @@ export const chatCompletionOutput = z.object({
 }) satisfies z.ZodType<ChatCompletion, any, any>;
 
 export const validatedChatOutput = (output: unknown) => chatMessage.parse(output);
+
+export enum SortOrder {
+  ASC = "asc",
+  DESC = "desc",
+}

--- a/app/src/utils/baseModels.ts
+++ b/app/src/utils/baseModels.ts
@@ -18,9 +18,15 @@ export const displayBaseModel = (baseModel: BaseModel) => {
 export const isComparisonModel = (modelId: string) =>
   ComparisonModel[modelId as keyof typeof ComparisonModel] !== undefined;
 
-export const getComparisonModelName = (comparisonModel: ComparisonModel) => {
-  switch (comparisonModel) {
-    case "GPT_3_5_TURBO":
-      return "gpt-3.5-turbo-0613";
-  }
+export const isComparisonModelName = (modelName: string) =>
+  Object.values(COMPARISON_MODEL_NAMES).includes(modelName);
+
+export const COMPARISON_MODEL_NAMES: Record<ComparisonModel, string> = {
+  GPT_3_5_TURBO: "gpt-3.5-turbo-0613",
+};
+
+export const getComparisonModel = (modelName: string) => {
+  const model = Object.entries(COMPARISON_MODEL_NAMES).find(([, name]) => name === modelName);
+  if (!model) return null;
+  return model[0] as ComparisonModel;
 };


### PR DESCRIPTION
It's important to be able to see what inputs are causing your model to mess up.

### Changes
* Add `useTestEntrySortOrder` hook
* Pass sort order and model slug to `listTestingEntries` route and order by accuracy and sortKey
* Store comparison model slug in url instead of id to determine visibility
* Add helpers to `baseModels` utils file
* Disable auto-refetch on load for logged calls