### PR TITLE
Run all infra on AWS

### DIFF
--- a/.github/workflows/app-prod.yaml
+++ b/.github/workflows/app-prod.yaml
@@ -1,8 +1,8 @@
-name: Deploy Stage
+name: Deploy Prod
 
 on:
   push:
-    branches: [stage]
+    branches: [prod]
 
 # Only run workflow for the latest commit
 concurrency: 
@@ -10,9 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy-stage:
+  deploy-prod:
     runs-on: ubuntu-latest
-    environment: stage
+    environment: prod
     container: ghcr.io/openpipe/deploy-infra
 
     steps:
@@ -36,20 +36,20 @@ jobs:
         uses: pulumi/actions@v3
         with:
           command: up
-          stack-name: openpipe/stage
+          stack-name: openpipe/prod
           work-dir: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           
-          # Lol I can't believe this is necessary but without it the AWS fails with cryptic errors.
+          # Lol I can't believe this is necessary but without it the AWS CLI fails when running on Azure with cryptic errors.
           # https://github.com/aws/aws-cli/issues/5234#issuecomment-705831465
           AWS_EC2_METADATA_DISABLED: true
 
       - name: Cancel Pulumi if the run was stopped
         if: ${{ cancelled() }}
-        run: pulumi cancel --stack=openpipe/stage --yes
+        run: pulumi cancel --stack=openpipe/prod --yes
         working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/app/src/server/db.ts
