### PR TITLE
Optimize the query to create datasets from logged calls

### DIFF
--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -88,7 +88,7 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
     }
   }, [disclosure.isOpen, existingDatasetOptions, maxSampleSize]);
 
-  const createDatasetEntriesMutation = api.datasetEntries.create.useMutation();
+  const createDatasetEntriesMutation = api.datasetEntries.createFromLoggedCalls.useMutation();
 
   const [addToDataset, addingInProgress] = useHandledAsyncCallback(async () => {
     if (

--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -1,4 +1,4 @@
-import { sql, type RawBuilder, type Expression, type SqlBool } from "kysely";
+import { sql, type Expression, type SqlBool } from "kysely";
 
 import { prisma, kysely } from "~/server/db";
 import { escapeString, escapeLikeString } from "~/utils/pruningRules";
@@ -39,7 +39,7 @@ export const updatePruningRuleMatches = async (
   });
 
   for (let i = numOmittedRules; i < allPruningRules.length; i++) {
-    let prunedInput: RawBuilder<string> = sql`CAST("DatasetEntry"."messages" AS TEXT)`;
+    let prunedInput = sql`CAST("DatasetEntry"."messages" AS TEXT)`;
 
     // For each rule to update, find all the dataset entries with matching prompts, after previous rules have been applied
     for (let j = 0; j < i; j++) {


### PR DESCRIPTION
Unfortunately this doesn't make things much faster for our largest customers, but it keeps our RAM requirements much lower (since we aren't loading all IDs into RAM anymore) and makes dataset creation faster for projects with relatively few logged calls.