### PR TITLE
Include Mistral in beta banner

### DIFF
--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -30,8 +30,8 @@ const BetaBanner = () => {
       <HStack>
         <Icon as={BsStars} color="orange.400" />
         <Text>
-          Fine-tuning Llama2 models is currently in beta. To receive early access to beta-only
-          features,{" "}
+          Fine-tuning Llama2 and Mistral models is currently in beta. To receive early access to
+          beta-only features,{" "}
           <Link
             href={`https://ax3nafkw0jp.typeform.com/to/ZNpYqvAc#email=${email}`}
             target="_blank"

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -167,8 +167,8 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
             )}
             {needsMissingBetaAccess && (
               <Text>
-                LLama2 fine-tuning is currently in beta. To receive early access to beta-only
-                features,{" "}
+                LLama2 and Mistral fine-tuning is currently in beta. To receive early access to
+                beta-only features,{" "}
                 <ChakraLink
                   href="https://ax3nafkw0jp.typeform.com/to/ZNpYqvAc#email=${email}"
                   target="_blank"


### PR DESCRIPTION
Before:
<img width="992" alt="Screenshot 2023-11-27 at 3 57 15 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/c925d2e6-7b66-4087-b25d-75dab5f84fac">


After:
<img width="985" alt="Screenshot 2023-11-27 at 3 58 08 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/cb540a65-5c04-4454-8740-9eb208913628">
