### PR TITLE
WIP: proposed provenance schema

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -226,6 +226,13 @@ enum DatasetEntryType {
     TEST
 }
 
+enum DatasetEntryProvenance {
+    REQUEST_LOG
+    UPLOAD
+    RELABELED_BY_MODEL
+    RELABELED_BY_HUMAN
+}
+
 model DatasetEntry {
     id String @id @default(uuid()) @db.Uuid
 
@@ -248,6 +255,8 @@ model DatasetEntry {
 
     fineTuneTrainingEntries    FineTuneTrainingEntry[]
     fineTuneTestDatasetEntries FineTuneTestingEntry[]
+
+    provenance DatasetEntryProvenance
 
     authoringUserId String? @db.Uuid // The user who created this version of the entry (if any)
     authoringUser   User?   @relation(fields: [authoringUserId], references: [id])


### PR DESCRIPTION
We won't have any `RELABELED_BY_MODEL` yet.

We should set the provenance to `RELABELED_BY_HUMAN` if there's an `authoringUserId`. Unfortunately we aren't actually setting `authoringUser` anywhere in code currently (need to add that) but I'll manually update it for some of the datasets where we know who did the labeling.