### PR TITLE
Save fine tune id on fineTuneTestingEntry

### DIFF
--- a/app/src/server/tasks/evaluateTestSetEntry.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntry.task.ts
@@ -61,6 +61,7 @@ export const evaluateTestSetEntry = defineTask<EvaluateTestSetEntryJob>({
       await prisma.fineTuneTestingEntry.create({
         data: {
           modelId,
+          fineTuneId: fineTune?.id,
           datasetEntryId,
         },
       });

--- a/app/src/server/utils/startTestJobs.ts
+++ b/app/src/server/utils/startTestJobs.ts
@@ -31,14 +31,6 @@ export const startTestJobs = async (datasetId: string, modelId: string) => {
     orderBy: { sortKey: "desc" },
   });
 
-  // create fineTuneTestEntry for each dataset entry
-  await prisma.fineTuneTestingEntry.createMany({
-    data: datasetEntries.map((entry) => ({
-      modelId,
-      datasetEntryId: entry.id,
-    })),
-    skipDuplicates: true,
-  });
   for (const entry of datasetEntries) {
     await evaluateTestSetEntry.enqueue({ modelId, datasetEntryId: entry.id });
   }


### PR DESCRIPTION
Previously, we weren't properly saving the fineTuneId on fine tune testing entries. This PR ensures that we do, and removes the step of creating many fine tune testing entries when a new job starts.