### PR TITLE
Eval logic changes

### DIFF
--- a/app/prisma/migrations/20231130074145_add_was_first_to_dataset_eval_result/migration.sql
+++ b/app/prisma/migrations/20231130074145_add_was_first_to_dataset_eval_result/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DatasetEvalResult" ADD COLUMN     "wasFirst" BOOLEAN;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -740,6 +740,10 @@ model DatasetEvalResult {
     errorMessage String?
     status       DatasetEvalResultStatus @default(PENDING)
 
+    // For comparative evaluations, whether this was the first option presented
+    // to the judge
+    wasFirst Boolean?
+
     comparisonResultId String? @db.Uuid // The id of the DatasetEvalResult to compare against
 
     comparisonOutputSourceId String?                  @db.Uuid // The id of the DatasetEvalOutputSource to compare against

--- a/app/src/server/tasks/evaluateTestSetEntries.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntries.task.ts
@@ -253,6 +253,7 @@ export const evaluateTestSetEntries = defineTask<EvaluateTestSetEntriesJob>({
           status: "COMPLETE",
           explanation,
           score: score1,
+          wasFirst: true,
         },
       });
 
@@ -262,6 +263,7 @@ export const evaluateTestSetEntries = defineTask<EvaluateTestSetEntriesJob>({
           status: "COMPLETE",
           explanation,
           score: score2,
+          wasFirst: false,
         },
       });
     } catch (e) {


### PR DESCRIPTION
1. Randomize which output we present first to work around GPT-4's bias towards the first result.
2. Randomize the order we run evals, so partial results are more representative.
3. Replace "Alice" and "Bob" with "Response 1" and "Response 2". This does actuallys seem to make the answers slightly more correct in places where it makes a difference at all.