### PR TITLE
Add header to original output row

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/AddEvalModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/AddEvalModal.tsx
@@ -101,6 +101,7 @@ const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
     });
     if (maybeReportError(resp)) return;
     await utils.datasetEntries.listTestingEntries.invalidate({ datasetId: dataset.id });
+    await utils.datasetEntries.testingStats.invalidate({ datasetId: dataset.id });
     await utils.datasets.get.invalidate();
 
     ensureEvalShown(resp.payload);

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/AddEvalModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/AddEvalModal.tsx
@@ -29,10 +29,10 @@ import {
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
 import AutoResizeTextArea from "~/components/AutoResizeTextArea";
 import { ORIGINAL_MODEL_ID } from "~/types/dbColumns.types";
-import { getComparisonModelName } from "~/utils/baseModels";
 import { useVisibleEvalIds } from "./useVisibleEvalIds";
 import { useFilters } from "~/components/Filters/useFilters";
 import { EvaluationFiltersDefaultFields } from "~/types/shared.types";
+import { getOutputTitle } from "./getOutputTitle";
 
 const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const mutation = api.datasetEvals.create.useMutation();
@@ -48,7 +48,7 @@ const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
     const options = [
       {
         id: ORIGINAL_MODEL_ID,
-        name: "Original",
+        name: getOutputTitle(ORIGINAL_MODEL_ID) ?? "",
       },
     ];
     if (!dataset) return options;
@@ -56,11 +56,11 @@ const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
       ...options,
       ...dataset.enabledComparisonModels.map((comparisonModelId) => ({
         id: comparisonModelId,
-        name: getComparisonModelName(comparisonModelId) || "Comparison Model",
+        name: getOutputTitle(comparisonModelId) ?? "",
       })),
       ...dataset.deployedFineTunes.map((model) => ({
         id: model.id,
-        name: "openpipe:" + model.slug,
+        name: getOutputTitle(model.id, model.slug) ?? "",
       })),
     ];
   }, [dataset]);

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/FieldComparisonModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/FieldComparisonModal.tsx
@@ -19,7 +19,7 @@ import type { ChatCompletionMessage } from "openai/resources/chat";
 
 import { useAppStore } from "~/state/store";
 import { api } from "~/utils/api";
-import { getOutputTitle } from "./getOutputTitle";
+import { getOutputTitle } from "../getOutputTitle";
 import FormattedMessage from "../FormattedMessage";
 import ColoredPercent from "~/components/ColoredPercent";
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
@@ -23,7 +23,7 @@ import { type RouterOutputs, api } from "~/utils/api";
 import { useAppStore } from "~/state/store";
 import FormattedMessage from "../FormattedMessage";
 import { isNumber } from "lodash-es";
-import { getOutputTitle } from "./getOutputTitle";
+import { getOutputTitle } from "../getOutputTitle";
 
 const HeadToHeadComparisonModal = () => {
   const comparisonCriteria = useAppStore((state) => state.evaluationsSlice.comparisonCriteria);
@@ -154,7 +154,7 @@ const HeadToHeadComparisonModal = () => {
   );
 };
 
-const MAX_OUTPUT_HEIGHT = 400;
+const MAX_OUTPUT_HEIGHT = 200;
 const VERTICAL_PADDING = 32;
 
 type ComparisonResult =
