### PR TITLE
Show the total input/output counts in dataset view, not the pruned counts

### DIFF
--- a/app/scripts/copy-db.sh
+++ b/app/scripts/copy-db.sh
@@ -107,4 +107,3 @@ report_progress "Restoring data to dev database..."
 pg_restore -v --no-owner --no-privileges -d openpipe-dev --format=d --jobs=8 --data-only --disable-triggers "$CACHE_DIR"
 
 report_progress "Database copy complete."
-```


### PR DESCRIPTION
Pruned counts aren't always accurate anyway (in fact I have a dataset where for some reason all the entries have negative counts), and since not every model has every pruning rule applied it's probably better to just show the original counts.