### PR TITLE
Show whitespace in formatted message content

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -272,7 +272,7 @@ const FormattedMessage = ({
       </VStack>
     );
   }
-  return <Text>{message.content}</Text>;
+  return <Text whiteSpace="pre-wrap">{message.content}</Text>;
 };
 
 export default EvaluationRow;


### PR DESCRIPTION
Before:
<img width="595" alt="Screenshot 2023-10-27 at 10 33 21 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/25dcf5bf-5db0-41f7-8425-2f0415ace05b">


After:
<img width="606" alt="Screenshot 2023-10-27 at 10 32 52 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/8e0aa108-caa7-47b0-b493-40a3b8cbf92f">
