### PR TITLE
Make file import slightly less naive

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/General/UploadDataButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/UploadDataButton.tsx
@@ -88,7 +88,7 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
     reader.onload = (e: ProgressEvent<FileReader>) => {
       const content = e.target?.result as string;
       try {
-        const resp = parseRowsToImport(content);
+        const resp = parseRowsToImport(content.trim().split("\n"));
 
         const errors = resp.filter(isParseError);
 

--- a/app/src/components/datasets/parseRowsToImport.ts
+++ b/app/src/components/datasets/parseRowsToImport.ts
@@ -47,8 +47,8 @@ export type ParsedRow = ParseError | RowToImport;
 
 export type ContentChatCompletionMessage = Omit<ChatCompletionMessageParam, "function_call">;
 
-export const parseRowsToImport = (jsonlString: string): ParsedRow[] => {
-  const lines = jsonlString.trim().split("\n");
+export const parseRowsToImport = (rawRows: string[]): ParsedRow[] => {
+  const lines = rawRows.map((row) => row.trim()).filter((row) => row.length > 0);
 
   const parsedRows = [];
 

--- a/infra/Pulumi.stage.yaml
+++ b/infra/Pulumi.stage.yaml
@@ -6,7 +6,7 @@ config:
   openpipe:AUTHENTICATED_SYSTEM_KEY:
     secure: AAABAIF/+V67LPOdOL1TJ6vYspfsshXqklCatXW4iwT9xkQiS5iQpIexXPiFAp2tFWwSi8w63gPExslbwltxbg==
   openpipe:AZURE_STORAGE_ACCOUNT_KEY:
-    secure: AAABABtQu3Y61sRqvJ5PiXn4wKY+auh9/UsakESmwq/TSHSnUx3p6hfiYSzjxK/OeFW/7IWm29UE5M2d5CTP7qocXX0C0Ucydl4gQmvnFW8p9RIt64Ld/7PX4mAPhaSJBDDjtwOkQGjsNog=
+    secure: AAABAMwPLm693oU/r9EBRtopeQkZV2/kXQ0hZ7luT6pj3x11hahfVMaG+7/hqk6GCSnMdm3HvbILSLUU2Gbuvzm4bjrHVSYn4okrsn+CjeMnwv0HQXjDWvac5SWShIeFs03y0D/e/8ZRQlGLATd/sdymx174PgOj
   openpipe:AZURE_STORAGE_ACCOUNT_NAME: openpipestorage
   openpipe:AZURE_STORAGE_CONTAINER_NAME: uploadedtrainingdata
   openpipe:DATABASE_URL:

--- a/infra/src/app-image.ts
+++ b/infra/src/app-image.ts
@@ -20,6 +20,11 @@ export const appImage = new awsx.ecr.Image(nm("app"), {
   dockerfile: "../app/Dockerfile",
   builderVersion: "BuilderBuildKit",
   platform: "linux/amd64",
+
+  // Note: this line will cause a new env from scratch to fail if there isn't
+  // already an image in the repo. Need to comment it out for the first build
+  // when bringing up a new env.
+  cacheFrom: [repo.url],
 });
 
 export const imageUri = appImage.imageUri;


### PR DESCRIPTION
Import jobs were crashing for very large # of rows (100k+) because NodeJS can't allocate a string that large. This fixes the immediate issue by allocating an array of strings at processing time instead of one bit one, as well as

The better fix that would get us to arbitrarily large upload sizes would be to switch our pipeline to process rows one at a time as they're streamed, probably using generators. But this should work until someone wants to upload a dataset that won't fit in RAM.