### PR TITLE
Speed up the request logs page

### DIFF
--- a/app/prisma/migrations/20231114015910_add_more_logged_call_indexes/migration.sql
+++ b/app/prisma/migrations/20231114015910_add_more_logged_call_indexes/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex
+CREATE INDEX "LoggedCall_projectId_idx" ON "LoggedCall"("projectId");
+
+-- CreateIndex
+CREATE INDEX "LoggedCall_projectId_requestedAt_idx" ON "LoggedCall"("projectId", "requestedAt");
+
+-- CreateIndex
+CREATE INDEX "LoggedCallModelResponse_originalLoggedCallId_idx" ON "LoggedCallModelResponse"("originalLoggedCallId");
+
+-- CreateIndex
+CREATE INDEX "LoggedCallTag_loggedCallId_idx" ON "LoggedCallTag"("loggedCallId");
+
+-- DropIndex
+DROP INDEX "LoggedCall_requestedAt_idx";

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -392,7 +392,8 @@ model LoggedCall {
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 
-    @@index([requestedAt])
+    @@index(projectId)
+    @@index([projectId, requestedAt])
 }
 
 model LoggedCallModelResponse {
@@ -432,7 +433,8 @@ model LoggedCallModelResponse {
     updatedAt   DateTime     @updatedAt
     loggedCalls LoggedCall[]
 
-    @@index([cacheKey])
+    @@index(originalLoggedCallId)
+    @@index(cacheKey)
 }
 
 model LoggedCallTag {
@@ -445,6 +447,7 @@ model LoggedCallTag {
     loggedCall   LoggedCall @relation(fields: [loggedCallId], references: [id], onDelete: Cascade)
 
     @@unique([loggedCallId, name])
+    @@index(loggedCallId)
     @@index([projectId, name])
     @@index([projectId, name, value])
 }

--- a/app/scripts/restore-dump.ts
+++ b/app/scripts/restore-dump.ts
@@ -1,0 +1,67 @@
+import { $ } from "execa";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const $$ = $({ stdio: "inherit", shell: true });
+
+const argv = await yargs(hideBin(process.argv)).option("dump-file-path", {
+  type: "string",
+  description: "Path to the dump file",
+}).argv;
+
+const dbName = "openpipe-dev";
+const templateDbName = `${dbName}_template`;
+
+const migrateTemplate = `
+delete from
+  "LoggedCall"
+where
+  id in (
+    SELECT
+      lc.id
+    FROM
+      "public"."LoggedCall" AS lc
+      LEFT JOIN "public"."LoggedCallModelResponse" AS lcmr ON lc."modelResponseId" = lcmr."id"
+    WHERE
+      lc."modelResponseId" IS NOT NULL
+      AND lcmr."id" IS NULL
+  );
+
+ALTER TABLE ONLY
+  "public"."LoggedCall"
+ADD
+  CONSTRAINT "LoggedCall_modelResponseId_fkey" FOREIGN KEY ("modelResponseId") REFERENCES "public"."LoggedCallModelResponse" ("id") ON UPDATE CASCADE ON DELETE CASCADE;`;
+
+const terminateConnections = async (databaseName: string) => {
+  console.log(`Terminating existing connections to ${databaseName} database...`);
+  await $$`psql -a -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '${databaseName}' AND pid <> pg_backend_pid();"`;
+};
+
+const restoreFromDisk = async (dumpFilePath: string) => {
+  if (!dumpFilePath) {
+    throw new Error("No dump file path provided.");
+  }
+
+  console.log(`Creating a temporary template database: ${templateDbName}`);
+  await terminateConnections(templateDbName);
+  await $$`psql -c 'UPDATE pg_database SET datistemplate = FALSE WHERE datname = "${templateDbName}"'`;
+  await $$`psql -c 'DROP DATABASE IF EXISTS "${templateDbName}"'`;
+  await $$`psql -c 'CREATE DATABASE "${templateDbName}"'`;
+  await $$`psql -c 'UPDATE pg_database SET datistemplate = TRUE WHERE datname = "${templateDbName}"'`;
+
+  console.log(`Processing the dump file and restoring to ${templateDbName}`);
+  await $$`sed '/CREATE ROLE/d;/ALTER ROLE/d;/DROP ROLE/d;/GRANT .* TO/d' ${dumpFilePath} | sed 's/"querykey_prod_x93p"/"${templateDbName}"/g' | psql -d "${templateDbName}"`;
+
+  await $$`psql -d "${templateDbName}" -c '${migrateTemplate}'`;
+};
+
+if (argv.dumpFilePath) {
+  await restoreFromDisk(argv.dumpFilePath);
+}
+
+console.log(`Dropping and recreating the database: ${dbName} from the template`);
+await terminateConnections(dbName);
+await $$`psql -c 'DROP DATABASE IF EXISTS "${dbName}"'`;
+await $$`psql -c 'CREATE DATABASE "${dbName}" WITH TEMPLATE "${templateDbName}"'`;
+
+console.log("Restoration completed.");

--- a/app/src/server/api/routers/loggedCalls.router.ts
+++ b/app/src/server/api/routers/loggedCalls.router.ts
@@ -85,11 +85,13 @@ export const loggedCallsRouter = createTRPCRouter({
         };
       });
 
-      const matchingLogIds = await baseQuery.select(["lc.id"]).execute();
+      const count = (
+        await baseQuery
+          .select(({ fn }) => [fn.count("lc.id").as("match_count")])
+          .executeTakeFirstOrThrow()
+      )?.match_count;
 
-      const count = matchingLogIds.length;
-
-      return { calls, count };
+      return { calls, count: Number(count) };
     }),
   getTagNames: protectedProcedure
     .input(z.object({ projectId: z.string() }))


### PR DESCRIPTION
Did some postgres query analysis and fixed the slowest parts of the request logs page.

It's still slow for users that legitimately have a lot of logs because of the query to get the unique tag names. I think the only solution there will be to change our database structure so we keep a list of all tags that have been applied in each project, but didn't want to block this PR on that change. This will improve performance significantly for users who do not have a large number of logs.