### PR TITLE
Add response_format to DatasetEntries

### DIFF
--- a/app/prisma/migrations/20231115025507_add_response_format/migration.sql
+++ b/app/prisma/migrations/20231115025507_add_response_format/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DatasetEntry" ADD COLUMN     "response_format" JSONB;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -240,11 +240,12 @@ model DatasetEntry {
     loggedCall   LoggedCall? @relation(fields: [loggedCallId], references: [id], onDelete: Cascade)
 
     // Equivalent to the same fields in the OpenAI chat completion input
-    function_call Json?
-    functions     Json?
-    tool_choice   Json?
-    tools         Json?
-    messages      Json  @default("[]")
+    function_call   Json?
+    functions       Json?
+    tool_choice     Json?
+    tools           Json?
+    messages        Json  @default("[]")
+    response_format Json?
 
     output       Json?
     inputTokens  Int?

--- a/app/prisma/seed-synthetic-dataset.ts
+++ b/app/prisma/seed-synthetic-dataset.ts
@@ -84,8 +84,8 @@ await Promise.all(
         inputTokens: 0,
         outputTokens: 0,
         split: entrySplit,
-        datasetId, // Use the preserved or new ID
-        sortKey: index.toString(), // Use array index as sortKey
+        datasetId,
+        sortKey: index.toString(),
         importId: "synthetic-dataset",
         provenance: "UPLOAD",
       },

