### PR TITLE
Fix crashes caused by isolated VM package

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "next build",
-    "dev:next": "TZ=UTC next dev",
+    "dev:next": "NODE_OPTIONS='--no-node-snapshot' TZ=UTC next dev",
     "dev:wss": "tsx --watch src/wss-server.ts",
     "dev:worker": "tsx --watch src/server/tasks/worker.ts",
     "worker": "tsx src/server/tasks/worker.ts",

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "build": "next build",
     "dev:next": "NODE_OPTIONS='--no-node-snapshot' TZ=UTC next dev",
     "dev:wss": "tsx --watch src/wss-server.ts",
-    "dev:worker": "tsx --watch src/server/tasks/worker.ts",
+    "dev:worker": "NODE_OPTIONS='--no-node-snapshot' tsx --watch src/server/tasks/worker.ts",
     "worker": "tsx src/server/tasks/worker.ts",
     "dev": "tsx scripts/run-dev.ts",
     "dev:tunnel": "tsx scripts/dev-tunnel.ts",

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
     "codegen:internalClient": "tsx src/server/scripts/internal-client-codegen.ts",
     "codegen:clients": "tsx scripts/codegen-clients.ts",
     "codegen:db": "prisma generate && kysely-codegen --dialect postgres --out-file src/types/kysely-codegen.types.ts",
-    "seed": "tsx prisma/seed.ts",
+    "seed": "NODE_OPTIONS='--no-node-snapshot' tsx prisma/seed.ts",
     "check": "concurrently 'pnpm lint' 'pnpm tsc' 'pnpm prettier . --check'",
     "test": "pnpm vitest",
     "repl": "tsx scripts/repl.ts",


### PR DESCRIPTION
Pass --no-node-snapshot in NODE_OPTIONS to the `dev:next`, `dev:worker` and `seed` commands. This is required according to the maintainers of isolated VM https://github.com/laverdet/isolated-vm/issues/420. This was causing difficult to debug issues where any trpc requests would return a 500 internal server error with this unhelpful error message. I was able to track it down to this cause by commenting out sections of server code until I found it.

```sh
[next] - error Error: socket hang up
[next]     at connResetException (node:internal/errors:721:14)
[next]     at Socket.socketOnEnd (node:_http_client:519:23)
[next]     at Socket.emit (node:events:526:35)
[next]     at Socket.emit (node:domain:488:12)
[next]     at endReadableNT (node:internal/streams/readable:1408:12)
[next]     at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
[next]   code: 'ECONNRESET'
[next] }
```

Not sure if it's because I'm running on an M2 Mac? But adding the node option fixes it.