### PR TITLE
Fix async python tests, tool conversions

### DIFF
--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -44,7 +44,7 @@ export async function getCompletion2(
       ...convertToolCallInputToFunctionInput(prunedInput),
       model,
     });
-    if (completion.choices[0]?.message.function_call) {
+    if (completion.choices[0]?.message && input.tools?.length) {
       // convert function call output to tool call output
       completion.choices[0].message = convertFunctionMessageToToolCall(
         completion.choices[0].message,

--- a/app/src/modelProviders/fine-tuned/serializers.ts
+++ b/app/src/modelProviders/fine-tuned/serializers.ts
@@ -73,7 +73,9 @@ export const serializeChatInput = (
   } else if (fineTune.pipelineVersion === 2) {
     let functions: string[] | null = null;
     const toolChoice = input.tool_choice ?? convertFunctionCallToToolChoice(input.function_call);
-    const tools = input.tools ?? convertFunctionsToTools(input.functions ?? undefined);
+    const tools = input.tools?.length
+      ? input.tools
+      : convertFunctionsToTools(input.functions ?? undefined);
     if (toolChoice === "none") {
       functions = null;
     } else if (

--- a/app/src/server/utils/convertFunctionCalls.ts
+++ b/app/src/server/utils/convertFunctionCalls.ts
@@ -54,7 +54,7 @@ export const convertToolCallInputToFunctionInput = (
   ...input,
   messages: convertToolCallMessagesToFunction(input.messages),
   function_call: input.function_call ?? convertToolChoiceToFunctionCall(input.tool_choice),
-  functions: input.functions ?? convertToolsToFunctions(input.tools),
+  functions: input.functions?.length ? input.functions : convertToolsToFunctions(input.tools),
   tool_choice: undefined,
   tools: undefined,
 });

--- a/app/src/server/utils/prepareDatasetEntriesForImport.ts
+++ b/app/src/server/utils/prepareDatasetEntriesForImport.ts
@@ -66,7 +66,9 @@ export const prepareDatasetEntriesForImport = async (
       tool_choice:
         row.input.tool_choice ||
         (convertFunctionCallToToolChoice(row.input.function_call) as object),
-      tools: row.input.tools || (convertFunctionsToTools(row.input.functions) as object[]),
+      tools: row.input.tools?.length
+        ? row.input.tools
+        : (convertFunctionsToTools(row.input.functions) as object[]),
       output: (convertFunctionMessageToToolCall(
         row.output,
       ) as unknown as Prisma.InputJsonValue) ?? {

--- a/client-libs/python/openpipe/test_async_client.py
+++ b/client-libs/python/openpipe/test_async_client.py
@@ -8,6 +8,13 @@ from .test_sync_client import function_call, function, last_logged_call
 client = AsyncOpenAI()
 
 
+@pytest.fixture(autouse=True)
+def setup():
+    print("\nresetting async client\n")
+    global client
+    client = AsyncOpenAI()
+
+
 async def test_async_content():
     completion = await client.chat.completions.create(
         model="gpt-3.5-turbo",


### PR DESCRIPTION
### Changes
* Reset client between each async python test
* Ignore empty arrays of tools or functions when converting between them