### PR TITLE
Validate that dataset rows actually match the function call schema

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ViewEvaluationButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ViewEvaluationButton.tsx
@@ -18,13 +18,13 @@ const ViewEvaluationButton = ({
         query: {
           id: datasetId,
           tab: DATASET_EVALUATION_TAB_KEY,
-          [EVALUATION_COLUMNS_KEY]: fineTuneSlug,
+          [EVALUATION_COLUMNS_KEY]: ["original", fineTuneSlug].join(","),
         },
       }}
       variant="link"
       color="blue.600"
     >
-      View Evalution
+      View Evaluation
     </Button>
   );
 };

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -30,6 +30,7 @@ import {
 import { countLlamaInputTokens, countLlamaOutputTokens } from "~/utils/countTokens";
 import { error, success } from "~/utils/errorHandling/standardResponses";
 import { truthyFilter } from "~/utils/utils";
+import { validateRowToImport } from "~/components/datasets/parseRowsToImport";
 
 export const datasetEntriesRouter = createTRPCRouter({
   list: protectedProcedure
@@ -265,13 +266,16 @@ export const datasetEntriesRouter = createTRPCRouter({
 
       const rowsToConvert = loggedCalls
         .map((loggedCall) => {
-          if (!loggedCall.modelResponse) return null;
-          const modelResponse = typedLoggedCallModelResponse(loggedCall.modelResponse);
+          const modelResponse =
+            loggedCall.modelResponse && typedLoggedCallModelResponse(loggedCall.modelResponse);
 
-          const output = modelResponse.respPayload?.choices[0]?.message;
-          if (!output) return null;
+          const validated = validateRowToImport({
+            input: modelResponse?.reqPayload,
+            output: modelResponse?.respPayload?.choices[0]?.message,
+          });
 
-          return { input: modelResponse.reqPayload, output };
+          if ("error" in validated) return null;
+          return validated;
         })
         .filter(truthyFilter);
 

--- a/app/src/server/utils/prepareDatasetEntriesForImport.ts
+++ b/app/src/server/utils/prepareDatasetEntriesForImport.ts
@@ -9,7 +9,7 @@ type CreateManyInput = Omit<Prisma.DatasetEntryCreateManyInput, "id"> & { id: st
 
 export const prepareDatasetEntriesForImport = async (
   datasetId: string,
-  trainingRows: RowToImport[],
+  entriesToImport: RowToImport[],
   updateCallback?: (progress: number) => Promise<void>,
   updateFrequency = 1000,
 ) => {
@@ -31,9 +31,9 @@ export const prepareDatasetEntriesForImport = async (
 
   const trainingRatio = dataset?.trainingRatio ?? 0.8;
 
-  const newTotalEntries = existingTrainingCount + existingTestingCount + trainingRows.length;
+  const newTotalEntries = existingTrainingCount + existingTestingCount + entriesToImport.length;
   const numTrainingToAdd = Math.floor(trainingRatio * newTotalEntries) - existingTrainingCount;
-  const numTestingToAdd = trainingRows.length - numTrainingToAdd;
+  const numTestingToAdd = entriesToImport.length - numTrainingToAdd;
   const typesToAssign = shuffle([
     ...Array(numTrainingToAdd).fill("TRAIN"),
     ...Array(numTestingToAdd).fill("TEST"),
@@ -41,7 +41,7 @@ export const prepareDatasetEntriesForImport = async (
   const datasetEntriesToCreate: CreateManyInput[] = [];
   const batchDate = Date.now();
   let i = 0;
-  for (const row of trainingRows) {
+  for (const row of entriesToImport) {
     if (updateCallback && i % updateFrequency === 0) await updateCallback(i);
     const persistentId = uuidv4();
     datasetEntriesToCreate.push({


### PR DESCRIPTION
Unfortunately even GPT-4 doesn't always respect the function call schema. But we really want our model to, so this PR filters our dataset entries on the way in to make sure we only add dataset entries that actually match the schema.