### PR TITLE
Remove deprecated accuracy

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
@@ -85,6 +85,7 @@ const HeadToHeadComparisonModal = () => {
             </VStack>
             <Grid
               display="grid"
+              w="full"
               gridTemplateColumns={`200px 200px 1fr 1fr`}
               borderWidth={1}
               borderColor="gray.300"

--- a/app/src/components/datasets/DatasetContentTabs/Models/Models.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Models/Models.tsx
@@ -61,12 +61,9 @@ const Models = () => {
             <HStack>
               <Text w={180}>Test Set Performance</Text>
               {fineTune.status === "DEPLOYED" ? (
-                <ColoredPercent value={fineTune.averageScore} />
+                <ViewEvaluationButton datasetId={fineTune.datasetId} fineTuneId={fineTune.id} />
               ) : (
                 <Text color="gray.500">Pending</Text>
-              )}
-              {fineTune.status === "DEPLOYED" && (
-                <ViewEvaluationButton datasetId={fineTune.datasetId} fineTuneId={fineTune.id} />
               )}
             </HStack>
             <HStack>

--- a/app/src/components/datasets/DatasetContentTabs/Models/Models.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Models/Models.tsx
@@ -1,7 +1,6 @@
 import { Card, VStack, HStack, Text, Button } from "@chakra-ui/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import ColoredPercent from "~/components/ColoredPercent";
 import { setActiveTab } from "~/components/ContentTabs";
 import { getStatusColor } from "~/components/fineTunes/FineTunesTable";
 import { displayBaseModel } from "~/utils/baseModels";

--- a/app/src/components/datasets/ViewDatasetButton.tsx
+++ b/app/src/components/datasets/ViewDatasetButton.tsx
@@ -1,0 +1,35 @@
+import { Button, type ButtonProps } from "@chakra-ui/react";
+import Link from "next/link";
+
+import { DATASET_GENERAL_TAB_KEY } from "./DatasetContentTabs/DatasetContentTabs";
+
+const ViewDatasetButton = ({
+  buttonText,
+  datasetId,
+  ...props
+}: {
+  buttonText: string;
+  datasetId: string;
+} & ButtonProps) => {
+  return (
+    <Button
+      as={Link}
+      href={{
+        pathname: "/datasets/[id]/[tab]",
+        query: {
+          id: datasetId,
+          tab: DATASET_GENERAL_TAB_KEY,
+        },
+      }}
+      variant="link"
+      color="blue.600"
+      fontWeight="normal"
+      _hover={{ textDecoration: "underline" }}
+      {...props}
+    >
+      {buttonText}
+    </Button>
+  );
+};
+
+export default ViewDatasetButton;

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -5,10 +5,9 @@ import ContentCard from "~/components/ContentCard";
 import FineTuneDangerZone from "./FineTuneDangerZone";
 import dayjs from "~/utils/dayjs";
 import { getStatusColor } from "../../FineTunesTable";
-import ColoredPercent from "~/components/ColoredPercent";
 import { api } from "~/utils/api";
 import ViewEvaluationButton from "~/components/datasets/DatasetContentTabs/Evaluation/ViewEvaluationButton";
-import Link from "next/link";
+import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 
 const General = () => {
   const fineTune = useFineTune().data;
@@ -38,9 +37,10 @@ const General = () => {
             </HStack>
             <HStack>
               <Text w={180}>Dataset</Text>
-              <Link href={{ pathname: "/datasets/[id]", query: { id: fineTune.datasetId } }}>
-                <Text color="blue.600">{fineTune.datasetName}</Text>
-              </Link>
+              <ViewDatasetButton
+                buttonText={fineTune.datasetName ?? ""}
+                datasetId={fineTune.datasetId}
+              />
             </HStack>
             <HStack>
               <Text w={180}>Training Set Size</Text>
@@ -53,12 +53,9 @@ const General = () => {
             <HStack>
               <Text w={180}>Test Set Performance</Text>
               {fineTune.status === "DEPLOYED" ? (
-                <ColoredPercent value={fineTune.averageScore} />
+                <ViewEvaluationButton datasetId={fineTune.datasetId} fineTuneId={fineTune.id} />
               ) : (
                 <Text color="gray.500">Pending</Text>
-              )}
-              {fineTune.status === "DEPLOYED" && (
-                <ViewEvaluationButton datasetId={fineTune.datasetId} fineTuneId={fineTune.id} />
               )}
             </HStack>
             <HStack>

--- a/app/src/components/fineTunes/FineTuneContentTabs/TrainingData/TrainingData.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/TrainingData/TrainingData.tsx
@@ -5,6 +5,7 @@ import { useFineTune, useTrainingEntries } from "~/utils/hooks";
 import ContentCard from "~/components/ContentCard";
 import TrainingDataRow, { TableHeader } from "./TrainingDataRow";
 import TrainingDataPaginator from "./TrainingDataPaginator";
+import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 
 const TrainingData = () => {
   const fineTune = useFineTune().data;
@@ -22,11 +23,11 @@ const TrainingData = () => {
             <Text fontWeight="bold" pb={2}>
               Training Data ({count} rows)
             </Text>
-            <Link href={{ pathname: "/datasets/[id]", query: { id: fineTune.datasetId } }}>
-              <Text color="blue.600" px={2}>
-                View Dataset
-              </Text>
-            </Link>
+            <ViewDatasetButton
+              buttonText="View Dataset"
+              datasetId={fineTune.datasetId}
+              fontWeight="500"
+            />
           </HStack>
 
           <VStack w="full" alignItems="flex-start" spacing={4} bgColor="white">

--- a/app/src/components/fineTunes/FineTuneContentTabs/TrainingData/TrainingData.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/TrainingData/TrainingData.tsx
@@ -1,5 +1,4 @@
 import { VStack, HStack, Text, Table, Tbody } from "@chakra-ui/react";
-import Link from "next/link";
 
 import { useFineTune, useTrainingEntries } from "~/utils/hooks";
 import ContentCard from "~/components/ContentCard";

--- a/app/src/components/fineTunes/FineTunesTable.tsx
+++ b/app/src/components/fineTunes/FineTunesTable.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import dayjs from "~/utils/dayjs";
 import { useFineTunes } from "~/utils/hooks";
 import { displayBaseModel } from "~/utils/baseModels";
-import ColoredPercent from "../ColoredPercent";
+import ViewDatasetButton from "../datasets/ViewDatasetButton";
 
 const FineTunesTable = ({}) => {
   const query = useFineTunes(10000);
@@ -25,7 +25,7 @@ const FineTunesTable = ({}) => {
               <Th>Created At</Th>
               <Th>Base Model</Th>
               <Th>Training Size</Th>
-              <Th>Accuracy</Th>
+              <Th>Dataset</Th>
               <Th>Status</Th>
             </Tr>
           </Thead>
@@ -42,7 +42,10 @@ const FineTunesTable = ({}) => {
                   <Td>{displayBaseModel(fineTune.baseModel)}</Td>
                   <Td>{fineTune.numTrainingEntries.toLocaleString()}</Td>
                   <Td>
-                    <ColoredPercent value={fineTune.averageScore} />
+                    <ViewDatasetButton
+                      buttonText={fineTune.datasetName ?? ""}
+                      datasetId={fineTune.datasetId}
+                    />
                   </Td>
                   <Td fontSize="sm" fontWeight="bold">
                     <Text color={getStatusColor(fineTune.status)}>{fineTune.status}</Text>

--- a/app/src/server/api/routers/datasetEvals.router.ts
+++ b/app/src/server/api/routers/datasetEvals.router.ts
@@ -501,12 +501,7 @@ export const datasetEvalsRouter = createTRPCRouter({
         baseQuery.groupBy(["modelId1", "slug1"]).orderBy("winRate", "desc").execute(),
 
         baseQuery
-          .innerJoin("DatasetEvalResult as der2", "der2.id", "der.comparisonResultId")
-          .innerJoin(
-            "DatasetEvalOutputSource as deos2",
-            "deos2.id",
-            "der2.datasetEvalOutputSourceId",
-          )
+          .innerJoin("DatasetEvalOutputSource as deos2", "deos2.id", "der.comparisonOutputSourceId")
           .leftJoin("FineTune as ft2", (join) =>
             join.onRef(sql`ft2.id::text`, "=", "deos2.modelId"),
           )

--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -28,15 +28,15 @@ export const fineTunesRouter = createTRPCRouter({
       const fineTunes = await kysely
         .selectFrom("FineTune as ft")
         .where("ft.projectId", "=", projectId)
-        .selectAll()
+        .leftJoin("Dataset as d", "ft.datasetId", "d.id")
+        .selectAll("ft")
         .select(() => [
+          "d.name as datasetName",
           sql<number>`(select count(*) from "FineTuneTrainingEntry" where "fineTuneId" = ft.id)::int`.as(
             "numTrainingEntries",
           ),
-          sql<number>`(select avg("score") from "FineTuneTestingEntry" where "fineTuneId" = ft.id)`.as(
-            "averageScore",
-          ),
         ])
+        .orderBy("d.createdAt", "desc")
         .orderBy("ft.createdAt", "desc")
         .execute();
 
@@ -83,9 +83,6 @@ export const fineTunesRouter = createTRPCRouter({
           sql<number>`(select count(*) from "PruningRule" where "fineTuneId" = ft.id)::int`.as(
             "numPruningRules",
           ),
-          sql<number>`(select avg("score") from "FineTuneTestingEntry" where "fineTuneId" = ft.id)`.as(
-            "averageScore",
-          ),
         ])
         .orderBy("ft.createdAt", "desc")
         .execute();
@@ -114,9 +111,6 @@ export const fineTunesRouter = createTRPCRouter({
           ),
           sql<number>`(select count(*) from "PruningRule" where "fineTuneId" = ft.id)::int`.as(
             "numPruningRules",
-          ),
-          sql<number>`(select avg("score") from "FineTuneTestingEntry" where "fineTuneId" = ft.id)`.as(
-            "averageScore",
           ),
         ])
         .executeTakeFirst();


### PR DESCRIPTION
We don't have a standard "accuracy" to show users now, so we should just point them to their evaluations.

### Changes
* Remove accuracy scores from fine-tune views
* Add more links to the dataset on which a fine-tune was trained
* Simplify a query we touched on [last night](https://github.com/OpenPipe/OpenPipe/pull/375#discussion_r1408883483)