### PR TITLE
Convert tool calls to function calls for 3.5 fine-tunes

### DIFF
--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -39,13 +39,13 @@ export async function getCompletion2(
 
     // TODO: create pipeline without this conversion once OpenAI supports tool_calls for their fine-tuned models
 
-    // convert tool call input to function call input
     const completion = await getOpenaiCompletion(fineTune.projectId, {
+      // convert tool call input to function call input
       ...convertToolCallInputToFunctionInput(prunedInput),
       model,
     });
-    // convert function call output to tool call output
     if (completion.choices[0]?.message.function_call) {
+      // convert function call output to tool call output
       completion.choices[0].message = convertFunctionMessageToToolCall(
         completion.choices[0].message,
       ) as ChatCompletionMessage;

--- a/app/src/modelProviders/fine-tuned/serializers.ts
+++ b/app/src/modelProviders/fine-tuned/serializers.ts
@@ -1,9 +1,9 @@
 import { isObject } from "lodash-es";
 import { type ChatCompletionMessage, type ChatCompletionCreateParams } from "openai/resources/chat";
 import {
-  convertFunctionCall,
-  convertFunctions,
-  convertMessages,
+  convertFunctionCallToToolChoice,
+  convertFunctionsToTools,
+  convertFunctionMessagesToToolCall,
 } from "~/server/utils/convertFunctionCalls";
 
 const FUNCTION_CALL_TAG = "<function>";
@@ -67,13 +67,13 @@ export const serializeChatInput = (
   },
   fineTune: { pipelineVersion: number; id?: string },
 ) => {
-  const convertedMessages = convertMessages(input.messages);
+  const convertedMessages = convertFunctionMessagesToToolCall(input.messages);
   if (fineTune.pipelineVersion === 1) {
     return JSON.stringify(convertedMessages);
   } else if (fineTune.pipelineVersion === 2) {
     let functions: string[] | null = null;
-    const toolChoice = input.tool_choice ?? convertFunctionCall(input.function_call);
-    const tools = input.tools ?? convertFunctions(input.functions);
+    const toolChoice = input.tool_choice ?? convertFunctionCallToToolChoice(input.function_call);
+    const tools = input.tools ?? convertFunctionsToTools(input.functions ?? undefined);
     if (toolChoice === "none") {
       functions = null;
     } else if (

--- a/app/src/server/scripts/migrate-tool-calls.ts
+++ b/app/src/server/scripts/migrate-tool-calls.ts
@@ -3,10 +3,10 @@ import type { ChatCompletionMessageParam } from "openai/resources/chat";
 import { kysely } from "../db";
 import { typedDatasetEntry } from "~/types/dbColumns.types";
 import {
-  convertFunctionCall,
-  convertFunctions,
-  convertMessages,
   convertFunctionMessageToToolCall,
+  convertFunctionCallToToolChoice,
+  convertFunctionsToTools,
+  convertFunctionMessagesToToolCall,
 } from "../utils/convertFunctionCalls";
 
 await kysely.transaction().execute(async (trx) => {
@@ -36,11 +36,11 @@ await kysely.transaction().execute(async (trx) => {
       continue;
     }
 
-    const tool_choice = convertFunctionCall(typedEntry.function_call);
+    const tool_choice = convertFunctionCallToToolChoice(typedEntry.function_call);
 
-    const tools = convertFunctions(typedEntry.functions);
+    const tools = convertFunctionsToTools(typedEntry.functions ?? undefined);
 
-    const messages = convertMessages(typedEntry.messages);
+    const messages = convertFunctionMessagesToToolCall(typedEntry.messages);
     const output = typedEntry.output ? convertFunctionMessageToToolCall(typedEntry.output) : null;
 
     await trx

--- a/app/src/server/utils/convertFunctionCalls.ts
+++ b/app/src/server/utils/convertFunctionCalls.ts
@@ -1,11 +1,9 @@
 import type { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions";
 
-export const convertFunctionCall = (
+export const convertFunctionCallToToolChoice = (
   functionCall: ChatCompletionCreateParamsBase["function_call"] | null,
-): ChatCompletionCreateParamsBase["tool_choice"] => {
-  if (!functionCall) {
-    return undefined;
-  } else if (functionCall === "auto" || functionCall === "none") {
+): ChatCompletionCreateParamsBase["tool_choice"] | null => {
+  if (!functionCall || functionCall === "auto" || functionCall === "none") {
     return functionCall;
   } else if (functionCall.name) {
     return {
@@ -17,9 +15,21 @@ export const convertFunctionCall = (
   }
 };
 
-export const convertFunctions = (
-  functions: ChatCompletionCreateParamsBase["functions"] | null,
-): ChatCompletionCreateParamsBase["tools"] | null => {
+export const convertToolChoiceToFunctionCall = (
+  toolChoice: ChatCompletionCreateParamsBase["tool_choice"],
+): ChatCompletionCreateParamsBase["function_call"] => {
+  if (!toolChoice || toolChoice === "auto" || toolChoice === "none") {
+    return toolChoice;
+  } else if (toolChoice.type === "function" && toolChoice.function) {
+    return {
+      name: toolChoice.function.name,
+    };
+  }
+};
+
+export const convertFunctionsToTools = (
+  functions: ChatCompletionCreateParamsBase["functions"],
+): ChatCompletionCreateParamsBase["tools"] => {
   if (!functions) return functions;
   return functions.map((func) => ({
     type: "function",
@@ -31,7 +41,29 @@ export const convertFunctions = (
   }));
 };
 
-export const convertMessages = (
+export const convertToolsToFunctions = (
+  tools: ChatCompletionCreateParamsBase["tools"],
+): ChatCompletionCreateParamsBase["functions"] => {
+  if (!tools) return tools;
+  return tools.map((tool) => ({
+    name: tool.function.name,
+    description: tool.function.description,
+    parameters: tool.function.parameters,
+  }));
+};
+
+export const convertToolCallInputToFunctionInput = (
+  input: ChatCompletionCreateParamsBase,
+): ChatCompletionCreateParamsBase => ({
+  ...input,
+  messages: convertToolCallMessagesToFunction(input.messages),
+  function_call: input.function_call ?? convertToolChoiceToFunctionCall(input.tool_choice),
+  functions: input.functions ?? convertToolsToFunctions(input.tools),
+  tool_choice: undefined,
+  tools: undefined,
+});
+
+export const convertFunctionMessagesToToolCall = (
   messages: ChatCompletionCreateParamsBase["messages"],
 ): ChatCompletionCreateParamsBase["messages"] => messages.map(convertFunctionMessageToToolCall);
 
@@ -44,20 +76,19 @@ export const convertFunctionMessageToToolCall = (
     case "tool":
       return message;
     case "assistant":
-      if (message.tool_calls?.length || !message.function_call) {
-        return message;
-      } else {
-        return {
-          ...message,
-          tool_calls: [
-            {
-              id: "",
-              type: "function" as const,
-              function: message.function_call,
-            },
-          ],
-        };
-      }
+      return {
+        ...message,
+        tool_calls: message.function_call
+          ? [
+              {
+                id: "",
+                type: "function" as const,
+                function: message.function_call,
+              },
+            ]
+          : undefined,
+        function_call: undefined,
+      };
     case "function":
       return {
         role: "tool" as const,
@@ -66,6 +97,10 @@ export const convertFunctionMessageToToolCall = (
       };
   }
 };
+
+export const convertToolCallMessagesToFunction = (
+  messages: ChatCompletionCreateParamsBase["messages"],
+): ChatCompletionCreateParamsBase["messages"] => messages.map(convertToolCallMessageToFunction);
 
 export const convertToolCallMessageToFunction = (
   message: ChatCompletionCreateParamsBase["messages"][0],
@@ -76,15 +111,11 @@ export const convertToolCallMessageToFunction = (
     case "function":
       return message;
     case "assistant":
-      if (message.function_call || !message.tool_calls?.length) {
-        return message;
-      } else {
-        return {
-          ...message,
-          function_call: message.tool_calls[0]?.function,
-          tool_calls: undefined,
-        };
-      }
+      return {
+        ...message,
+        function_call: message.function_call || message.tool_calls?.[0]?.function,
+        tool_calls: undefined,
+      };
     case "tool":
       return {
         role: "function" as const,

--- a/app/src/server/utils/convertFunctionCalls.ts
+++ b/app/src/server/utils/convertFunctionCalls.ts
@@ -76,17 +76,19 @@ export const convertFunctionMessageToToolCall = (
     case "tool":
       return message;
     case "assistant":
+      let tool_calls = message.tool_calls;
+      if (!tool_calls && message.function_call) {
+        tool_calls = [
+          {
+            id: "",
+            type: "function" as const,
+            function: message.function_call,
+          },
+        ];
+      }
       return {
         ...message,
-        tool_calls: message.function_call
-          ? [
-              {
-                id: "",
-                type: "function" as const,
-                function: message.function_call,
-              },
-            ]
-          : undefined,
+        tool_calls,
         function_call: undefined,
       };
     case "function":

--- a/app/src/server/utils/convertFunctionCalls.ts
+++ b/app/src/server/utils/convertFunctionCalls.ts
@@ -29,9 +29,8 @@ export const convertToolChoiceToFunctionCall = (
 
 export const convertFunctionsToTools = (
   functions: ChatCompletionCreateParamsBase["functions"],
-): ChatCompletionCreateParamsBase["tools"] => {
-  if (!functions) return functions;
-  return functions.map((func) => ({
+): ChatCompletionCreateParamsBase["tools"] =>
+  functions?.map((func) => ({
     type: "function",
     function: {
       name: func.name,
@@ -39,18 +38,15 @@ export const convertFunctionsToTools = (
       parameters: func.parameters,
     },
   }));
-};
 
 export const convertToolsToFunctions = (
   tools: ChatCompletionCreateParamsBase["tools"],
-): ChatCompletionCreateParamsBase["functions"] => {
-  if (!tools) return tools;
-  return tools.map((tool) => ({
+): ChatCompletionCreateParamsBase["functions"] =>
+  tools?.map((tool) => ({
     name: tool.function.name,
     description: tool.function.description,
     parameters: tool.function.parameters,
   }));
-};
 
 export const convertToolCallInputToFunctionInput = (
   input: ChatCompletionCreateParamsBase,

--- a/app/src/server/utils/prepareDatasetEntriesForImport.ts
+++ b/app/src/server/utils/prepareDatasetEntriesForImport.ts
@@ -5,10 +5,10 @@ import { type RowToImport } from "~/components/datasets/parseRowsToImport";
 
 import { prisma } from "~/server/db";
 import {
-  convertFunctionCall,
-  convertFunctions,
+  convertFunctionCallToToolChoice,
+  convertFunctionsToTools,
   convertFunctionMessageToToolCall,
-  convertMessages,
+  convertFunctionMessagesToToolCall,
 } from "./convertFunctionCalls";
 
 export const prepareDatasetEntriesForImport = async (
@@ -60,12 +60,13 @@ export const prepareDatasetEntriesForImport = async (
     return {
       id: uuidv4(),
       datasetId: datasetId,
-      messages: convertMessages(row.input.messages) as object[],
+      messages: convertFunctionMessagesToToolCall(row.input.messages) as object[],
       function_call: row.input.function_call,
       functions: row.input.functions as object[],
       tool_choice:
-        row.input.tool_choice || (convertFunctionCall(row.input.function_call) as object),
-      tools: row.input.tools || (convertFunctions(row.input.functions) as object[]),
+        row.input.tool_choice ||
+        (convertFunctionCallToToolChoice(row.input.function_call) as object),
+      tools: row.input.tools || (convertFunctionsToTools(row.input.functions) as object[]),
       output: (convertFunctionMessageToToolCall(
         row.output,
       ) as unknown as Prisma.InputJsonValue) ?? {

--- a/app/src/server/utils/updatePruningRuleMatches.test.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.test.ts
@@ -15,7 +15,7 @@ const input1: ChatCompletionMessageParam[] = [
   {
     role: "user",
     content:
-      'Prompt constructor function:\n---\n/**\n * Use Javascript to define an OpenAI chat completion\n * (https://platform.openai.com/docs/api-reference/chat/create).\n *\n * You have access to the current scenario in the `scenario`\n * variable.\n */\n\ndefinePrompt("openai/ChatCompletion", {\n  model: "gpt-3.5-turbo-0613",\n  messages: [\n    {\n      role: "system",\n      content: `Write \'Start experimenting!\' in ${scenario.language}`,\n    },\n  ],\n});',
+      "This is the user message.\nIt has a newline.\n\nAnd another two. Then it has text without newlines.",
   },
   {
     role: "assistant",
@@ -106,7 +106,7 @@ it("matches string with newline", async () => {
     createDatasetEntry(datasetId, input1),
     createPruningRule(
       datasetId,
-      "Prompt constructor function:\n---\n/**\n * Use Javascript to define an OpenAI chat completion\n * (https://platform.openai.com/docs/api-reference/chat/create).\n *",
+      "This is the user message.\nIt has a newline.\n\nAnd another two. ",
     ),
   ]);
 

--- a/app/src/types/dbColumns.types.ts
+++ b/app/src/types/dbColumns.types.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { type DatasetEntry, type LoggedCallModelResponse } from "@prisma/client";
+
 import {
   chatCompletionMessage,
   chatCompletionInput,
@@ -9,7 +11,6 @@ import {
   toolChoiceInput,
   toolsInput,
 } from "./shared.types";
-import { type DatasetEntry, type LoggedCallModelResponse } from "@prisma/client";
 
 export const datasetEntrySchema = z
   .object({

--- a/app/src/utils/baseModels.ts
+++ b/app/src/utils/baseModels.ts
@@ -11,7 +11,7 @@ export const displayBaseModel = (baseModel: BaseModel) => {
     case "LLAMA2_13b":
       return "llama2-13b";
     case "GPT_3_5_TURBO":
-      return "gpt-3.5-turbo";
+      return "gpt-3.5-turbo-1106";
   }
 };
 
@@ -44,7 +44,7 @@ export const isComparisonModelName = (modelName: string) =>
   Object.values(COMPARISON_MODEL_NAMES).includes(modelName);
 
 export const COMPARISON_MODEL_NAMES: Record<ComparisonModel, string> = {
-  GPT_3_5_TURBO: "gpt-3.5-turbo-0613",
+  GPT_3_5_TURBO: "gpt-3.5-turbo-1106",
 };
 
 export const getComparisonModel = (modelName: string) => {


### PR DESCRIPTION
Unfortunately, OpenAI's 3.5 fine-tuning services have not been updated to support the tool call syntax. Consequently, we need to convert incoming requests to fine-tuned 3.5 models to use the function call syntax, and then convert completions generated from fine-tuned 3.5 models back into the tool call syntax to ensure consistency with the remainder of our app.