### PR TITLE
Hide deprecated experiments page

### DIFF
--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -18,7 +18,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { BsGearFill, BsGithub, BsPersonCircle } from "react-icons/bs";
 import { IoStatsChartOutline } from "react-icons/io5";
-import { RiHome3Line, RiFlaskLine } from "react-icons/ri";
+import { RiHome3Line } from "react-icons/ri";
 import { AiOutlineThunderbolt, AiOutlineDatabase } from "react-icons/ai";
 import { FaReadme } from "react-icons/fa";
 import { signIn, useSession } from "next-auth/react";
@@ -82,7 +82,7 @@ const NavSidebar = () => {
             <IconLink icon={IoStatsChartOutline} label="Request Logs" href="/request-logs" />
             <IconLink icon={AiOutlineDatabase} label="Datasets" href="/datasets" beta />
             <IconLink icon={AiOutlineThunderbolt} label="Fine Tunes" href="/fine-tunes" beta />
-            <IconLink icon={RiFlaskLine} label="Experiments" href="/experiments" />
+            {/* <IconLink icon={RiFlaskLine} label="Experiments" href="/experiments" /> */}
             <VStack w="full" alignItems="flex-start" spacing={0} pt={8}>
               <Text
                 pl={2}

--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -80,7 +80,7 @@ const NavSidebar = () => {
 
             <IconLink icon={RiHome3Line} label="Dashboard" href="/dashboard" />
             <IconLink icon={IoStatsChartOutline} label="Request Logs" href="/request-logs" />
-            <IconLink icon={AiOutlineDatabase} label="Datasets" href="/datasets" beta />
+            <IconLink icon={AiOutlineDatabase} label="Datasets" href="/datasets" />
             <IconLink icon={AiOutlineThunderbolt} label="Fine Tunes" href="/fine-tunes" beta />
             {/* <IconLink icon={RiFlaskLine} label="Experiments" href="/experiments" /> */}
             <VStack w="full" alignItems="flex-start" spacing={0} pt={8}>


### PR DESCRIPTION
Experiments are deprecated, so while we don't want to actually stop supporting them for those users who rely on them, we shouldn't encourage more people to focus on that part of our previous product offering.

Before:
<img width="237" alt="Screenshot 2023-10-30 at 2 28 07 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/454f09bc-a5a9-4129-80f4-149e650a178b">


After:
<img width="237" alt="Screenshot 2023-10-30 at 2 28 28 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/0ff55ee7-091e-415f-ae44-2db37b31f5e6">

