### PR TITLE
Handle evals on incomplete dataset entries

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
@@ -18,11 +18,10 @@ import {
 } from "@chakra-ui/react";
 import { FaBalanceScale } from "react-icons/fa";
 import { FiChevronUp, FiChevronDown } from "react-icons/fi";
-import type { ChatCompletionMessage } from "openai/resources/chat";
 
 import { type RouterOutputs, api } from "~/utils/api";
 import { useAppStore } from "~/state/store";
-import FormattedMessage from "../FormattedMessage";
+import { PotentiallyPendingFormattedMessage } from "../FormattedMessage";
 import { isNumber } from "lodash-es";
 import { getOutputTitle } from "../getOutputTitle";
 import { useVisibleModelIds } from "../useVisibleModelIds";
@@ -244,11 +243,7 @@ const ComparisonRow = ({
           overflow="hidden"
         >
           <Box ref={outputRef}>
-            {result.output ? (
-              <FormattedMessage message={result.output as unknown as ChatCompletionMessage} />
-            ) : (
-              <Text as="i">Pending</Text>
-            )}
+            <PotentiallyPendingFormattedMessage output={result.output} />
           </Box>
           {expandable && (
             <VStack position="absolute" bottom={0} w="full" spacing={0}>
@@ -356,7 +351,7 @@ const SelectedComparisonTable = ({ datasetEntry }: { datasetEntry: ComparisonEnt
         </GridItem>
         <GridItem position="relative" {...contentProps} {...leftBorderProps} {...topBorderProps}>
           <Box ref={outputRef}>
-            <FormattedMessage message={datasetEntry.output as unknown as ChatCompletionMessage} />
+            <PotentiallyPendingFormattedMessage output={datasetEntry.output} />
           </Box>
           {expandable && !expanded && (
             <Box

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/ModelHeader.tsx
@@ -59,7 +59,7 @@ const ModelHeader = ({ modelId }: { modelId: string }) => {
         )}
         <HStack>
           {modelId !== ORIGINAL_MODEL_ID && stats.finishedCount < entries.count && (
-            <Text>
+            <Text fontSize="xs">
               {stats.finishedCount}/{entries.count}
             </Text>
           )}

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/FormattedMessage.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/FormattedMessage.tsx
@@ -1,6 +1,18 @@
 import { Text, VStack } from "@chakra-ui/react";
+import type { DatasetEntry } from "@prisma/client";
 import type { ChatCompletionMessageToolCall, ChatCompletionMessage } from "openai/resources/chat";
 import SyntaxHighlighter from "react-syntax-highlighter";
+
+export const PotentiallyPendingFormattedMessage = ({
+  output,
+}: {
+  output: DatasetEntry["output"];
+}) => {
+  if (output) {
+    return <FormattedMessage message={output as unknown as ChatCompletionMessage} />;
+  }
+  return <Text color="gray.500">Pending</Text>;
+};
 
 const FormattedMessage = ({ message }: { message: ChatCompletionMessage }) => {
   if (message.tool_calls) {


### PR DESCRIPTION
This fixes a bug in which evals did not properly handle dataset entry rows that had empty fine tune outputs at the time the eval was created or edited. The solution is to search for previously created `DatasetEvalResult`s by their unique foreign keys rather than assuming that none exist at the time we want to run an evaluation.

### Changes
* Find `DatasetEvalResult`s by foreign keys inside our `evaluateTestSetEntries` task
* Properly display pending text for all pending outputs within the comparison modal