+++ b/app/src/server/db.ts
@@ -41,9 +41,7 @@ export const pgPool = new Pool({
 });
 
 export const kysely = new Kysely<DB>({
-  dialect: new PostgresDialect({
-    pool: pgPool,
-  }),
+  dialect: new PostgresDialect({ pool: pgPool }),
 });
 
 if (env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/app/src/server/tasks/defineTask.ts
+++ b/app/src/server/tasks/defineTask.ts
@@ -1,13 +1,13 @@
 import { type Helpers, type Task, makeWorkerUtils, type TaskSpec } from "graphile-worker";
 import { merge } from "lodash-es";
-import { env } from "~/env.mjs";
+import { pgPool } from "../db";
 
 let workerUtilsPromise: ReturnType<typeof makeWorkerUtils> | null = null;
 
 function workerUtils() {
   if (!workerUtilsPromise) {
     workerUtilsPromise = makeWorkerUtils({
-      connectionString: env.DATABASE_URL,
+      pgPool,
     });
   }
   return workerUtilsPromise;

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -41,3 +41,4 @@ config:
   openpipe:SMTP_PORT: "587"
   openpipe:WORKER_CONCURRENCY: "10"
   openpipe:deployDomain: openpipe.ai
+  openpipe:numWorkers: "3"

--- a/infra/scripts/migrate-prod-db.ts
+++ b/infra/scripts/migrate-prod-db.ts
@@ -1,0 +1,34 @@
+// Just checking this in as a historical record of the steps we took to migrate
+// the db to aws. This is not meant to be run again.
+
+import "dotenv/config";
+import { $ } from "execa";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+const $$ = $({ stdio: "inherit", shell: true });
+
+const oldDb = process.env.OLD_DATABASE_URL!;
+const newDb = process.env.NEW_DATABASE_URL!;
+
+if (process.env.RUN_DUMP === "true") {
+  const startTime = Date.now();
+
+  await $$`rm -rf /tmp/migrate-prod`;
+  await $$`mkdir -p /tmp/migrate-prod`;
+  await $$`pg_dump -v -Fc --no-acl --no-owner --format=directory --jobs=8 -f /tmp/migrate-prod ${oldDb}`;
+
+  const dumpEndTime = Date.now();
+  console.log(`Dump completed. Time taken: ${(dumpEndTime - startTime) / 1000} seconds`);
+}
+
+if (process.env.RUN_RESTORE === "true") {
+  await $$`pg_restore -v --no-acl --no-owner --exit-on-error -d '${newDb}' --jobs=8 /tmp/migrate-prod`;
+  console.log(`Restore completed. Time taken: ${(Date.now() - dumpEndTime) / 1000} seconds`);
+}
+
+// // // Now export just the schema
+await $$`pg_dump -v -Fp --no-acl --no-owner --schema-only ${oldDb} > /tmp/schema.sql`;
+
+// // Now import the schema in case it broke
+// await $$`pg_restore -v --no-acl --no-owner -d '${newDb}' --jobs=8 /tmp/migrate-prod/schema.dump`;

--- a/infra/src/app-env.ts
+++ b/infra/src/app-env.ts
@@ -12,8 +12,8 @@ export const environment = new kubernetes.core.v1.Secret(
   nm("app"),
   {
     stringData: {
-      // DATABASE_URL: dbConnectionString,
-      DATABASE_URL: getSecret("DATABASE_URL"),
+      DATABASE_URL: dbConnectionString,
+      // DATABASE_URL: getSecret("DATABASE_URL"),
       OPENAI_API_KEY: getSecret("OPENAI_API_KEY"),
       NEXTAUTH_SECRET: getSecret("NEXTAUTH_SECRET"),
       GITHUB_CLIENT_ID: getSecret("GITHUB_CLIENT_ID"),

--- a/infra/src/app-worker.ts
+++ b/infra/src/app-worker.ts
@@ -1,16 +1,21 @@
-import * as kubernetes from "@pulumi/kubernetes";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
 import { environment } from "./app-env";
 import { imageUri } from "./app-image";
 import { eksProvider } from "./cluster";
 import { nm } from "./helpers";
+import { getConfig } from "./config";
 
 const appWorker = "app-worker-v1";
 
-const deployment = new kubernetes.apps.v1.Deployment(
+const cfg = new pulumi.Config();
+
+const deployment = new k8s.apps.v1.Deployment(
   nm("app-worker"),
   {
     metadata: { labels: { appClass: appWorker } },
     spec: {
+      replicas: cfg.getNumber("numWorkers") ?? 1,
       selector: { matchLabels: { appClass: appWorker } },
       template: {
         metadata: { labels: { appClass: appWorker } },

--- a/infra/src/database.ts
+++ b/infra/src/database.ts
@@ -25,9 +25,9 @@ const dbInstance = new aws.rds.Instance(nm("app"), {
   username: "openpipe",
   password: password.result,
   dbName,
-  instanceClass: "db.m5.large",
-  allocatedStorage: 50,
-  maxAllocatedStorage: 1024,
+  instanceClass: "db.m7g.2xlarge",
+  allocatedStorage: 200,
+  maxAllocatedStorage: 1000,
   engine: "postgres",
   engineVersion: "15.5",
   parameterGroupName: "default.postgres15",
@@ -37,8 +37,7 @@ const dbInstance = new aws.rds.Instance(nm("app"), {
   applyImmediately: true,
   backupRetentionPeriod: 30,
   performanceInsightsEnabled: true,
-  // multiAz: true,
-  // monitoringInterval: 60,
+  multiAz: true,
   // skipFinalSnapshot: true,
 });
 

--- a/infra/src/dns.ts
+++ b/infra/src/dns.ts
@@ -29,14 +29,14 @@ const dnsRecord = new aws.route53.Record(nm("validationRecord"), {
 });
 
 // To ensure the certificate is validated before it's used
-// const validatedWildcardCert = new aws.acm.CertificateValidation(
-//   nm("certValidation"),
-//   {
-//     certificateArn: wildcardCert.arn,
-//     validationRecordFqdns: [dnsRecord.fqdn],
-//   },
-//   { dependsOn: [dnsRecord] },
-// );
+const validatedWildcardCert = new aws.acm.CertificateValidation(
+  nm("certValidation"),
+  {
+    certificateArn: wildcardCert.arn,
+    validationRecordFqdns: [dnsRecord.fqdn],
+  },
+  { dependsOn: [dnsRecord] },
+);
 
-// export const certificateArn = validatedWildcardCert.certificateArn;
-export const certificateArn = wildcardCert.arn;
+export const certificateArn = validatedWildcardCert.certificateArn;
+// export const certificateArn = wildcardCert.arn;


### PR DESCRIPTION
We've successfully migrated all our infra from Render to AWS. This PR contains the infra definition files, as well as a Github Action to deploy whenever we push to `main`.