### PR TITLE
Add date filter to request logs

### DIFF
--- a/app/src/components/Filters/AddFilterButton.tsx
+++ b/app/src/components/Filters/AddFilterButton.tsx
@@ -1,10 +1,10 @@
 import { Button, HStack, Icon, Text } from "@chakra-ui/react";
 import { BsPlus } from "react-icons/bs";
 import { useFilters } from "./useFilters";
-import { comparators } from "~/types/shared.types";
+import { type AtLeastOne, comparators } from "~/types/shared.types";
 import { type FilterOptionType } from "./types";
 
-const AddFilterButton = ({ filterOptions }: { filterOptions: FilterOptionType[] }) => {
+const AddFilterButton = ({ filterOptions }: { filterOptions: AtLeastOne<FilterOptionType> }) => {
   const addFilter = useFilters().addFilter;
 
   return (
@@ -14,7 +14,7 @@ const AddFilterButton = ({ filterOptions }: { filterOptions: FilterOptionType[] 
       onClick={() =>
         addFilter({
           id: Date.now().toString(),
-          field: filterOptions[0]?.field as string,
+          field: filterOptions[0].field,
           comparator: comparators[0],
           value: "",
         })

--- a/app/src/components/Filters/AddFilterButton.tsx
+++ b/app/src/components/Filters/AddFilterButton.tsx
@@ -2,8 +2,9 @@ import { Button, HStack, Icon, Text } from "@chakra-ui/react";
 import { BsPlus } from "react-icons/bs";
 import { useFilters } from "./useFilters";
 import { comparators } from "~/types/shared.types";
+import { type FilterOptionType } from "./types";
 
-const AddFilterButton = ({ filterOptions }: { filterOptions: string[] }) => {
+const AddFilterButton = ({ filterOptions }: { filterOptions: FilterOptionType[] }) => {
   const addFilter = useFilters().addFilter;
 
   return (
@@ -13,7 +14,7 @@ const AddFilterButton = ({ filterOptions }: { filterOptions: string[] }) => {
       onClick={() =>
         addFilter({
           id: Date.now().toString(),
-          field: filterOptions[0] as string,
+          field: filterOptions[0]?.field as string,
           comparator: comparators[0],
           value: "",
         })

--- a/app/src/components/Filters/Filter/DateFilter.tsx
+++ b/app/src/components/Filters/Filter/DateFilter.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useState, useEffect } from "react";
+import { HStack, IconButton, Input, Icon } from "@chakra-ui/react";
+import { BsTrash, BsDash } from "react-icons/bs";
+import { debounce } from "lodash-es";
+
+import { formatDateForPicker } from "~/utils/dayjs";
+import SelectFieldDropdown from "../SelectFieldDropdown";
+import SelectComparatorDropdown from "../SelectComparatorDropdown";
+import { useFilters } from "../useFilters";
+import { type FilterDataType, type FilterOptionType } from "../types";
+
+const DateFilter = ({
+  filterOptions,
+  filter,
+}: {
+  filterOptions: FilterOptionType[];
+  filter: FilterDataType;
+}) => {
+  const updateFilter = useFilters().updateFilter;
+  const removeFilter = useFilters().removeFilter;
+
+  const isArray = Array.isArray(filter.value);
+
+  const [firstDate, setFirstDate] = useState<number>(
+    isArray ? (filter.value[0] as number) : Date.now(),
+  );
+  const [secondDate, setSecondDate] = useState<number>(
+    isArray ? (filter.value[1] as number) : Date.now(),
+  );
+
+  const debouncedUpdateFilter = useCallback(
+    debounce((filter: FilterDataType) => updateFilter(filter), 500, {
+      leading: true,
+    }),
+    [updateFilter],
+  );
+
+  const updateDate = useCallback(
+    (dateStr: string, isSecondDate?: boolean) => {
+      const date = dateStr ? new Date(dateStr).getTime() : Date.now();
+      let date1 = firstDate;
+      let date2 = secondDate;
+      if (isSecondDate) {
+        date2 = date;
+        if (date < firstDate) date1 = date;
+      } else {
+        date1 = date;
+        if (date > secondDate) date2 = date;
+      }
+      setFirstDate(date1);
+      setSecondDate(date2);
+      debouncedUpdateFilter({ ...filter, value: [date1, date2] });
+    },
+    [firstDate, secondDate, setFirstDate, setSecondDate, filter, debouncedUpdateFilter],
+  );
+
+  const valueIsEmpty = !filter.value;
+
+  useEffect(() => {
+    if (valueIsEmpty) {
+      updateDate("");
+    }
+  }, [valueIsEmpty, updateDate]);
+
+  return (
+    <HStack>
+      <SelectFieldDropdown filterOptions={filterOptions} filter={filter} />
+      <SelectComparatorDropdown filter={filter} filterType="date" />
+      <HStack>
+        {!["LAST 15M", "LAST 24H", "LAST 7D"].includes(filter.comparator) && (
+          <Input
+            type="datetime-local"
+            w={240}
+            name="startDate"
+            onChange={(e) => updateDate(e.target.value)}
+            value={formatDateForPicker(firstDate)}
+          />
+        )}
+        {filter.comparator === "RANGE" && (
+          <>
+            <Icon as={BsDash} />
+            <Input
+              type="datetime-local"
+              w={240}
+              name="endDate"
+              onChange={(e) => updateDate(e.target.value, true)}
+              value={formatDateForPicker(secondDate)}
+            />
+          </>
+        )}
+      </HStack>
+
+      <IconButton
+        aria-label="Remove Filter"
+        icon={<BsTrash />}
+        onClick={() => removeFilter(filter)}
+      />
+    </HStack>
+  );
+};
+
+export default DateFilter;

--- a/app/src/components/Filters/Filter/DateFilter.tsx
+++ b/app/src/components/Filters/Filter/DateFilter.tsx
@@ -8,12 +8,13 @@ import SelectFieldDropdown from "../SelectFieldDropdown";
 import SelectComparatorDropdown from "../SelectComparatorDropdown";
 import { useFilters } from "../useFilters";
 import { type FilterDataType, type FilterOptionType } from "../types";
+import { type AtLeastOne } from "~/types/shared.types";
 
 const DateFilter = ({
   filterOptions,
   filter,
 }: {
-  filterOptions: FilterOptionType[];
+  filterOptions: AtLeastOne<FilterOptionType>;
   filter: FilterDataType;
 }) => {
   const updateFilter = useFilters().updateFilter;
@@ -71,7 +72,7 @@ const DateFilter = ({
           <Input
             type="datetime-local"
             w={240}
-            name="startDate"
+            aria-label="first date"
             onChange={(e) => updateDate(e.target.value)}
             value={formatDateForPicker(firstDate)}
           />
@@ -82,7 +83,7 @@ const DateFilter = ({
             <Input
               type="datetime-local"
               w={240}
-              name="endDate"
+              aria-label="second date"
               onChange={(e) => updateDate(e.target.value, true)}
               value={formatDateForPicker(secondDate)}
             />

--- a/app/src/components/Filters/Filter/TextFilter.tsx
+++ b/app/src/components/Filters/Filter/TextFilter.tsx
@@ -7,12 +7,13 @@ import SelectFieldDropdown from "../SelectFieldDropdown";
 import SelectComparatorDropdown from "../SelectComparatorDropdown";
 import { useFilters } from "../useFilters";
 import { type FilterOptionType, type FilterDataType } from "../types";
+import { type AtLeastOne } from "~/types/shared.types";
 
 const TextFilter = ({
   filterOptions,
   filter,
 }: {
-  filterOptions: FilterOptionType[];
+  filterOptions: AtLeastOne<FilterOptionType>;
   filter: FilterDataType;
 }) => {
   const updateFilter = useFilters().updateFilter;

--- a/app/src/components/Filters/Filter/TextFilter.tsx
+++ b/app/src/components/Filters/Filter/TextFilter.tsx
@@ -3,18 +3,25 @@ import { HStack, IconButton, Input } from "@chakra-ui/react";
 import { BsTrash } from "react-icons/bs";
 
 import { debounce } from "lodash-es";
-import SelectFieldDropdown from "./SelectFieldDropdown";
-import SelectComparatorDropdown from "./SelectComparatorDropdown";
-import { useFilters, type FilterType } from "./useFilters";
+import SelectFieldDropdown from "../SelectFieldDropdown";
+import SelectComparatorDropdown from "../SelectComparatorDropdown";
+import { useFilters } from "../useFilters";
+import { type FilterOptionType, type FilterDataType } from "../types";
 
-const Filter = ({ filterOptions, filter }: { filterOptions: string[]; filter: FilterType }) => {
+const TextFilter = ({
+  filterOptions,
+  filter,
+}: {
+  filterOptions: FilterOptionType[];
+  filter: FilterDataType;
+}) => {
   const updateFilter = useFilters().updateFilter;
   const removeFilter = useFilters().removeFilter;
 
-  const [editedValue, setEditedValue] = useState(filter.value);
+  const [editedValue, setEditedValue] = useState(filter.value as string);
 
   const debouncedUpdateFilter = useCallback(
-    debounce((filter: FilterType) => updateFilter(filter), 500, {
+    debounce((filter: FilterDataType) => updateFilter(filter), 500, {
       leading: true,
     }),
     [updateFilter],
@@ -23,13 +30,14 @@ const Filter = ({ filterOptions, filter }: { filterOptions: string[]; filter: Fi
   return (
     <HStack>
       <SelectFieldDropdown filterOptions={filterOptions} filter={filter} />
-      <SelectComparatorDropdown filter={filter} />
+      <SelectComparatorDropdown filter={filter} filterType="text" />
       <Input
         value={editedValue}
         onChange={(e) => {
           setEditedValue(e.target.value);
           debouncedUpdateFilter({ ...filter, value: e.target.value });
         }}
+        w={486}
       />
       <IconButton
         aria-label="Remove Filter"
@@ -40,4 +48,4 @@ const Filter = ({ filterOptions, filter }: { filterOptions: string[]; filter: Fi
   );
 };
 
-export default Filter;
+export default TextFilter;

--- a/app/src/components/Filters/Filter/index.tsx
+++ b/app/src/components/Filters/Filter/index.tsx
@@ -1,0 +1,23 @@
+import { type FilterDataType, type FilterOptionType } from "../types";
+import DateFilter from "./DateFilter";
+import TextFilter from "./TextFilter";
+
+const Filter = ({
+  filterOptions,
+  filter,
+}: {
+  filterOptions: FilterOptionType[];
+  filter: FilterDataType;
+}) => {
+  const selectedFilterOption = filterOptions.find(
+    (filterOption) => filterOption.field === filter.field,
+  );
+
+  if (selectedFilterOption?.type === "date") {
+    return <DateFilter filterOptions={filterOptions} filter={filter} />;
+  }
+
+  return <TextFilter filterOptions={filterOptions} filter={filter} />;
+};
+
+export default Filter;

--- a/app/src/components/Filters/Filter/index.tsx
+++ b/app/src/components/Filters/Filter/index.tsx
@@ -1,3 +1,4 @@
+import { type AtLeastOne } from "~/types/shared.types";
 import { type FilterDataType, type FilterOptionType } from "../types";
 import DateFilter from "./DateFilter";
 import TextFilter from "./TextFilter";
@@ -6,7 +7,7 @@ const Filter = ({
   filterOptions,
   filter,
 }: {
-  filterOptions: FilterOptionType[];
+  filterOptions: AtLeastOne<FilterOptionType>;
   filter: FilterDataType;
 }) => {
   const selectedFilterOption = filterOptions.find(

--- a/app/src/components/Filters/Filters.tsx
+++ b/app/src/components/Filters/Filters.tsx
@@ -4,9 +4,14 @@ import AddFilterButton from "../Filters/AddFilterButton";
 import Filter from "./Filter";
 import { useFilters } from "./useFilters";
 import { type FilterOptionType } from "./types";
+import { type AtLeastOne } from "~/types/shared.types";
 
 const Filters = ({ filterOptions }: { filterOptions: FilterOptionType[] }) => {
   const filters = useFilters().filters;
+
+  if (!filterOptions.length) return null;
+
+  const typedFilterOptions = filterOptions as unknown as AtLeastOne<FilterOptionType>;
 
   return (
     <Card w="full">
@@ -15,9 +20,9 @@ const Filters = ({ filterOptions }: { filterOptions: FilterOptionType[] }) => {
           Filters
         </Text>
         {filters.map((filter) => (
-          <Filter key={filter.id} filterOptions={filterOptions} filter={filter} />
+          <Filter key={filter.id} filterOptions={typedFilterOptions} filter={filter} />
         ))}
-        <AddFilterButton filterOptions={filterOptions} />
+        <AddFilterButton filterOptions={typedFilterOptions} />
       </VStack>
     </Card>
   );

--- a/app/src/components/Filters/Filters.tsx
+++ b/app/src/components/Filters/Filters.tsx
@@ -3,8 +3,9 @@ import { VStack, Text, Card } from "@chakra-ui/react";
 import AddFilterButton from "../Filters/AddFilterButton";
 import Filter from "./Filter";
 import { useFilters } from "./useFilters";
+import { type FilterOptionType } from "./types";
 
-const Filters = ({ filterOptions }: { filterOptions: string[] }) => {
+const Filters = ({ filterOptions }: { filterOptions: FilterOptionType[] }) => {
   const filters = useFilters().filters;
 
   return (

--- a/app/src/components/Filters/SelectComparatorDropdown.tsx
+++ b/app/src/components/Filters/SelectComparatorDropdown.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import InputDropdown from "~/components/InputDropdown";
 import { useFilters } from "./useFilters";
 import { type FilterDataType, type FilterTypeType, comparatorsForFilterType } from "./types";
+import { comparators } from "~/types/shared.types";
 
 const SelectComparatorDropdown = ({
   filter,
@@ -26,9 +27,33 @@ const SelectComparatorDropdown = ({
     <InputDropdown
       options={comparators}
       selectedOption={comparator}
+      getDisplayLabel={getComparatorLabel}
       onSelect={(option) => updateFilter({ ...filter, comparator: option })}
     />
   );
+};
+
+const getComparatorLabel = (comparator: (typeof comparators)[number]) => {
+  switch (comparator) {
+    case "CONTAINS":
+      return "Contains";
+    case "NOT_CONTAINS":
+      return "Does not contain";
+    case "LAST 15M":
+      return "Last 15 minutes";
+    case "LAST 24H":
+      return "Last 24 hours";
+    case "LAST 7D":
+      return "Last 7 days";
+    case "BEFORE":
+      return "Before";
+    case "AFTER":
+      return "After";
+    case "RANGE":
+      return "Range";
+    default:
+      return comparator;
+  }
 };
 
 export default SelectComparatorDropdown;

--- a/app/src/components/Filters/SelectComparatorDropdown.tsx
+++ b/app/src/components/Filters/SelectComparatorDropdown.tsx
@@ -18,7 +18,7 @@ const SelectComparatorDropdown = ({
 
   useEffect(() => {
     if (!comparators.includes(comparator)) {
-      updateFilter({ ...filter, comparator: comparators[0] as (typeof comparators)[number] });
+      updateFilter({ ...filter, comparator: comparators[0] });
     }
   }, [comparator, comparators, filter, updateFilter]);
 

--- a/app/src/components/Filters/SelectComparatorDropdown.tsx
+++ b/app/src/components/Filters/SelectComparatorDropdown.tsx
@@ -1,11 +1,26 @@
+import { useEffect } from "react";
 import InputDropdown from "~/components/InputDropdown";
-import { type FilterType, useFilters } from "./useFilters";
-import { comparators } from "~/types/shared.types";
+import { useFilters } from "./useFilters";
+import { type FilterDataType, type FilterTypeType, comparatorsForFilterType } from "./types";
 
-const SelectComparatorDropdown = ({ filter }: { filter: FilterType }) => {
+const SelectComparatorDropdown = ({
+  filter,
+  filterType,
+}: {
+  filter: FilterDataType;
+  filterType: FilterTypeType;
+}) => {
   const updateFilter = useFilters().updateFilter;
 
+  const comparators = comparatorsForFilterType(filterType);
+
   const { comparator } = filter;
+
+  useEffect(() => {
+    if (!comparators.includes(comparator)) {
+      updateFilter({ ...filter, comparator: comparators[0] as (typeof comparators)[number] });
+    }
+  }, [comparator, comparators, filter, updateFilter]);
 
   return (
     <InputDropdown

--- a/app/src/components/Filters/SelectFieldDropdown.tsx
+++ b/app/src/components/Filters/SelectFieldDropdown.tsx
@@ -3,12 +3,13 @@ import { useMemo } from "react";
 import InputDropdown from "~/components/InputDropdown";
 import { useFilters } from "./useFilters";
 import { type FilterDataType, comparatorsForFilterType, type FilterOptionType } from "./types";
+import { type AtLeastOne } from "~/types/shared.types";
 
 const SelectFieldDropdown = ({
   filterOptions,
   filter,
 }: {
-  filterOptions: FilterOptionType[];
+  filterOptions: AtLeastOne<FilterOptionType>;
   filter: FilterDataType;
 }) => {
   const updateFilter = useFilters().updateFilter;
@@ -25,7 +26,7 @@ const SelectFieldDropdown = ({
     let value = filter.value;
     if (optionTypeChanged) {
       const newComparatorOptions = comparatorsForFilterType(option.type);
-      comparator = newComparatorOptions[0] as (typeof newComparatorOptions)[number];
+      comparator = newComparatorOptions[0];
       value = "";
     }
 

--- a/app/src/components/Filters/SelectFieldDropdown.tsx
+++ b/app/src/components/Filters/SelectFieldDropdown.tsx
@@ -1,22 +1,47 @@
+import { useMemo } from "react";
+
 import InputDropdown from "~/components/InputDropdown";
-import { type FilterType, useFilters } from "./useFilters";
+import { useFilters } from "./useFilters";
+import { type FilterDataType, comparatorsForFilterType, type FilterOptionType } from "./types";
 
 const SelectFieldDropdown = ({
   filterOptions,
   filter,
 }: {
-  filterOptions: string[];
-  filter: FilterType;
+  filterOptions: FilterOptionType[];
+  filter: FilterDataType;
 }) => {
   const updateFilter = useFilters().updateFilter;
 
   const { field } = filter;
 
+  const selectedOption = useMemo(() => {
+    return filterOptions.find((option) => option.field === field);
+  }, [field, filterOptions]);
+
+  const updateFieldSelection = (option: FilterOptionType) => {
+    const optionTypeChanged = option.type !== selectedOption?.type;
+    let comparator = filter.comparator;
+    let value = filter.value;
+    if (optionTypeChanged) {
+      const newComparatorOptions = comparatorsForFilterType(option.type);
+      comparator = newComparatorOptions[0] as (typeof newComparatorOptions)[number];
+      value = "";
+    }
+
+    updateFilter({ ...filter, field: option.field, comparator, value });
+  };
+
+  if (!selectedOption) {
+    return null;
+  }
+
   return (
     <InputDropdown
       options={filterOptions}
-      selectedOption={field}
-      onSelect={(option) => updateFilter({ ...filter, field: option })}
+      getDisplayLabel={(option) => option.field}
+      selectedOption={selectedOption}
+      onSelect={updateFieldSelection}
     />
   );
 };

--- a/app/src/components/Filters/types.ts
+++ b/app/src/components/Filters/types.ts
@@ -1,0 +1,22 @@
+import { type comparators, dateComparators, textComparators } from "~/types/shared.types";
+
+export type FilterTypeType = "text" | "date";
+
+export type FilterOptionType = {
+  field: string;
+  type?: FilterTypeType;
+};
+
+export interface FilterDataType {
+  id: string;
+  field: string;
+  comparator: (typeof comparators)[number];
+  value: string | number[];
+}
+
+export const comparatorsForFilterType = (
+  filterType?: FilterTypeType,
+): readonly (typeof comparators)[number][] => {
+  if (filterType === "date") return dateComparators;
+  return textComparators;
+};

--- a/app/src/components/Filters/types.ts
+++ b/app/src/components/Filters/types.ts
@@ -1,4 +1,9 @@
-import { type comparators, dateComparators, textComparators } from "~/types/shared.types";
+import {
+  type comparators,
+  dateComparators,
+  textComparators,
+  type AtLeastOne,
+} from "~/types/shared.types";
 
 export type FilterTypeType = "text" | "date";
 
@@ -11,12 +16,12 @@ export interface FilterDataType {
   id: string;
   field: string;
   comparator: (typeof comparators)[number];
-  value: string | number[];
+  value: string | [number, number];
 }
 
 export const comparatorsForFilterType = (
   filterType?: FilterTypeType,
-): readonly (typeof comparators)[number][] => {
+): AtLeastOne<(typeof comparators)[number]> => {
   if (filterType === "date") return dateComparators;
   return textComparators;
 };

--- a/app/src/components/Filters/useFilters.ts
+++ b/app/src/components/Filters/useFilters.ts
@@ -1,21 +1,17 @@
 import { useQueryParam, JsonParam, withDefault } from "use-query-params";
-import { type comparators } from "~/types/shared.types";
-
-export interface FilterType {
-  id: string;
-  field: string;
-  comparator: (typeof comparators)[number];
-  value: string;
-}
+import { type FilterDataType } from "./types";
 
 export const useFilters = () => {
-  const [filters, setFilters] = useQueryParam<FilterType[]>("filters", withDefault(JsonParam, []));
+  const [filters, setFilters] = useQueryParam<FilterDataType[]>(
+    "filters",
+    withDefault(JsonParam, []),
+  );
 
-  const addFilter = (filter: FilterType) => setFilters([...filters, filter]);
-  const updateFilter = (filter: FilterType) =>
+  const addFilter = (filter: FilterDataType) => setFilters([...filters, filter]);
+  const updateFilter = (filter: FilterDataType) =>
     setFilters(filters.map((f) => (f.id === filter.id ? filter : f)));
 
-  const removeFilter = (filter: FilterType) =>
+  const removeFilter = (filter: FilterDataType) =>
     setFilters(filters.filter((f) => f.id !== filter.id));
 
   return { filters, setFilters, addFilter, updateFilter, removeFilter };

--- a/app/src/components/InputDropdown.tsx
+++ b/app/src/components/InputDropdown.tsx
@@ -43,7 +43,7 @@ const InputDropdown = <T,>({
       <PopoverTrigger>
         <InputGroup
           cursor="pointer"
-          w={getDisplayLabel(selectedOption).length * 14 + 180}
+          w={getDisplayLabel(selectedOption).length * 9 + 110}
           {...inputGroupProps}
         >
           <Input

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationFilters.tsx
@@ -10,8 +10,8 @@ import {
 import { COMPARISON_MODEL_NAMES } from "~/utils/baseModels";
 
 const defaultEvaluationFilterOptions = [
-  EvaluationFiltersDefaultFields.Input,
-  EvaluationFiltersDefaultFields.OriginalOutput,
+  { field: EvaluationFiltersDefaultFields.Input },
+  { field: EvaluationFiltersDefaultFields.OriginalOutput },
 ];
 
 const EvaluationFilters = () => {
@@ -21,11 +21,12 @@ const EvaluationFilters = () => {
     () => [
       ...defaultEvaluationFilterOptions,
       ...[
-        ...(dataset?.enabledComparisonModels.map(
-          (cm) => COMPARISON_MODEL_NAMES[cm] + EVALUATION_FILTERS_OUTPUT_APPENDIX,
-        ) || []),
-        ...(dataset?.deployedFineTunes?.map((ft) => ft.slug + EVALUATION_FILTERS_OUTPUT_APPENDIX) ||
-          []),
+        ...(dataset?.enabledComparisonModels || []).map((cm) => ({
+          field: COMPARISON_MODEL_NAMES[cm] + EVALUATION_FILTERS_OUTPUT_APPENDIX,
+        })),
+        ...(dataset?.deployedFineTunes || []).map((ft) => ({
+          field: ft.slug + EVALUATION_FILTERS_OUTPUT_APPENDIX,
+        })),
       ],
     ],
     [dataset?.enabledComparisonModels, dataset?.deployedFineTunes],

--- a/app/src/components/datasets/DatasetContentTabs/General/GeneralFilters.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/GeneralFilters.tsx
@@ -4,8 +4,8 @@ import Filters from "~/components/Filters/Filters";
 import { GeneralFiltersDefaultFields } from "~/types/shared.types";
 
 const defaultFilterOptions = [
-  GeneralFiltersDefaultFields.Input,
-  GeneralFiltersDefaultFields.Output,
+  { field: GeneralFiltersDefaultFields.Input },
+  { field: GeneralFiltersDefaultFields.Output },
 ];
 
 const GeneralFilters = () => {

--- a/app/src/components/requestLogs/LogFilters.tsx
+++ b/app/src/components/requestLogs/LogFilters.tsx
@@ -1,20 +1,25 @@
+import { useMemo } from "react";
 import { LoggedCallsFiltersDefaultFields } from "~/types/shared.types";
 import Filters from "../Filters/Filters";
 import { useTagNames } from "~/utils/hooks";
 
 const defaultFilterableFields = [
-  LoggedCallsFiltersDefaultFields.Request,
-  LoggedCallsFiltersDefaultFields.Response,
-  LoggedCallsFiltersDefaultFields.Model,
-  LoggedCallsFiltersDefaultFields.StatusCode,
+  { field: LoggedCallsFiltersDefaultFields.Request },
+  { field: LoggedCallsFiltersDefaultFields.Response },
+  { field: LoggedCallsFiltersDefaultFields.Model },
+  { field: LoggedCallsFiltersDefaultFields.StatusCode },
+  { field: LoggedCallsFiltersDefaultFields.SentAt, type: "date" },
 ];
 
 const LogFilters = () => {
   const tagNames = useTagNames().data;
 
-  if (!tagNames) return null;
+  const filterOptions = useMemo(
+    () => [...defaultFilterableFields, ...(tagNames || []).map((tag) => ({ field: tag }))],
+    [tagNames],
+  );
 
-  return <Filters filterOptions={[...defaultFilterableFields, ...tagNames]} />;
+  return <Filters filterOptions={filterOptions} />;
 };
 
 export default LogFilters;

--- a/app/src/server/utils/constructDatasetEntryFiltersQuery.ts
+++ b/app/src/server/utils/constructDatasetEntryFiltersQuery.ts
@@ -3,7 +3,7 @@ import { type Expression, type SqlBool, sql } from "kysely";
 
 import { kysely } from "~/server/db";
 import { GeneralFiltersDefaultFields, type filtersSchema } from "~/types/shared.types";
-import { comparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
+import { textComparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
 
 export const constructDatasetEntryFiltersQuery = (
   filters: z.infer<typeof filtersSchema>,
@@ -17,7 +17,10 @@ export const constructDatasetEntryFiltersQuery = (
 
     for (const filter of filters) {
       if (!filter.value) continue;
-      const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+      const filterExpression = textComparatorToSqlExpression(
+        filter.comparator,
+        filter.value as string,
+      );
 
       if (filter.field === GeneralFiltersDefaultFields.Input) {
         wheres.push(filterExpression(sql.raw(`de."messages"::text`)));

--- a/app/src/server/utils/constructEvaluationFiltersQuery.ts
+++ b/app/src/server/utils/constructEvaluationFiltersQuery.ts
@@ -3,7 +3,7 @@ import { type Expression, type SqlBool, sql } from "kysely";
 
 import { kysely } from "~/server/db";
 import { EVALUATION_FILTERS_OUTPUT_APPENDIX, type filtersSchema } from "~/types/shared.types";
-import { comparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
+import { textComparatorToSqlExpression } from "./constructLoggedCallFiltersQuery";
 import { EvaluationFiltersDefaultFields } from "~/types/shared.types";
 
 export const constructEvaluationFiltersQuery = (
@@ -19,7 +19,10 @@ export const constructEvaluationFiltersQuery = (
 
     for (const filter of filters) {
       if (!filter.value) continue;
-      const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+      const filterExpression = textComparatorToSqlExpression(
+        filter.comparator,
+        filter.value as string,
+      );
 
       if (filter.field === EvaluationFiltersDefaultFields.Input) {
         wheres.push(filterExpression(sql.raw(`de."messages"::text`)));
@@ -47,7 +50,10 @@ export const constructEvaluationFiltersQuery = (
     const filter = modelOutputFilters[i];
     if (!filter?.value) continue;
     const tableAlias = `te${i}`;
-    const filterExpression = comparatorToSqlExpression(filter.comparator, filter.value);
+    const filterExpression = textComparatorToSqlExpression(
+      filter.comparator,
+      filter.value as string,
+    );
 
     updatedBaseQuery = updatedBaseQuery
       .leftJoin(`FineTuneTestingEntry as ${tableAlias}`, (join) =>

--- a/app/src/server/utils/constructLoggedCallFiltersQuery.ts
+++ b/app/src/server/utils/constructLoggedCallFiltersQuery.ts
@@ -31,14 +31,14 @@ export const textComparatorToSqlExpression = (
 
 export const dateComparatorToSqlExpression = (
   comparator: (typeof comparators)[number],
-  value: number[],
+  value: [number, number],
 ) => {
   const [start, end] = value;
   let startDate: string;
   let endDate: string;
   try {
-    startDate = new Date(start as number).toISOString();
-    endDate = new Date(end as number).toISOString();
+    startDate = new Date(start).toISOString();
+    endDate = new Date(end).toISOString();
   } catch (e) {
     throw new Error("Failed to parse start and end dates");
   }
@@ -77,8 +77,6 @@ export const constructLoggedCallFiltersQuery = (
     .where((eb) => {
       const wheres: Expression<SqlBool>[] = [eb("lc.projectId", "=", projectId)];
 
-      console.log("filters", filters);
-
       const dateFilters = filters.filter(
         (filter) => filter.field === LoggedCallsFiltersDefaultFields.SentAt,
       );
@@ -87,7 +85,7 @@ export const constructLoggedCallFiltersQuery = (
       for (const filter of dateFilters) {
         const filterExpression = dateComparatorToSqlExpression(
           filter.comparator,
-          filter.value as number[],
+          filter.value as [number, number],
         );
 
         if (filter.field === LoggedCallsFiltersDefaultFields.SentAt) {

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -93,17 +93,28 @@ export enum SortOrder {
   DESC = "desc",
 }
 
-export const comparators = ["=", "!=", "CONTAINS", "NOT_CONTAINS"] as const;
+export const textComparators = ["=", "!=", "CONTAINS", "NOT_CONTAINS"] as const;
+export const dateComparators = [
+  "LAST 15M",
+  "LAST 24H",
+  "LAST 7D",
+  "BEFORE",
+  "AFTER",
+  "RANGE",
+] as const;
+export const comparators = [...textComparators, ...dateComparators] as const;
+export type ComparatorsSubsetType = typeof textComparators | typeof dateComparators;
 
 export const filtersSchema = z.array(
   z.object({
     field: z.string(),
     comparator: z.enum(comparators),
-    value: z.string(),
+    value: z.string().or(z.array(z.number())),
   }),
 );
 
 export enum LoggedCallsFiltersDefaultFields {
+  SentAt = "Sent At",
   Request = "Request",
   Response = "Response",
   Model = "Model",

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 
 export const CURRENT_PIPELINE_VERSION = 2;
 
+export type AtLeastOne<T> = readonly [T, ...T[]];
+
 export const validatedChatInput = <
   T extends { messages: unknown; functions?: unknown; function_call?: unknown },
 >(

--- a/app/src/utils/dayjs.ts
+++ b/app/src/utils/dayjs.ts
@@ -10,4 +10,7 @@ dayjs.extend(timezone);
 export const formatTimePast = (date: Date) =>
   dayjs.duration(dayjs(date).diff(dayjs())).humanize(true);
 
+export const formatDateForPicker = (date: number) =>
+  dayjs(new Date(date)).format("YYYY-MM-DD HH:mm");
+
 export default dayjs;


### PR DESCRIPTION
With this change, we can now filter request logs by date.

### Changes
* Add `text | date` type field to filter option
* Split filter into TextFilter and DateFilter
* Add `LAST 15M`, `LAST 24H`, `LAST 7D`, `BEFORE`, `AFTER` and `RANGE` date comparators
* Add `"Sent At"` as a filterable field for request logs

Sent At filters:
<img width="1070" alt="Screenshot 2023-10-30 at 1 15 13 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/14365885-820e-4b06-af13-7122186fea83">


