### PR TITLE
Bump background worker to higher Render plan

### DIFF
--- a/app/src/components/requestLogs/ColumnVisibilityDropdown.tsx
+++ b/app/src/components/requestLogs/ColumnVisibilityDropdown.tsx
@@ -22,10 +22,6 @@ import ActionButton from "../ActionButton";
 const ColumnVisibilityDropdown = () => {
   const tagNames = useTagNames().data;
 
-  const visibleColumns = useAppStore((s) => s.columnVisibility.visibleColumns);
-  const toggleColumnVisibility = useAppStore((s) => s.columnVisibility.toggleColumnVisibility);
-  const totalColumns = Object.keys(StaticColumnKeys).length + (tagNames?.length ?? 0);
-
   const popover = useDisclosure();
 
   const columnVisibilityOptions = useMemo(() => {
@@ -68,6 +64,15 @@ const ColumnVisibilityDropdown = () => {
     return options;
   }, [tagNames]);
 
+  const columnVisibilityKeys = new Set(columnVisibilityOptions.map((option) => option.key));
+
+  const visibleColumns = new Set(
+    Array.from(useAppStore((s) => s.columnVisibility.visibleColumns)).filter((key) =>
+      columnVisibilityKeys.has(key),
+    ),
+  );
+  const toggleColumnVisibility = useAppStore((s) => s.columnVisibility.toggleColumnVisibility);
+
   const isClientRehydrated = useIsClientRehydrated();
   if (!isClientRehydrated) return null;
 
@@ -81,7 +86,7 @@ const ColumnVisibilityDropdown = () => {
       <PopoverTrigger>
         <Box>
           <ActionButton
-            label={`Columns (${visibleColumns.size}/${totalColumns})`}
+            label={`Columns (${visibleColumns.size}/${columnVisibilityOptions.length})`}
             icon={BsToggles}
           />
         </Box>

--- a/app/src/server/tasks/importDatasetEntries.task.ts
+++ b/app/src/server/tasks/importDatasetEntries.task.ts
@@ -74,8 +74,6 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
       progress: 30,
     });
 
-    console.log("got to processing");
-
     const importId = new Date().toISOString();
     let datasetEntriesToCreate;
     try {
@@ -96,24 +94,16 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
       return;
     }
 
-    console.log("got to saving");
-
     await updateDatasetFileUpload({
       status: "SAVING",
       progress: 75,
     });
 
-    console.log("got to saving");
-
     await prisma.datasetEntry.createMany({
       data: datasetEntriesToCreate,
     });
 
-    await updateDatasetFileUpload({
-      progress: 80,
-    });
-
-    console.log("got to pruning");
+    await updateDatasetFileUpload({ progress: 80 });
 
     await updatePruningRuleMatches(
       datasetFileUpload.datasetId,
@@ -121,19 +111,11 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
       datasetEntriesToCreate.map((entry) => entry.id),
     );
 
-    await updateDatasetFileUpload({
-      progress: 85,
-    });
-
-    console.log("got to start test jobs");
+    await updateDatasetFileUpload({ progress: 85 });
 
     await startDatasetTestJobs(datasetFileUpload.datasetId);
 
-    await updateDatasetFileUpload({
-      progress: 90,
-    });
-
-    console.log("got to start token counting");
+    await updateDatasetFileUpload({ progress: 90 });
 
     await countDatasetEntryTokens.enqueue();
 

--- a/render.yaml
+++ b/render.yaml
@@ -44,7 +44,7 @@ services:
     runtime: docker
     dockerfilePath: ./app/Dockerfile
     dockerContext: .
-    plan: pro
+    plan: pro plus
     dockerCommand: /code/app/scripts/run-workers-prod.sh
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
Some extremely large dataset import jobs were failing due to OOM errors. Bumping up to a larger instance to fix.

Separately, fixes a bug where the request logs page would sometimes report eg. 11/9 columns visible when you switch between projects.