### PR TITLE
Deploy any branch to stage

### DIFF
--- a/.github/workflows/app-stage.yaml
+++ b/.github/workflows/app-stage.yaml
@@ -1,8 +1,12 @@
 name: Deploy Stage
 
 on:
-  push:
-    branches: [stage]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: 'main'
 
 # Only run workflow for the latest commit
 concurrency: 


### PR DESCRIPTION
Instead of auto-deploying the stage branch, let you deploy any branch to stage from the Action page.