### PR TITLE
Add request logs filter on first press

### DIFF
--- a/app/src/components/Filters/useFilters.ts
+++ b/app/src/components/Filters/useFilters.ts
@@ -1,40 +1,33 @@
-import {
-  useQueryParam,
-  JsonParam,
-  BooleanParam,
-  withDefault,
-  encodeQueryParams,
-} from "use-query-params";
+import { useQueryParam, JsonParam, withDefault, encodeQueryParams } from "use-query-params";
 
 import { type FilterDataType } from "./types";
 
-export const useFilters = () => {
-  const [filters, setFilters] = useQueryParam<FilterDataType[]>(
+export const useFilters = (defaultShown?: boolean) => {
+  const [filterData, setFilterData] = useQueryParam<{ shown: boolean; filters: FilterDataType[] }>(
     "filters",
-    withDefault(JsonParam, []),
+    withDefault(JsonParam, { shown: !!defaultShown, filters: [] }),
   );
-  const [filtersShown, setFiltersShown] = useQueryParam<boolean>(
-    "filtersShown",
-    withDefault(BooleanParam, false),
-  );
+
+  const setFiltersShown = (shown: boolean) => setFilterData({ ...filterData, shown });
 
   const addFilter = (filter: FilterDataType) => {
-    setFilters([...filters, filter]);
-    setFiltersShown(true);
+    setFilterData({ shown: true, filters: [...filterData.filters, filter] });
   };
   const updateFilter = (filter: FilterDataType) =>
-    setFilters(filters.map((f) => (f.id === filter.id ? filter : f)));
+    setFilterData({
+      shown: true,
+      filters: filterData.filters.map((f) => (f.id === filter.id ? filter : f)),
+    });
 
   const removeFilter = (filter: FilterDataType) =>
-    setFilters(filters.filter((f) => f.id !== filter.id));
+    setFilterData({ ...filterData, filters: filterData.filters.filter((f) => f.id !== filter.id) });
 
   return {
-    filters,
-    setFilters,
+    filters: filterData.filters,
+    filtersShown: filterData.shown,
     addFilter,
     updateFilter,
     removeFilter,
-    filtersShown,
     setFiltersShown,
   };
 };

--- a/app/src/pages/request-logs/index.tsx
+++ b/app/src/pages/request-logs/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Text, VStack, HStack, Box, IconButton, Icon, keyframes } from "@chakra-ui/react";
 import { BiRefresh } from "react-icons/bi";
 import { FiFilter } from "react-icons/fi";
@@ -13,6 +12,7 @@ import ExportButton from "~/components/requestLogs/ExportButton";
 import AddToDatasetButton from "~/components/requestLogs/AddToDatasetButton";
 import { api } from "~/utils/api";
 import { useLoggedCalls } from "~/utils/hooks";
+import { useFilters } from "~/components/Filters/useFilters";
 
 const spin = keyframes`
   from { transform: rotate(0deg); }
@@ -20,7 +20,8 @@ const spin = keyframes`
 `;
 
 export default function LoggedCalls() {
-  const [filtersShown, setFiltersShown] = useState(true);
+  const filtersShown = useFilters(true).filtersShown;
+  const setFiltersShown = useFilters(true).setFiltersShown;
 
   const utils = api.useContext();
 


### PR DESCRIPTION
A previous PR introduced a bug in which the user had to press the "Add Filter" button twice on the request logs page to create their first filter. The issue was that we were simultaneously updating the filter state in the url in two different ways in two different requests. In practice, the second request was ignored. This PR combines all filter state into a single object, and updates multiple of its keys simultaneously.