### PR TITLE
Read base url environment variable in python sdk

### DIFF
--- a/client-libs/python/openpipe/shared.py
+++ b/client-libs/python/openpipe/shared.py
@@ -17,6 +17,9 @@ configured_client = AuthenticatedClient(
 if os.environ.get("OPENPIPE_API_KEY"):
     configured_client.token = os.environ["OPENPIPE_API_KEY"]
 
+if os.environ.get("OPENPIPE_BASE_URL"):
+    configured_client._base_url = os.environ["OPENPIPE_BASE_URL"]
+
 
 def _get_tags(openpipe_options):
     tags = openpipe_options.get("tags") or {}

--- a/client-libs/python/pyproject.toml
+++ b/client-libs/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openpipe"
-version = "3.3.3"
+version = "3.3.5"
 description = "Python client library for the OpenPipe service"
 authors = ["Kyle Corbitt <kyle@openpipe.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The python SDK now reads its base url from `OPENPIPE_BASE_URL` if it is defined.