@@ -208,7 +208,7 @@ const CollapsibleResult = ({ result }: { result: ComparisonResult }) => {
           !expandable
             ? innerOutputHeight
             : outputExpanded
-            ? innerOutputHeight + 52
+            ? innerOutputHeight + 120
             : MAX_OUTPUT_HEIGHT + VERTICAL_PADDING
         }
         transition="height 0.5s ease-in-out"

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EditEvalModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EditEvalModal.tsx
@@ -28,10 +28,10 @@ import {
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
 import AutoResizeTextArea from "~/components/AutoResizeTextArea";
 import { ORIGINAL_MODEL_ID } from "~/types/dbColumns.types";
-import { getComparisonModelName } from "~/utils/baseModels";
 import { useAppStore } from "~/state/store";
 import DeleteEvalDialog from "./DeleteEvalDialog";
 import InfoCircle from "~/components/InfoCircle";
+import { getOutputTitle } from "./getOutputTitle";
 
 const EditEvalModal = () => {
   const utils = api.useContext();
@@ -56,7 +56,7 @@ const EditEvalModal = () => {
     const options = [
       {
         id: ORIGINAL_MODEL_ID,
-        name: "Original",
+        name: getOutputTitle(ORIGINAL_MODEL_ID) ?? "",
       },
     ];
     if (!dataset) return options;
@@ -64,11 +64,11 @@ const EditEvalModal = () => {
       ...options,
       ...dataset.enabledComparisonModels.map((comparisonModelId) => ({
         id: comparisonModelId,
-        name: getComparisonModelName(comparisonModelId) || "Comparison Model",
+        name: getOutputTitle(comparisonModelId) ?? "",
       })),
       ...dataset.deployedFineTunes.map((model) => ({
         id: model.id,
-        name: "openpipe:" + model.slug,
+        name: getOutputTitle(model.id, model.slug) ?? "",
       })),
     ];
   }, [dataset]);
@@ -246,9 +246,8 @@ const EditEvalModal = () => {
                       borderWidth={1}
                       p={2}
                     >
-                      These changes eval will add <b>{numAddedComparisons}</b> head-to-head
-                      comparisons and cost approximately{" "}
-                      <b>${(numAddedComparisons * 0.06).toFixed(2)}</b>.
+                      These changes will add <b>{numAddedComparisons}</b> head-to-head comparisons
+                      and cost approximately <b>${(numAddedComparisons * 0.06).toFixed(2)}</b>.
                     </Text>
                   </VStack>
                   <VStack alignItems="flex-start" w="full">

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EditEvalModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EditEvalModal.tsx
@@ -113,6 +113,7 @@ const EditEvalModal = () => {
     });
     if (maybeReportError(resp)) return;
     await utils.datasetEntries.listTestingEntries.invalidate({ datasetId: dataset.id });
+    await utils.datasetEntries.testingStats.invalidate({ datasetId: dataset.id });
     await utils.datasets.get.invalidate();
 
     setDatasetEvalIdToEdit(null);

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EditEvalModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EditEvalModal.tsx
@@ -136,6 +136,13 @@ const EditEvalModal = () => {
   const numAddedComparisons = useMemo(() => {
     if (!datasetEval?.outputSources) return 0;
 
+    const numRowFinalComparisons = (includedModelIds.length * (includedModelIds.length - 1)) / 2;
+
+    // If the instructions have changed, we need to re-evaluate all comparisons
+    if (instructions !== datasetEval.instructions) {
+      return numRowFinalComparisons * numDatasetEntries;
+    }
+
     const numPersistedRows = Math.min(datasetEval.numDatasetEntries, numDatasetEntries || 0);
 
     const numNewModelIds = includedModelIds.filter(
@@ -145,7 +152,6 @@ const EditEvalModal = () => {
       ((includedModelIds.length - numNewModelIds) *
         (includedModelIds.length - numNewModelIds - 1)) /
       2;
-    const numRowFinalComparisons = (includedModelIds.length * (includedModelIds.length - 1)) / 2;
 
     const newComparisonsFromAddedModels =
       numPersistedRows * (numRowFinalComparisons - numPersistedRowPersistedComparisons);
@@ -160,6 +166,8 @@ const EditEvalModal = () => {
     numDatasetEntries,
     datasetEval?.outputSources,
     includedModelIds,
+    datasetEval?.instructions,
+    instructions,
   ]);
 
   return (

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvalHeaderPill.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvalHeaderPill.tsx
@@ -13,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import { FiChevronDown, FiEdit2 } from "react-icons/fi";
 import { FaArrowDown, FaArrowUp, FaEyeSlash } from "react-icons/fa";
+import { isNumber } from "lodash-es";
 
 import { useModelTestingStats, useDataset } from "~/utils/hooks";
 import ColoredPercent from "~/components/ColoredPercent";
@@ -81,7 +82,10 @@ const EvalHeaderPill = ({
             <Text fontWeight="bold" color="gray.500">
               {datasetEval.name}
             </Text>
-            <ColoredPercent value={modelEvalStats.score} />
+            {isNumber(modelEvalStats.score) && <ColoredPercent value={modelEvalStats.score} />}
+            {modelEvalStats.numPending && (
+              <Box bgColor="yellow.300" borderRadius={4} mt={0.5} px={1} py={1} />
+            )}
             {isSortingAscending && <Icon as={FaArrowUp} boxSize={3} strokeWidth={2} />}
             {isSortingDescending && <Icon as={FaArrowDown} boxSize={3} strokeWidth={2} />}
             <Icon as={FiChevronDown} boxSize={3} strokeWidth={2} />

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvalHeaderPill.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvalHeaderPill.tsx
@@ -11,7 +11,6 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@chakra-ui/react";
-import { isNumber } from "lodash-es";
 import { FiChevronDown, FiEdit2 } from "react-icons/fi";
 import { FaArrowDown, FaArrowUp, FaEyeSlash } from "react-icons/fa";
 
@@ -48,10 +47,10 @@ const EvalHeaderPill = ({
     ];
   }, [testEntrySortOrder, modelId, datasetEval]);
 
-  const score = useMemo(() => {
-    if (!stats?.averageScores || !(datasetEval.id in stats?.averageScores)) return null;
-    return stats.averageScores[datasetEval.id];
-  }, [stats?.averageScores, datasetEval]);
+  const modelEvalStats = useMemo(() => {
+    if (!stats?.evalPerformances) return null;
+    return stats.evalPerformances[datasetEval.id];
+  }, [stats?.evalPerformances, datasetEval]);
 
   const buttonRef = useRef<HTMLDivElement>(null);
   const [buttonWidth, setButtonWidth] = useState(0);
@@ -61,7 +60,7 @@ const EvalHeaderPill = ({
     setButtonWidth(buttonRef.current.offsetWidth);
   }, [buttonRef, setButtonWidth]);
 
-  if (!isNumber(score)) return null;
+  if (!modelEvalStats) return null;
 
   return (
     <Popover placement="bottom-end">
@@ -82,7 +81,7 @@ const EvalHeaderPill = ({
             <Text fontWeight="bold" color="gray.500">
               {datasetEval.name}
             </Text>
-            <ColoredPercent value={score} />
+            <ColoredPercent value={modelEvalStats.score} />
             {isSortingAscending && <Icon as={FaArrowUp} boxSize={3} strokeWidth={2} />}
             {isSortingDescending && <Icon as={FaArrowDown} boxSize={3} strokeWidth={2} />}
             <Icon as={FiChevronDown} boxSize={3} strokeWidth={2} />
@@ -96,6 +95,20 @@ const EvalHeaderPill = ({
         mt={-1}
       >
         <VStack w="full" spacing={0}>
+          {datasetEval.type === "HEAD_TO_HEAD" && (
+            <HStack
+              w="full"
+              justifyContent="space-between"
+              fontWeight="bold"
+              fontSize="2xs"
+              p={2}
+              bgColor="gray.100"
+            >
+              <Text color="green.500">{modelEvalStats.totalWins} WINS</Text>
+              <Text color="gray.500">{modelEvalStats.totalTies} TIES</Text>
+              <Text color="red.500">{modelEvalStats.totalLosses} LOSSES</Text>
+            </HStack>
+          )}
           <HStack
             as={Button}
             w="full"

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -44,9 +44,7 @@ export const TableHeader = ({
       </GridItem>
       {showOriginalOutput && (
         <GridItem sx={sharedProps} borderLeftWidth={1}>
-          <Text fontWeight="bold" color="gray.500">
-            Original Output
-          </Text>
+          <ModelHeader modelId={ORIGINAL_MODEL_ID} />
         </GridItem>
       )}
       {visibleModelIds.map((modelId, i) => (

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -6,6 +6,8 @@ import { useDataset, useModelTestingStats, useTestingEntries } from "~/utils/hoo
 import { displayBaseModel } from "~/utils/baseModels";
 import EvalHeaderPill from "./EvalHeaderPill";
 import { useVisibleEvalIds } from "../useVisibleEvalIds";
+import { getOutputTitle } from "../getOutputTitle";
+import { ORIGINAL_MODEL_ID } from "~/types/dbColumns.types";
 
 const ModelHeader = ({ modelId }: { modelId: string }) => {
   const [refetchInterval, setRefetchInterval] = useState(0);
@@ -34,11 +36,7 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
   return (
     <VStack alignItems="flex-start" justifyContent="space-between" h="full" spacing={0}>
       <HStack w="full" justifyContent="space-between">
-        {stats.isComparisonModel ? (
-          <Text fontWeight="bold" color="gray.500">
-            {stats.slug}
-          </Text>
-        ) : (
+        {stats.slug ? (
           <Text
             as={Link}
             href={{ pathname: "/fine-tunes/[id]", query: { id: modelId } }}
@@ -46,11 +44,15 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
             fontWeight="bold"
             color="gray.500"
           >
-            openpipe:{stats.slug}
+            {getOutputTitle(modelId, stats.slug)}
+          </Text>
+        ) : (
+          <Text fontWeight="bold" color="gray.500">
+            {getOutputTitle(modelId)}
           </Text>
         )}
         <HStack>
-          {stats.finishedCount < entries.count && (
+          {modelId !== ORIGINAL_MODEL_ID && stats.finishedCount < entries.count && (
             <Text>
               {stats.finishedCount}/{entries.count}
             </Text>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -16,12 +16,18 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
   const entries = useTestingEntries().data;
 
   useEffect(() => {
-    if (!stats?.finishedCount || !entries?.count || stats?.finishedCount < entries?.count) {
+    if (
+      !stats ||
+      !stats.finishedCount ||
+      !entries?.count ||
+      stats.finishedCount < entries.count ||
+      stats.resultsPending
+    ) {
       setRefetchInterval(5000);
     } else {
       setRefetchInterval(0);
     }
-  }, [stats?.finishedCount, entries?.count]);
+  }, [stats, entries?.count]);
 
   const visibleEvalIds = useVisibleEvalIds().visibleEvalIds;
 

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/getOutputTitle.ts
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/getOutputTitle.ts
@@ -1,10 +1,10 @@
 import { ORIGINAL_MODEL_ID } from "~/types/dbColumns.types";
 import { getComparisonModelName, isComparisonModel } from "~/utils/baseModels";
 
-export const getOutputTitle = (modelId: string | null, slug: string | null) => {
+export const getOutputTitle = (modelId: string | null, slug?: string | null) => {
   let title = null;
   if (modelId === ORIGINAL_MODEL_ID) {
-    title = "Original Model";
+    title = "Original Output";
   } else if (modelId && isComparisonModel(modelId)) {
     title = getComparisonModelName(modelId);
   } else if (slug) {


### PR DESCRIPTION
Add header to original output row. For head to head evals, also show wins, ties, and losses in the eval dropdown.

<img width="346" alt="Screenshot 2023-11-26 at 12 59 05 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/6dc291a2-442b-43e2-908e-fdb6b3154c9e">
