### PR TITLE
Revert "replicate api token made optional"

### DIFF
--- a/app/src/env.mjs
+++ b/app/src/env.mjs
@@ -17,7 +17,7 @@ export const env = createEnv({
     GITHUB_CLIENT_ID: z.string().min(1),
     GITHUB_CLIENT_SECRET: z.string().min(1),
     OPENAI_API_KEY: z.string().min(1),
-    REPLICATE_API_TOKEN: z.string().optional(),
+    REPLICATE_API_TOKEN: z.string().default("placeholder"),
     ANTHROPIC_API_KEY: z.string().default("placeholder"),
     SENTRY_AUTH_TOKEN: z.string().optional(),
     OPENPIPE_API_KEY: z.string().optional(),


### PR DESCRIPTION
Reverts OpenPipe/OpenPipe#390

That change unfortunately broke deploys that didn't have a REPLICATE_API_TOKEN set.