### PR TITLE
Replace | with Union[]

### DIFF
--- a/client-libs/python/openpipe/openai_async_wrapper.py
+++ b/client-libs/python/openpipe/openai_async_wrapper.py
@@ -33,7 +33,7 @@ class AsyncCompletionsWrapper(AsyncCompletions):
 
     async def create(
         cls, *args, **kwargs
-    ) -> ChatCompletion | AsyncStream[ChatCompletionChunk]:
+    ) -> Union[ChatCompletion, AsyncStream[ChatCompletionChunk]]:
         openpipe_options = kwargs.pop("openpipe", {})
 
         requested_at = int(time.time() * 1000)
@@ -150,14 +150,14 @@ class AsyncOpenAIWrapper(OriginalAsyncOpenAI):
         self,
         *,
         openpipe: Optional[Dict[str, str]] = None,
-        api_key: str | None = None,
-        organization: str | None = None,
-        base_url: str | httpx.URL | None = None,
+        api_key: Union[str, None] = None,
+        organization: Union[str, None] = None,
+        base_url: Union[str, httpx.URL, None] = None,
         timeout: Union[float, Timeout, None, NotGiven] = NOT_GIVEN,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        default_headers: Mapping[str, str] | None = None,
-        default_query: Mapping[str, object] | None = None,
-        http_client: httpx.Client | None = None,
+        default_headers: Union[Mapping[str, str], None] = None,
+        default_query: Union[Mapping[str, object], None] = None,
+        http_client: Union[httpx.Client, None] = None,
         _strict_response_validation: bool = False,
     ) -> None:
         super().__init__(

--- a/client-libs/python/openpipe/openai_sync_wrapper.py
+++ b/client-libs/python/openpipe/openai_sync_wrapper.py
@@ -31,7 +31,9 @@ class CompletionsWrapper(Completions):
         super().__init__(client)
         self.openpipe_client = openpipe_client
 
-    def create(cls, *args, **kwargs) -> ChatCompletion | Stream[ChatCompletionChunk]:
+    def create(
+        cls, *args, **kwargs
+    ) -> Union[ChatCompletion, Stream[ChatCompletionChunk]]:
         openpipe_options = kwargs.pop("openpipe", {})
 
         requested_at = int(time.time() * 1000)
@@ -141,14 +143,14 @@ class OpenAIWrapper(OriginalOpenAI):
         self,
         *,
         openpipe: Optional[Dict[str, str]] = None,
-        api_key: str | None = None,
-        organization: str | None = None,
-        base_url: str | httpx.URL | None = None,
+        api_key: Union[str, None] = None,
+        organization: Union[str, None] = None,
+        base_url: Union[str, httpx.URL, None] = None,
         timeout: Union[float, Timeout, None, NotGiven] = NOT_GIVEN,
         max_retries: int = DEFAULT_MAX_RETRIES,
-        default_headers: Mapping[str, str] | None = None,
-        default_query: Mapping[str, object] | None = None,
-        http_client: httpx.Client | None = None,
+        default_headers: Union[Mapping[str, str], None] = None,
+        default_query: Union[Mapping[str, object], None] = None,
+        http_client: Union[httpx.Client, None] = None,
         _strict_response_validation: bool = False,
     ) -> None:
         super().__init__(

--- a/client-libs/python/pyproject.toml
+++ b/client-libs/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openpipe"
-version = "4.0.2"
+version = "4.0.3"
 description = "Python client library for the OpenPipe service"
 authors = ["Kyle Corbitt <kyle@openpipe.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Python 3.9 users should no longer have trouble with newfangled typing.

`|` was introduced as a replacement for `Union` in [PEP 604](https://peps.python.org/pep-0604/) with the release of python 3.10. Unfortunately, that means its syntax is not compatible with 3.9 versions.