### PR TITLE
Add filters to General and Evaluate tabs

### DIFF
--- a/app/src/components/Filters/AddFilterButton.tsx
+++ b/app/src/components/Filters/AddFilterButton.tsx
@@ -1,6 +1,7 @@
 import { Button, HStack, Icon, Text } from "@chakra-ui/react";
 import { BsPlus } from "react-icons/bs";
-import { comparators, useFilters } from "./useFilters";
+import { useFilters } from "./useFilters";
+import { comparators } from "~/types/shared.types";
 
 const AddFilterButton = ({ filterOptions }: { filterOptions: string[] }) => {
   const addFilter = useFilters().addFilter;

--- a/app/src/components/Filters/SelectComparatorDropdown.tsx
+++ b/app/src/components/Filters/SelectComparatorDropdown.tsx
@@ -1,5 +1,6 @@
 import InputDropdown from "~/components/InputDropdown";
-import { type FilterType, useFilters, comparators } from "./useFilters";
+import { type FilterType, useFilters } from "./useFilters";
+import { comparators } from "~/types/shared.types";
 
 const SelectComparatorDropdown = ({ filter }: { filter: FilterType }) => {
   const updateFilter = useFilters().updateFilter;

--- a/app/src/components/Filters/useFilters.ts
+++ b/app/src/components/Filters/useFilters.ts
@@ -1,6 +1,5 @@
 import { useQueryParam, JsonParam, withDefault } from "use-query-params";
-
-export const comparators = ["=", "!=", "CONTAINS", "NOT_CONTAINS"] as const;
+import { type comparators } from "~/types/shared.types";
 
 export interface FilterType {
   id: string;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ColumnVisibilityDropdown.tsx
@@ -15,7 +15,7 @@ import { BiCheck } from "react-icons/bi";
 import { BsPlusSquare, BsToggles } from "react-icons/bs";
 import { ComparisonModel } from "@prisma/client";
 
-import { useIsClientRehydrated, useTestingEntries } from "~/utils/hooks";
+import { useDataset, useIsClientRehydrated } from "~/utils/hooks";
 import ActionButton from "~/components/ActionButton";
 import { useVisibleEvaluationColumns } from "./useVisibleEvaluationColumns";
 import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
@@ -26,10 +26,10 @@ export const ORIGINAL_OUTPUT_COLUMN_KEY = "original";
 
 const ColumnVisibilityDropdown = () => {
   const { visibleColumns, setVisibleColumns } = useVisibleEvaluationColumns();
-  const entries = useTestingEntries().data;
+  const dataset = useDataset().data;
   const fineTuneSlugs = useMemo(
-    () => entries?.deployedFineTunes?.map((ft) => ft.slug) || [],
-    [entries?.deployedFineTunes],
+    () => dataset?.deployedFineTunes?.map((ft) => ft.slug) || [],
+    [dataset?.deployedFineTunes],
   );
 
   const popover = useDisclosure();
@@ -46,7 +46,7 @@ const ColumnVisibilityDropdown = () => {
         key: ORIGINAL_OUTPUT_COLUMN_KEY,
       },
     ];
-    for (const comparisonModel of entries?.enabledComparisonModels ?? []) {
+    for (const comparisonModel of dataset?.enabledComparisonModels ?? []) {
       options.push({
         label: COMPARISON_MODEL_NAMES[comparisonModel],
         key: COMPARISON_MODEL_NAMES[comparisonModel],
@@ -59,7 +59,7 @@ const ColumnVisibilityDropdown = () => {
       });
     }
     return options;
-  }, [entries?.enabledComparisonModels, fineTuneSlugs]);
+  }, [dataset?.enabledComparisonModels, fineTuneSlugs]);
 
   const toggleColumnVisibility = useCallback(
     (key: string) => {
@@ -141,7 +141,7 @@ const ColumnVisibilityDropdown = () => {
                 </Box>
               </HStack>
             ))}
-            {!entries?.enabledComparisonModels.includes(ComparisonModel.GPT_3_5_TURBO) && (
+            {!dataset?.enabledComparisonModels.includes(ComparisonModel.GPT_3_5_TURBO) && (
               <HStack
                 as={Button}
                 w="full"

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -1,26 +1,21 @@
 import { useState } from "react";
-import { VStack, HStack, Box } from "@chakra-ui/react";
+import { VStack, HStack, Box, Text } from "@chakra-ui/react";
 import { FiFilter } from "react-icons/fi";
 
 import EvaluationTable from "./EvaluationTable/EvaluationTable";
 import ColumnVisibilityDropdown from "./ColumnVisibilityDropdown";
 import ActionButton from "~/components/ActionButton";
 import EvaluationFilters from "./EvaluationFilters";
+import { useTestingEntries } from "~/utils/hooks";
 
 const Evaluation = () => {
   const [filtersShown, setFiltersShown] = useState(true);
 
+  const { data } = useTestingEntries();
+
   return (
     <>
-      <VStack
-        px={8}
-        position="sticky"
-        left={0}
-        w="full"
-        justifyContent="flex-start"
-        pb={4}
-        zIndex={5}
-      >
+      <VStack px={8} position="sticky" left={0} w="full" alignItems="flex-start" pb={4} zIndex={5}>
         <HStack w="full">
           <ColumnVisibilityDropdown />
           <ActionButton
@@ -32,6 +27,9 @@ const Evaluation = () => {
           />
         </HStack>
         {filtersShown && <EvaluationFilters />}
+        <Text fontWeight="bold" fontSize="lg" pt={8}>
+          Results {data?.count !== undefined ? `(${data.count})` : ""}
+        </Text>
       </VStack>
       <Box w="full" flex={1}>
         <EvaluationTable />

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -7,6 +7,7 @@ import ColumnVisibilityDropdown from "./ColumnVisibilityDropdown";
 import ActionButton from "~/components/ActionButton";
 import EvaluationFilters from "./EvaluationFilters";
 import { useTestingEntries } from "~/utils/hooks";
+import EvaluationPaginator from "./EvaluationTable/EvaluationPaginator";
 
 const Evaluation = () => {
   const [filtersShown, setFiltersShown] = useState(false);
@@ -33,6 +34,9 @@ const Evaluation = () => {
       </VStack>
       <Box w="full" flex={1}>
         <EvaluationTable />
+      </Box>
+      <Box px={8} position="sticky" left={0} w="full">
+        <EvaluationPaginator py={8} />
       </Box>
     </>
   );

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -9,7 +9,7 @@ import EvaluationFilters from "./EvaluationFilters";
 import { useTestingEntries } from "~/utils/hooks";
 
 const Evaluation = () => {
-  const [filtersShown, setFiltersShown] = useState(true);
+  const [filtersShown, setFiltersShown] = useState(false);
 
   const { data } = useTestingEntries();
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -8,9 +8,11 @@ import ActionButton from "~/components/ActionButton";
 import EvaluationFilters from "./EvaluationFilters";
 import { useTestingEntries } from "~/utils/hooks";
 import EvaluationPaginator from "./EvaluationTable/EvaluationPaginator";
+import { useFilters } from "~/components/Filters/useFilters";
 
 const Evaluation = () => {
-  const [filtersShown, setFiltersShown] = useState(false);
+  const filters = useFilters().filters;
+  const [filtersShown, setFiltersShown] = useState(filters.length > 0);
 
   const { data } = useTestingEntries();
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/Evaluation.tsx
@@ -1,12 +1,18 @@
-import { HStack, Box } from "@chakra-ui/react";
+import { useState } from "react";
+import { VStack, HStack, Box } from "@chakra-ui/react";
+import { FiFilter } from "react-icons/fi";
 
 import EvaluationTable from "./EvaluationTable/EvaluationTable";
 import ColumnVisibilityDropdown from "./ColumnVisibilityDropdown";
+import ActionButton from "~/components/ActionButton";
+import EvaluationFilters from "./EvaluationFilters";
 
 const Evaluation = () => {
+  const [filtersShown, setFiltersShown] = useState(true);
+
   return (
     <>
-      <HStack
+      <VStack
         px={8}
         position="sticky"
         left={0}
@@ -15,8 +21,18 @@ const Evaluation = () => {
         pb={4}
         zIndex={5}
       >
-        <ColumnVisibilityDropdown />
-      </HStack>
+        <HStack w="full">
+          <ColumnVisibilityDropdown />
+          <ActionButton
+            onClick={() => {
+              setFiltersShown(!filtersShown);
+            }}
+            label={filtersShown ? "Hide Filters" : "Show Filters"}
+            icon={FiFilter}
+          />
+        </HStack>
+        {filtersShown && <EvaluationFilters />}
+      </VStack>
       <Box w="full" flex={1}>
         <EvaluationTable />
       </Box>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
@@ -1,0 +1,15 @@
+import { Box } from "@chakra-ui/react";
+
+import Filters from "~/components/Filters/Filters";
+
+const defaultFilterOptions = ["Input", "Original Output"];
+
+const EvaluationFilters = () => {
+  return (
+    <Box w="full" pt={1}>
+      <Filters filterOptions={defaultFilterOptions} />
+    </Box>
+  );
+};
+
+export default EvaluationFilters;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
@@ -1,13 +1,32 @@
+import { useMemo } from "react";
 import { Box } from "@chakra-ui/react";
 
+import { useTestingEntries } from "~/utils/hooks";
 import Filters from "~/components/Filters/Filters";
+import { EvaluationFiltersDefaultFields } from "~/types/shared.types";
 
-const defaultFilterOptions = ["Input", "Original Output"];
+const defaultEvaluationFilterOptions = [
+  EvaluationFiltersDefaultFields.Input,
+  EvaluationFiltersDefaultFields.OriginalOutput,
+];
 
 const EvaluationFilters = () => {
+  const entries = useTestingEntries().data;
+
+  const filterOptions = useMemo(
+    () => [
+      ...defaultEvaluationFilterOptions,
+      ...[
+        ...(entries?.enabledComparisonModels.map((cm) => `${cm} (output)`) || []),
+        ...(entries?.deployedFineTunes?.map((ft) => `${ft.slug} (output)`) || []),
+      ],
+    ],
+    [entries?.enabledComparisonModels, entries?.deployedFineTunes],
+  );
+
   return (
     <Box w="full" pt={1}>
-      <Filters filterOptions={defaultFilterOptions} />
+      <Filters filterOptions={filterOptions} />
     </Box>
   );
 };

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
@@ -1,9 +1,13 @@
 import { useMemo } from "react";
 import { Box } from "@chakra-ui/react";
 
-import { useTestingEntries } from "~/utils/hooks";
+import { useDataset } from "~/utils/hooks";
 import Filters from "~/components/Filters/Filters";
-import { EvaluationFiltersDefaultFields } from "~/types/shared.types";
+import {
+  EVALUATION_FILTERS_OUTPUT_APPENDIX,
+  EvaluationFiltersDefaultFields,
+} from "~/types/shared.types";
+import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
 
 const defaultEvaluationFilterOptions = [
   EvaluationFiltersDefaultFields.Input,
@@ -11,17 +15,20 @@ const defaultEvaluationFilterOptions = [
 ];
 
 const EvaluationFilters = () => {
-  const entries = useTestingEntries().data;
+  const dataset = useDataset().data;
 
   const filterOptions = useMemo(
     () => [
       ...defaultEvaluationFilterOptions,
       ...[
-        ...(entries?.enabledComparisonModels.map((cm) => `${cm} (output)`) || []),
-        ...(entries?.deployedFineTunes?.map((ft) => `${ft.slug} (output)`) || []),
+        ...(dataset?.enabledComparisonModels.map(
+          (cm) => COMPARISON_MODEL_NAMES[cm] + EVALUATION_FILTERS_OUTPUT_APPENDIX,
+        ) || []),
+        ...(dataset?.deployedFineTunes?.map((ft) => ft.slug + EVALUATION_FILTERS_OUTPUT_APPENDIX) ||
+          []),
       ],
     ],
-    [entries?.enabledComparisonModels, entries?.deployedFineTunes],
+    [dataset?.enabledComparisonModels, dataset?.deployedFineTunes],
   );
 
   return (

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -71,6 +71,11 @@ const EvaluationTable = () => {
                 visibleModelIds={visibleModelIds}
               />
             ))}
+            {!entries.entries.length && (
+              <Box gridColumn="1 / -1" textAlign="center">
+                No entries found.
+              </Box>
+            )}
           </Grid>
         </Card>
         <Box minW={8}>&nbsp;</Box>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { VStack, Card, Grid, HStack, Box, Text } from "@chakra-ui/react";
 
-import { useTestingEntries } from "~/utils/hooks";
+import { useDataset, useTestingEntries } from "~/utils/hooks";
 import EvaluationRow, { TableHeader } from "./EvaluationRow";
 import EvaluationPaginator from "./EvaluationPaginator";
 import { ORIGINAL_OUTPUT_COLUMN_KEY } from "../ColumnVisibilityDropdown";
@@ -10,6 +10,7 @@ import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
 
 const EvaluationTable = () => {
   const [refetchInterval, setRefetchInterval] = useState(0);
+  const dataset = useDataset().data;
   const entries = useTestingEntries(refetchInterval).data;
 
   useEffect(
@@ -24,21 +25,21 @@ const EvaluationTable = () => {
       !visibleColumns.length || visibleColumns.includes(ORIGINAL_OUTPUT_COLUMN_KEY);
     const combinedColumnIds: string[] = [];
 
-    if (!entries?.enabledComparisonModels || !entries?.deployedFineTunes)
+    if (!dataset?.enabledComparisonModels || !dataset?.deployedFineTunes)
       return [showOriginalOutput, combinedColumnIds];
 
     combinedColumnIds.push(
-      ...entries.enabledComparisonModels.filter(
+      ...dataset.enabledComparisonModels.filter(
         (cm) => !visibleColumns.length || visibleColumns.includes(COMPARISON_MODEL_NAMES[cm]),
       ),
     );
     combinedColumnIds.push(
-      ...entries.deployedFineTunes
+      ...dataset.deployedFineTunes
         .filter((ft) => !visibleColumns.length || visibleColumns.includes(ft.slug))
         .map((ft) => ft.id),
     );
     return [showOriginalOutput, combinedColumnIds];
-  }, [entries?.enabledComparisonModels, entries?.deployedFineTunes, visibleColumns]);
+  }, [dataset?.enabledComparisonModels, dataset?.deployedFineTunes, visibleColumns]);
   const numOutputColumns = visibleModelIds.length + (showOriginalOutput ? 1 : 0);
 
   if (!entries) return null;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { VStack, Card, Grid, HStack, Box } from "@chakra-ui/react";
+import { VStack, Card, Grid, HStack, Box, Text } from "@chakra-ui/react";
 
 import { useTestingEntries } from "~/utils/hooks";
 import EvaluationRow, { TableHeader } from "./EvaluationRow";
@@ -72,8 +72,8 @@ const EvaluationTable = () => {
               />
             ))}
             {!entries.entries.length && (
-              <Box gridColumn="1 / -1" textAlign="center">
-                No entries found.
+              <Box gridColumn="1 / -1" textAlign="center" py={6}>
+                <Text color="gray.500">No matching entries found. Try removing some filters.</Text>
               </Box>
             )}
           </Grid>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationTable.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect, useMemo } from "react";
-import { VStack, Card, Grid, HStack, Box, Text } from "@chakra-ui/react";
+import { Card, Grid, HStack, Box, Text } from "@chakra-ui/react";
 
 import { useDataset, useTestingEntries } from "~/utils/hooks";
 import EvaluationRow, { TableHeader } from "./EvaluationRow";
-import EvaluationPaginator from "./EvaluationPaginator";
 import { ORIGINAL_OUTPUT_COLUMN_KEY } from "../ColumnVisibilityDropdown";
 import { useVisibleEvaluationColumns } from "../useVisibleEvaluationColumns";
 import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
@@ -45,44 +44,38 @@ const EvaluationTable = () => {
   if (!entries) return null;
 
   return (
-    <VStack w="full" h="full" justifyContent="space-between" px={8}>
-      <HStack w="full" spacing={0}>
-        <Card flex={1} minW="fit-content" variant="outline">
-          <Grid
-            display="grid"
-            gridTemplateColumns={`minmax(600px, 1fr) repeat(${numOutputColumns}, 480px)`}
-            sx={{
-              "> *": {
-                borderColor: "gray.300",
-                padding: 4,
-              },
-            }}
-          >
-            <TableHeader
+    <HStack w="full" px={8} spacing={0}>
+      <Card flex={1} minW="fit-content" variant="outline">
+        <Grid
+          display="grid"
+          gridTemplateColumns={`minmax(600px, 1fr) repeat(${numOutputColumns}, 480px)`}
+          sx={{
+            "> *": {
+              borderColor: "gray.300",
+              padding: 4,
+            },
+          }}
+        >
+          <TableHeader showOriginalOutput={showOriginalOutput} visibleModelIds={visibleModelIds} />
+          {entries.entries.map((entry) => (
+            <EvaluationRow
+              key={entry.id}
+              messages={entry.messages}
+              output={entry.output}
+              fineTuneEntries={entry.fineTuneTestDatasetEntries}
               showOriginalOutput={showOriginalOutput}
               visibleModelIds={visibleModelIds}
             />
-            {entries.entries.map((entry) => (
-              <EvaluationRow
-                key={entry.id}
-                messages={entry.messages}
-                output={entry.output}
-                fineTuneEntries={entry.fineTuneTestDatasetEntries}
-                showOriginalOutput={showOriginalOutput}
-                visibleModelIds={visibleModelIds}
-              />
-            ))}
-            {!entries.entries.length && (
-              <Box gridColumn="1 / -1" textAlign="center" py={6}>
-                <Text color="gray.500">No matching entries found. Try removing some filters.</Text>
-              </Box>
-            )}
-          </Grid>
-        </Card>
-        <Box minW={8}>&nbsp;</Box>
-      </HStack>
-      <EvaluationPaginator py={8} />
-    </VStack>
+          ))}
+          {!entries.entries.length && (
+            <Box gridColumn="1 / -1" textAlign="center" py={6}>
+              <Text color="gray.500">No matching entries found. Try removing some filters.</Text>
+            </Box>
+          )}
+        </Grid>
+      </Card>
+      <Box minW={8}>&nbsp;</Box>
+    </HStack>
   );
 };
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/useMappedModelIdFilters.ts
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/useMappedModelIdFilters.ts
@@ -1,0 +1,25 @@
+import { type ComparisonModel } from "@prisma/client";
+
+import { EVALUATION_FILTERS_OUTPUT_APPENDIX } from "~/types/shared.types";
+import { useFilters } from "~/components/Filters/useFilters";
+import { useDataset } from "~/utils/hooks";
+import { getComparisonModel, isComparisonModelName } from "~/utils/baseModels";
+
+export const useMappedModelIdFilters = () => {
+  const dataset = useDataset().data;
+
+  const filters = useFilters().filters;
+
+  // Map displayed model names to their IDs
+  return filters.map((filter) => {
+    if (!filter.field.endsWith(EVALUATION_FILTERS_OUTPUT_APPENDIX)) return filter;
+    const modelName = filter.field.replace(EVALUATION_FILTERS_OUTPUT_APPENDIX, "");
+    let modelId = "";
+    if (isComparisonModelName(modelName)) {
+      modelId = getComparisonModel(modelName) as ComparisonModel;
+    } else {
+      modelId = dataset?.deployedFineTunes.find((ft) => ft.slug === modelName)?.id ?? "";
+    }
+    return { ...filter, field: modelId + EVALUATION_FILTERS_OUTPUT_APPENDIX };
+  });
+};

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/TableRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/TableRow.tsx
@@ -1,5 +1,6 @@
 import { Box, Td, Tr, Thead, Th, Tooltip, HStack, Text, Checkbox } from "@chakra-ui/react";
 import Link from "next/link";
+import { DatasetEntryType } from "@prisma/client";
 
 import dayjs from "~/utils/dayjs";
 import { type RouterOutputs } from "~/utils/api";
@@ -90,8 +91,30 @@ export const TableRow = ({
       </Td>
       <Td isNumeric>{datasetEntry.inputTokens.toLocaleString()}</Td>
       <Td isNumeric>{datasetEntry.outputTokens.toLocaleString()}</Td>
-      <Td isNumeric>{datasetEntry.type}</Td>
+      <Td isNumeric>
+        <EntryType type={datasetEntry.type} />
+      </Td>
     </Tr>
+  );
+};
+
+const EntryType = ({ type }: { type: string }) => {
+  const color = type === DatasetEntryType.TRAIN ? "orange.500" : "purple.500";
+  return (
+    <HStack justifyContent="flex-end">
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        w="14"
+        color={color}
+        borderColor={color}
+        borderWidth={1}
+        borderRadius={4}
+        textAlign="center"
+      >
+        {type}
+      </Text>
+    </HStack>
   );
 };
 

--- a/app/src/components/datasets/DatasetContentTabs/General/DeleteButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DeleteButton.tsx
@@ -32,7 +32,7 @@ const DeleteButton = () => {
     <>
       <ActionButton
         onClick={disclosure.onOpen}
-        label="Delete"
+        label="Delete Rows"
         icon={BsTrash}
         isDisabled={selectedIds.size === 0}
       />

--- a/app/src/components/datasets/DatasetContentTabs/General/General.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/General.tsx
@@ -1,19 +1,33 @@
+import { useState } from "react";
 import { VStack, HStack } from "@chakra-ui/react";
 
-import DeleteButton from "~/components/datasets/DatasetContentTabs/General/DeleteButton";
+import ActionButton from "~/components/ActionButton";
+import DeleteButton from "./DeleteButton";
 import FineTuneButton from "./FineTuneButton";
 import UploadDataButton from "./UploadDataButton";
 import DatasetEntriesTable from "./DatasetEntriesTable/DatasetEntriesTable";
 import DatasetEntryPaginator from "./DatasetEntryPaginator";
+import { FiFilter } from "react-icons/fi";
+import GeneralFilters from "./GeneralFilters";
 
 const General = () => {
+  const [filtersShown, setFiltersShown] = useState(false);
+
   return (
     <VStack pb={8} px={8} alignItems="flex-start" spacing={4} w="full">
       <HStack w="full" justifyContent="flex-end">
         <FineTuneButton />
         <UploadDataButton />
+        <ActionButton
+          onClick={() => {
+            setFiltersShown(!filtersShown);
+          }}
+          label={filtersShown ? "Hide Filters" : "Show Filters"}
+          icon={FiFilter}
+        />
         <DeleteButton />
       </HStack>
+      {filtersShown && <GeneralFilters />}
       <DatasetEntriesTable />
       <DatasetEntryPaginator />
     </VStack>

--- a/app/src/components/datasets/DatasetContentTabs/General/General.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/General.tsx
@@ -9,9 +9,11 @@ import DatasetEntriesTable from "./DatasetEntriesTable/DatasetEntriesTable";
 import DatasetEntryPaginator from "./DatasetEntryPaginator";
 import { FiFilter } from "react-icons/fi";
 import GeneralFilters from "./GeneralFilters";
+import { useFilters } from "~/components/Filters/useFilters";
 
 const General = () => {
-  const [filtersShown, setFiltersShown] = useState(false);
+  const filters = useFilters().filters;
+  const [filtersShown, setFiltersShown] = useState(filters.length > 0);
 
   return (
     <VStack pb={8} px={8} alignItems="flex-start" spacing={4} w="full">

--- a/app/src/components/datasets/DatasetContentTabs/General/GeneralFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/GeneralFilters.tsx
@@ -1,0 +1,15 @@
+import { Box } from "@chakra-ui/react";
+
+import Filters from "~/components/Filters/Filters";
+
+const defaultFilterOptions = ["Input", "Output"];
+
+const GeneralFilters = () => {
+  return (
+    <Box w="full" pt={1}>
+      <Filters filterOptions={defaultFilterOptions} />
+    </Box>
+  );
+};
+
+export default GeneralFilters;

--- a/app/src/components/datasets/DatasetContentTabs/General/GeneralFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/GeneralFilters.tsx
@@ -1,8 +1,12 @@
 import { Box } from "@chakra-ui/react";
 
 import Filters from "~/components/Filters/Filters";
+import { GeneralFiltersDefaultFields } from "~/types/shared.types";
 
-const defaultFilterOptions = ["Input", "Output"];
+const defaultFilterOptions = [
+  GeneralFiltersDefaultFields.Input,
+  GeneralFiltersDefaultFields.Output,
+];
 
 const GeneralFilters = () => {
   return (

--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -136,6 +136,7 @@ const NavSidebar = () => {
             color="gray.500"
             _hover={{ color: "gray.800" }}
             p={2}
+            mt={1}
           >
             <Icon as={FaReadme} boxSize={6} />
           </ChakraLink>

--- a/app/src/components/requestLogs/LogFilters.tsx
+++ b/app/src/components/requestLogs/LogFilters.tsx
@@ -1,7 +1,13 @@
+import { LoggedCallsFiltersDefaultFields } from "~/types/shared.types";
 import Filters from "../Filters/Filters";
 import { useTagNames } from "~/utils/hooks";
 
-export const defaultFilterableFields = ["Request", "Response", "Model", "Status Code"] as const;
+const defaultFilterableFields = [
+  LoggedCallsFiltersDefaultFields.Request,
+  LoggedCallsFiltersDefaultFields.Response,
+  LoggedCallsFiltersDefaultFields.Model,
+  LoggedCallsFiltersDefaultFields.StatusCode,
+];
 
 const LogFilters = () => {
   const tagNames = useTagNames().data;

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -665,6 +665,8 @@ export const datasetEntriesRouter = createTRPCRouter({
       const baseQuery = constructTestDatasetEntryFiltersQuery(filters, datasetId);
 
       const averageScoreResult = await baseQuery
+        .leftJoin("FineTuneTestingEntry as te", "de.id", "te.datasetEntryId")
+        .where("te.modelId", "=", modelId)
         .where(sql.raw(`te."output" is not null`))
         .select(({ fn }) => ["te.modelId", fn.agg<number>("AVG", ["te.score"]).as("averageScore")])
         .groupBy("te.modelId")

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -591,24 +591,20 @@ export const datasetEntriesRouter = createTRPCRouter({
         .limit(pageSize)
         .execute();
 
-      const [count, deployedFineTunes] = await prisma.$transaction([
-        prisma.datasetEntry.count({
-          where: {
-            datasetId,
-            outdated: false,
-            type: "TEST",
-          },
-        }),
-        prisma.fineTune.findMany({
-          where: {
-            datasetId,
-            status: "DEPLOYED",
-          },
-          orderBy: {
-            createdAt: "desc",
-          },
-        }),
-      ]);
+      const count = await baseQuery
+        .select("de.id")
+        .execute()
+        .then((rows) => rows.length);
+
+      const deployedFineTunes = await prisma.fineTune.findMany({
+        where: {
+          datasetId,
+          status: "DEPLOYED",
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
 
       const pageIncomplete = !!entries.find((entry) =>
         entry.fineTuneTestDatasetEntries.find((entry) => !entry.output),

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -619,16 +619,6 @@ export const datasetEntriesRouter = createTRPCRouter({
         .execute()
         .then((rows) => rows.length);
 
-      const deployedFineTunes = await prisma.fineTune.findMany({
-        where: {
-          datasetId,
-          status: "DEPLOYED",
-        },
-        orderBy: {
-          createdAt: "desc",
-        },
-      });
-
       const pageIncomplete = !!entries.find((entry) =>
         entry.fineTuneTestDatasetEntries.find((entry) => !entry.output),
       );
@@ -637,8 +627,6 @@ export const datasetEntriesRouter = createTRPCRouter({
         entries,
         count,
         pageIncomplete,
-        enabledComparisonModels: dataset.enabledComparisonModels,
-        deployedFineTunes,
       };
     }),
   testingStats: protectedProcedure

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -30,7 +30,7 @@ import {
 import { countLlamaInputTokens, countLlamaOutputTokens } from "~/utils/countTokens";
 import { error, success } from "~/utils/errorHandling/standardResponses";
 import { truthyFilter } from "~/utils/utils";
-import { constructTestDatasetEntryFiltersQuery } from "~/server/utils/constructTestDatasetEntryFiltersQuery";
+import { constructEvaluationFiltersQuery } from "~/server/utils/constructEvaluationFiltersQuery";
 import { constructDatasetEntryFiltersQuery } from "~/server/utils/constructDatasetEntryFiltersQuery";
 import { validateRowToImport } from "~/components/datasets/parseRowsToImport";
 
@@ -576,7 +576,7 @@ export const datasetEntriesRouter = createTRPCRouter({
         scoreSortOrder = SortOrder.ASC;
       }
 
-      const baseQuery = constructTestDatasetEntryFiltersQuery(filters, datasetId);
+      const baseQuery = constructEvaluationFiltersQuery(filters, datasetId);
 
       const entries = await baseQuery
         .leftJoin(
@@ -662,7 +662,7 @@ export const datasetEntriesRouter = createTRPCRouter({
         .select(["FineTuneTestingEntry.id"])
         .execute();
 
-      const baseQuery = constructTestDatasetEntryFiltersQuery(filters, datasetId);
+      const baseQuery = constructEvaluationFiltersQuery(filters, datasetId);
 
       const averageScoreResult = await baseQuery
         .leftJoin("FineTuneTestingEntry as te", "de.id", "te.datasetEntryId")

--- a/app/src/server/api/routers/datasets.router.ts
+++ b/app/src/server/api/routers/datasets.router.ts
@@ -17,12 +17,21 @@ export const datasetsRouter = createTRPCRouter({
       where: { id: input.id },
       include: {
         project: true,
+        fineTunes: {
+          where: {
+            status: "DEPLOYED",
+          },
+          orderBy: {
+            createdAt: "desc",
+          },
+        },
       },
     });
 
     await requireCanViewProject(dataset.projectId, ctx);
 
-    return dataset;
+    const { fineTunes, ...rest } = dataset;
+    return { deployedFineTunes: fineTunes, ...rest };
   }),
   list: protectedProcedure
     .input(z.object({ projectId: z.string() }))

--- a/app/src/server/api/routers/loggedCalls.router.ts
+++ b/app/src/server/api/routers/loggedCalls.router.ts
@@ -9,7 +9,8 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { kysely } from "~/server/db";
 import { requireCanViewProject } from "~/utils/accessControl";
 import hashObject from "~/server/utils/hashObject";
-import { constructFiltersQuery, logFiltersSchema } from "~/server/utils/constructFiltersQuery";
+import { constructLoggedCallFiltersQuery } from "~/server/utils/constructLoggedCallFiltersQuery";
+import { filtersSchema } from "~/types/shared.types";
 
 export const loggedCallsRouter = createTRPCRouter({
   list: protectedProcedure
@@ -18,7 +19,7 @@ export const loggedCallsRouter = createTRPCRouter({
         projectId: z.string(),
         page: z.number(),
         pageSize: z.number(),
-        filters: logFiltersSchema,
+        filters: filtersSchema,
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -26,7 +27,7 @@ export const loggedCallsRouter = createTRPCRouter({
 
       await requireCanViewProject(projectId, ctx);
 
-      const baseQuery = constructFiltersQuery(input.filters, projectId);
+      const baseQuery = constructLoggedCallFiltersQuery(input.filters, projectId);
 
       const rawCalls = await baseQuery
         .select((eb) => [
@@ -109,7 +110,7 @@ export const loggedCallsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        filters: logFiltersSchema,
+        filters: filtersSchema,
         defaultToSelected: z.boolean(),
         selectedLogIds: z.string().array(),
         deselectedLogIds: z.string().array(),
@@ -121,7 +122,7 @@ export const loggedCallsRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       await requireCanViewProject(input.projectId, ctx);
 
-      const baseQuery = constructFiltersQuery(input.filters, input.projectId, {
+      const baseQuery = constructLoggedCallFiltersQuery(input.filters, input.projectId, {
         defaultToSelected: input.defaultToSelected,
         selectedLogIds: input.selectedLogIds,
         deselectedLogIds: input.deselectedLogIds,

--- a/app/src/server/utils/constructDatasetEntryFiltersQuery.ts
+++ b/app/src/server/utils/constructDatasetEntryFiltersQuery.ts
@@ -1,0 +1,34 @@
+import { type z } from "zod";
+import { type Expression, type SqlBool, sql } from "kysely";
+
+import { kysely } from "~/server/db";
+import { type filtersSchema } from "~/types/shared.types";
+import { comparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
+
+export const constructDatasetEntryFiltersQuery = (
+  filters: z.infer<typeof filtersSchema>,
+  datasetId: string,
+) => {
+  const baseQuery = kysely.selectFrom("DatasetEntry as de").where((eb) => {
+    const wheres: Expression<SqlBool>[] = [
+      eb("de.datasetId", "=", datasetId),
+      eb("de.outdated", "=", false),
+    ];
+
+    for (const filter of filters) {
+      if (!filter.value) continue;
+      const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+
+      if (filter.field === "Input") {
+        wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
+      }
+      if (filter.field === "Output") {
+        wheres.push(filterExpression(sql.raw(`de."output"::text`)));
+      }
+    }
+
+    return eb.and(wheres);
+  });
+
+  return baseQuery;
+};

--- a/app/src/server/utils/constructDatasetEntryFiltersQuery.ts
+++ b/app/src/server/utils/constructDatasetEntryFiltersQuery.ts
@@ -2,7 +2,7 @@ import { type z } from "zod";
 import { type Expression, type SqlBool, sql } from "kysely";
 
 import { kysely } from "~/server/db";
-import { type filtersSchema } from "~/types/shared.types";
+import { GeneralFiltersDefaultFields, type filtersSchema } from "~/types/shared.types";
 import { comparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
 
 export const constructDatasetEntryFiltersQuery = (
@@ -19,10 +19,10 @@ export const constructDatasetEntryFiltersQuery = (
       if (!filter.value) continue;
       const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
 
-      if (filter.field === "Input") {
+      if (filter.field === GeneralFiltersDefaultFields.Input) {
         wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
       }
-      if (filter.field === "Output") {
+      if (filter.field === GeneralFiltersDefaultFields.Output) {
         wheres.push(filterExpression(sql.raw(`de."output"::text`)));
       }
     }

--- a/app/src/server/utils/constructEvaluationFiltersQuery.ts
+++ b/app/src/server/utils/constructEvaluationFiltersQuery.ts
@@ -4,8 +4,9 @@ import { type Expression, type SqlBool, sql } from "kysely";
 import { kysely } from "~/server/db";
 import { type filtersSchema } from "~/types/shared.types";
 import { comparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
+import { EvaluationFiltersDefaultFields } from "~/types/shared.types";
 
-export const constructTestDatasetEntryFiltersQuery = (
+export const constructEvaluationFiltersQuery = (
   filters: z.infer<typeof filtersSchema>,
   datasetId: string,
 ) => {
@@ -20,10 +21,10 @@ export const constructTestDatasetEntryFiltersQuery = (
       if (!filter.value) continue;
       const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
 
-      if (filter.field === "Input") {
+      if (filter.field === EvaluationFiltersDefaultFields.Input) {
         wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
       }
-      if (filter.field === "Original Output") {
+      if (filter.field === EvaluationFiltersDefaultFields.OriginalOutput) {
         wheres.push(filterExpression(sql.raw(`de."output"::text`)));
       }
     }

--- a/app/src/server/utils/constructLoggedCallFiltersQuery.ts
+++ b/app/src/server/utils/constructLoggedCallFiltersQuery.ts
@@ -1,8 +1,11 @@
 import { type z } from "zod";
 import { type Expression, type SqlBool, sql, type RawBuilder } from "kysely";
 import { kysely } from "~/server/db";
-import { defaultFilterableFields } from "~/components/requestLogs/LogFilters";
-import { type comparators, type filtersSchema } from "~/types/shared.types";
+import {
+  LoggedCallsFiltersDefaultFields,
+  type comparators,
+  type filtersSchema,
+} from "~/types/shared.types";
 
 // create comparator type based off of comparators
 export const comparatorToSqlExpression = (
@@ -45,16 +48,16 @@ export const constructLoggedCallFiltersQuery = (
         if (!filter.value) continue;
         const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
 
-        if (filter.field === "Request") {
+        if (filter.field === LoggedCallsFiltersDefaultFields.Request) {
           wheres.push(filterExpression(sql.raw(`lcmr."reqPayload"::text`)));
         }
-        if (filter.field === "Response") {
+        if (filter.field === LoggedCallsFiltersDefaultFields.Response) {
           wheres.push(filterExpression(sql.raw(`lcmr."respPayload"::text`)));
         }
-        if (filter.field === "Model") {
+        if (filter.field === LoggedCallsFiltersDefaultFields.Model) {
           wheres.push(filterExpression(sql.raw(`lc."model"`)));
         }
-        if (filter.field === "Status Code") {
+        if (filter.field === LoggedCallsFiltersDefaultFields.StatusCode) {
           wheres.push(filterExpression(sql.raw(`lcmr."statusCode"::text`)));
         }
       }
@@ -64,7 +67,9 @@ export const constructLoggedCallFiltersQuery = (
 
   const tagFilters = filters.filter(
     (filter) =>
-      !defaultFilterableFields.includes(filter.field as (typeof defaultFilterableFields)[number]),
+      !Object.values(LoggedCallsFiltersDefaultFields).includes(
+        filter.field as LoggedCallsFiltersDefaultFields,
+      ),
   );
 
   let updatedBaseQuery = baseQuery;

--- a/app/src/server/utils/constructLoggedCallFiltersQuery.ts
+++ b/app/src/server/utils/constructLoggedCallFiltersQuery.ts
@@ -1,19 +1,14 @@
-import { z } from "zod";
+import { type z } from "zod";
 import { type Expression, type SqlBool, sql, type RawBuilder } from "kysely";
 import { kysely } from "~/server/db";
-import { comparators } from "~/components/Filters/useFilters";
 import { defaultFilterableFields } from "~/components/requestLogs/LogFilters";
-
-export const logFiltersSchema = z.array(
-  z.object({
-    field: z.string(),
-    comparator: z.enum(comparators),
-    value: z.string(),
-  }),
-);
+import { type comparators, type filtersSchema } from "~/types/shared.types";
 
 // create comparator type based off of comparators
-const comparatorToSqlExpression = (comparator: (typeof comparators)[number], value: string) => {
+export const comparatorToSqlExpression = (
+  comparator: (typeof comparators)[number],
+  value: string,
+) => {
   return (reference: RawBuilder<unknown>): Expression<SqlBool> => {
     switch (comparator) {
       case "=":
@@ -31,8 +26,8 @@ const comparatorToSqlExpression = (comparator: (typeof comparators)[number], val
   };
 };
 
-export const constructFiltersQuery = (
-  filters: z.infer<typeof logFiltersSchema>,
+export const constructLoggedCallFiltersQuery = (
+  filters: z.infer<typeof filtersSchema>,
   projectId: string,
   selectionParams?: {
     defaultToSelected: boolean;

--- a/app/src/server/utils/constructTestDatasetEntryFiltersQuery.ts
+++ b/app/src/server/utils/constructTestDatasetEntryFiltersQuery.ts
@@ -1,0 +1,38 @@
+import { type z } from "zod";
+import { type Expression, type SqlBool, sql } from "kysely";
+
+import { kysely } from "~/server/db";
+import { type filtersSchema } from "~/types/shared.types";
+import { comparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
+
+export const constructTestDatasetEntryFiltersQuery = (
+  filters: z.infer<typeof filtersSchema>,
+  datasetId: string,
+) => {
+  const baseQuery = kysely
+    .selectFrom("DatasetEntry as de")
+    .leftJoin("FineTuneTestingEntry as te", "de.id", "te.datasetEntryId")
+    .where((eb) => {
+      const wheres: Expression<SqlBool>[] = [
+        eb("de.datasetId", "=", datasetId),
+        eb("de.outdated", "=", false),
+        eb("de.type", "=", "TEST"),
+      ];
+
+      for (const filter of filters) {
+        if (!filter.value) continue;
+        const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+
+        if (filter.field === "Input") {
+          wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
+        }
+        if (filter.field === "Original Output") {
+          wheres.push(filterExpression(sql.raw(`de."output"::text`)));
+        }
+      }
+
+      return eb.and(wheres);
+    });
+
+  return baseQuery;
+};

--- a/app/src/server/utils/constructTestDatasetEntryFiltersQuery.ts
+++ b/app/src/server/utils/constructTestDatasetEntryFiltersQuery.ts
@@ -9,30 +9,27 @@ export const constructTestDatasetEntryFiltersQuery = (
   filters: z.infer<typeof filtersSchema>,
   datasetId: string,
 ) => {
-  const baseQuery = kysely
-    .selectFrom("DatasetEntry as de")
-    .leftJoin("FineTuneTestingEntry as te", "de.id", "te.datasetEntryId")
-    .where((eb) => {
-      const wheres: Expression<SqlBool>[] = [
-        eb("de.datasetId", "=", datasetId),
-        eb("de.outdated", "=", false),
-        eb("de.type", "=", "TEST"),
-      ];
+  const baseQuery = kysely.selectFrom("DatasetEntry as de").where((eb) => {
+    const wheres: Expression<SqlBool>[] = [
+      eb("de.datasetId", "=", datasetId),
+      eb("de.outdated", "=", false),
+      eb("de.type", "=", "TEST"),
+    ];
 
-      for (const filter of filters) {
-        if (!filter.value) continue;
-        const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+    for (const filter of filters) {
+      if (!filter.value) continue;
+      const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
 
-        if (filter.field === "Input") {
-          wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
-        }
-        if (filter.field === "Original Output") {
-          wheres.push(filterExpression(sql.raw(`de."output"::text`)));
-        }
+      if (filter.field === "Input") {
+        wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
       }
+      if (filter.field === "Original Output") {
+        wheres.push(filterExpression(sql.raw(`de."output"::text`)));
+      }
+    }
 
-      return eb.and(wheres);
-    });
+    return eb.and(wheres);
+  });
 
   return baseQuery;
 };

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -92,3 +92,13 @@ export enum SortOrder {
   ASC = "asc",
   DESC = "desc",
 }
+
+export const comparators = ["=", "!=", "CONTAINS", "NOT_CONTAINS"] as const;
+
+export const filtersSchema = z.array(
+  z.object({
+    field: z.string(),
+    comparator: z.enum(comparators),
+    value: z.string(),
+  }),
+);

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -102,3 +102,20 @@ export const filtersSchema = z.array(
     value: z.string(),
   }),
 );
+
+export enum LoggedCallsFiltersDefaultFields {
+  Request = "Request",
+  Response = "Response",
+  Model = "Model",
+  StatusCode = "Status Code",
+}
+
+export enum GeneralFiltersDefaultFields {
+  Input = "Input",
+  Output = "Output",
+}
+
+export enum EvaluationFiltersDefaultFields {
+  Input = "Input",
+  OriginalOutput = "Original Output",
+}

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -119,3 +119,5 @@ export enum EvaluationFiltersDefaultFields {
   Input = "Input",
   OriginalOutput = "Original Output",
 }
+
+export const EVALUATION_FILTERS_OUTPUT_APPENDIX = " (output)";

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -6,6 +6,7 @@ import { api } from "~/utils/api";
 import { useAppStore } from "~/state/store";
 import { useTestEntrySortOrder } from "~/components/datasets/DatasetContentTabs/Evaluation/useTestEntrySortOrder";
 import { useFilters } from "~/components/Filters/useFilters";
+import { useMappedModelIdFilters } from "~/components/datasets/DatasetContentTabs/Evaluation/useMappedModelIdFilters";
 
 export const useExperiments = () => {
   const selectedProjectId = useAppStore((state) => state.selectedProjectId);
@@ -243,7 +244,7 @@ export const useTrainingEntries = () => {
 export const useTestingEntries = (refetchInterval?: number) => {
   const dataset = useDataset().data;
 
-  const filters = useFilters().filters;
+  const filters = useMappedModelIdFilters();
 
   const { page, pageSize } = usePageParams();
 
@@ -277,7 +278,7 @@ export const useModelTestingStats = (
   modelId?: string,
   refetchInterval?: number,
 ) => {
-  const filters = useFilters().filters;
+  const filters = useMappedModelIdFilters();
 
   const { data, isFetching, ...rest } = api.datasetEntries.testingStats.useQuery(
     { datasetId: datasetId ?? "", filters, modelId: modelId ?? "" },

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -287,7 +287,7 @@ export const useModelTestingStats = (
   const [stableData, setStableData] = useState(data);
 
   useEffect(() => {
-    // Prevent annoying flashes while entries are loading from the server
+    // Prevent annoying flashes while stats are loading from the server
     if (!isFetching) {
       setStableData(data);
     }

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -193,10 +193,13 @@ export const useDataset = () => {
 
 export const useDatasetEntries = () => {
   const dataset = useDataset().data;
+
+  const filters = useFilters().filters;
+
   const { page, pageSize } = usePageParams();
 
   const { data, isFetching, ...rest } = api.datasetEntries.list.useQuery(
-    { datasetId: dataset?.id ?? "", page, pageSize },
+    { datasetId: dataset?.id ?? "", filters, page, pageSize },
     { enabled: !!dataset?.id },
   );
 


### PR DESCRIPTION
Add input and output filters to dataset entries in the General and Evaluate tabs. We still need to add filters to dataset entry type in the General tab, and dataset entry provenance in the Evaluate tab.

### Changes
* Use enums to standardize filter field names between client and server
* Add filters to `General` and `Evaluate` tabs
* Move `deployedFineTunes` field from `datasetEntries.testingStats` to `datasets.get`
* Color-code TRAIN and TEST rows