--- a/app/src/components/datasets/parseRowsToImport.ts
+++ b/app/src/components/datasets/parseRowsToImport.ts
@@ -3,6 +3,7 @@ import { isObject } from "lodash-es";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
 import { z } from "zod";
 import {
+  chatCompletionInputReqPayload,
   chatCompletionMessage,
   chatMessage,
   functionCallInput,
@@ -11,6 +12,8 @@ import {
   toolsInput,
 } from "~/types/shared.types";
 
+const chatInputs = chatCompletionInputReqPayload.shape;
+
 export const rowSchema = z.object({
   input: z.object({
     messages: z.array(chatMessage),
@@ -18,6 +21,7 @@ export const rowSchema = z.object({
     functions: functionsInput,
     tool_choice: toolChoiceInput,
     tools: toolsInput,
+    response_format: chatInputs.response_format,
   }),
   output: chatCompletionMessage,
   split: z.enum(["TRAIN", "TEST"]).optional(),

--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -420,6 +420,7 @@ export const datasetEntriesRouter = createTRPCRouter({
         function_call: prevEntry.function_call ?? undefined,
         tool_choice: prevEntry.tool_choice ?? undefined,
         tools: prevEntry.tools ?? undefined,
+        response_format: prevEntry.response_format ?? undefined,
       });
 
       const newEntry = await prisma.datasetEntry.create({
@@ -566,7 +567,7 @@ export const datasetEntriesRouter = createTRPCRouter({
       });
 
       let rows = datasetEntries.map(typedDatasetEntry).map((entry) => ({
-        input: pick(entry, ["messages", "functions", "function_call"]),
+        input: pick(entry, ["messages", "functions", "function_call", "tool_choice", "tools"]),
         output: entry.output,
       }));
 

--- a/app/src/server/utils/calculateEntryScore.test.ts
+++ b/app/src/server/utils/calculateEntryScore.test.ts
@@ -94,8 +94,8 @@ const generatedMismatchingNames: ChatCompletionMessageParam = {
 
 it("calculates 1 for perfect match", () => {
   const score = calculateEntryScore(
-    originalMatchingArgs.tool_calls,
-    generatedMatchingArgs.tool_calls,
+    { messages: [], output: originalMatchingArgs },
+    generatedMatchingArgs,
   );
 
   expect(score).toBe(1);
@@ -103,8 +103,8 @@ it("calculates 1 for perfect match", () => {
 
 it("calculates 0 for mismatching names", () => {
   const score = calculateEntryScore(
-    originalMismatchingNames.tool_calls,
-    generatedMismatchingNames.tool_calls,
+    { messages: [], output: originalMismatchingNames },
+    generatedMismatchingNames,
   );
 
   expect(score).toBe(0);
@@ -112,8 +112,8 @@ it("calculates 0 for mismatching names", () => {
 
 it("calculates 0 for no matching args", () => {
   const score = calculateEntryScore(
-    originalMismatchingArgs.tool_calls,
-    generatedMismatchingArgs.tool_calls,
+    { messages: [], output: originalMismatchingArgs },
+    generatedMismatchingArgs,
   );
 
   expect(score).toBe(0);

--- a/app/src/server/utils/prepareDatasetEntriesForImport.ts
+++ b/app/src/server/utils/prepareDatasetEntriesForImport.ts
@@ -69,6 +69,7 @@ export const prepareDatasetEntriesForImport = async (
       tools: row.input.tools?.length
         ? row.input.tools
         : (convertFunctionsToTools(row.input.functions) as object[]),
+      response_format: row.input.response_format,
       output: (convertFunctionMessageToToolCall(
         row.output,
       ) as unknown as Prisma.InputJsonValue) ?? {

--- a/app/src/types/dbColumns.types.ts
+++ b/app/src/types/dbColumns.types.ts
@@ -1,24 +1,23 @@
-import { z } from "zod";
 import { type DatasetEntry, type LoggedCallModelResponse } from "@prisma/client";
+import { z } from "zod";
 
 import {
-  chatCompletionMessage,
   chatCompletionInput,
+  chatCompletionInputReqPayload,
+  chatCompletionMessage,
   chatCompletionOutput,
-  chatMessage,
-  functionCallInput,
-  functionsInput,
-  toolChoiceInput,
-  toolsInput,
 } from "./shared.types";
+
+const chatInputs = chatCompletionInputReqPayload.shape;
 
 export const datasetEntrySchema = z
   .object({
-    messages: z.array(chatMessage),
-    function_call: functionCallInput.nullable(),
-    functions: functionsInput.nullable(),
-    tool_choice: toolChoiceInput.nullable(),
-    tools: toolsInput.nullable(),
+    messages: chatInputs.messages,
+    function_call: chatInputs.function_call.nullable(),
+    functions: chatInputs.functions.nullable(),
+    tool_choice: chatInputs.tool_choice.nullable(),
+    tools: chatInputs.tools.nullable(),
+    response_format: chatInputs.response_format.nullable(),
     output: chatCompletionMessage.optional().nullable(),
   })
   .passthrough();

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -1,4 +1,3 @@
-import { pick } from "lodash-es";
 import type {
   ChatCompletion,
   ChatCompletionCreateParams,
@@ -9,18 +8,6 @@ import { z } from "zod";
 export const CURRENT_PIPELINE_VERSION = 2;
 
 export type AtLeastOne<T> = readonly [T, ...T[]];
-
-export const validatedChatInput = <
-  T extends { messages: unknown; functions?: unknown; function_call?: unknown },
->(
-  entry: T,
-) => {
-  // TODO: actually validate. We'll just assert the types for now.
-  return pick(entry, ["messages", "functions", "function_call", "tool_choice", "tools"]) as Pick<
-    ChatCompletionCreateParams,
-    "messages" | "functions" | "function_call" | "tool_choice" | "tools"
-  >;
-};
 
 export const functionCallOutput = z
   .object({
@@ -143,6 +130,11 @@ const chatCompletionInputBase = z.object({
   n: z.number().optional(),
   max_tokens: z.number().nullable().optional(),
   temperature: z.number().optional(),
+  response_format: z
+    .object({
+      type: z.union([z.literal("text"), z.literal("json_object")]),
+    })
+    .optional(),
 });
 
 const chatCompletionInputStreaming = z.object({


### PR DESCRIPTION
This way if a user requests JSON, we (1) pass that through to the gpt-3.5 comparison on the evals page, and (2) automatically run our accuracy checks as if it were a function call.

I didn't make the changes to format the output as JSON and show accuracy, since I think David will be touching that code imminently anyway.