### PR TITLE
Change results tab key to "results"

### DIFF
--- a/app/src/components/evals/EvalContentTabs/EvalContentTabs.tsx
+++ b/app/src/components/evals/EvalContentTabs/EvalContentTabs.tsx
@@ -2,7 +2,7 @@ import Results from "./Results/Results";
 import Settings from "./Settings/Settings";
 import ContentTabs from "~/components/ContentTabs";
 
-export const EVAL_RESULTS_TAB_KEY = "general";
+export const EVAL_RESULTS_TAB_KEY = "results";
 export const EVAL_SETTINGS_TAB_KEY = "settings";
 
 const tabs = [


### PR DESCRIPTION
It makes more sense to use "results" as the tab key for the results tab than "general".