### PR TITLE
Don't try to load all the training data into memory at once

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -71,6 +71,7 @@
     "graphile-worker": "^0.13.0",
     "human-id": "^4.0.0",
     "immer": "^10.0.2",
+    "ix": "^5.0.0",
     "json-schema-to-typescript": "^13.0.2",
     "json-stringify-pretty-compact": "^4.0.0",
     "jsonschema": "^1.4.1",

--- a/app/scripts/copy-db.sh
+++ b/app/scripts/copy-db.sh
@@ -10,14 +10,6 @@ report_progress() {
 export CACHE_DIR=~/.cache/openpipe/prod-db
 export TEMP_DB_NAME="openpipe_temp"
 
-parse_connection_string() {
-    TEMP_URL=${PROD_DATABASE_URL#postgres://}
-    DB_USERNAME=$(echo $TEMP_URL | cut -d':' -f1)
-    PASSWORD=$(echo $TEMP_URL | cut -d':' -f2 | cut -d'@' -f1)
-    HOST=$(echo $TEMP_URL | cut -d'@' -f2 | cut -d'/' -f1)
-    DB_NAME=$(echo $TEMP_URL | cut -d'/' -f2 | cut -d'?' -f1)
-}
-
 should_dump_prod_db() {
     [ "$FORCE_DUMP" = "true" ]
 }
@@ -39,9 +31,7 @@ dump_prod_db() {
       --exclude-table-data '"LoggedCall"' \
       --exclude-table-data '"LoggedCallTag"' \
       --exclude-table-data 'graphile_worker.jobs' \
-      -h "$HOST" \
-      -U "$DB_USERNAME" \
-      -d "$DB_NAME"
+      -d "$PROD_DATABASE_URL"
     
     # Unset the password environment variable
     unset PGPASSWORD
@@ -79,7 +69,6 @@ else
 fi
 
 source .env
-parse_connection_string
 
 if should_dump_prod_db; then
     dump_prod_db

--- a/app/scripts/repl.ts
+++ b/app/scripts/repl.ts
@@ -4,6 +4,7 @@
 import "dotenv/config";
 import { prisma } from "../src/server/db";
 import { generateBlobDownloadUrl } from "~/utils/azure/server";
+import { trainFineTune } from "~/server/tasks/fineTuning/trainFineTune.task";
 
 const setGlobal = (key: string, value: any) => {
   (global as any)[key] = value;
@@ -22,8 +23,14 @@ setGlobal("prisma", prisma);
 // await startTestJobs(fineTune.datasetId, "7546b2e5-88f4-4c13-9780-187ecbc1913c");
 
 // console.log("done");
-console.log(
-  await generateBlobDownloadUrl(
-    "1453795139259-04708bc4-4f35-4b89-beb1-7ee25efc29e2-training.jsonl",
-  ),
-);
+// console.log(
+//   await generateBlobDownloadUrl(
+//     "1453795139259-04708bc4-4f35-4b89-beb1-7ee25efc29e2-training.jsonl",
+//   ),
+// );
+
+// large
+// await trainFineTune.runNow({ fineTuneId: "a72645ec-377c-4179-8bb5-772812c0bfde" });
+
+// test
+await trainFineTune.runNow({ fineTuneId: "c5364071-73f0-40ff-910b-bd580b319bb0" });

--- a/app/src/server/tasks/fineTuning/trainOpenaiFineTune.ts
+++ b/app/src/server/tasks/fineTuning/trainOpenaiFineTune.ts
@@ -52,6 +52,8 @@ export const trainOpenaiFineTune = async (fineTuneId: string) => {
 
   const stringsToPrune = await getStringsToPrune(fineTune.id);
 
+  // TODO: this will break for large datasets. Switch to the iterateTrainingRows
+  // approach we use in trainFineTune.
   const trainingEntries = fineTune.trainingEntries.map((entry) => {
     const outputMessage = chatCompletionMessage.parse(entry.datasetEntry.output);
     return {

--- a/app/src/utils/azure/server.ts
+++ b/app/src/utils/azure/server.ts
@@ -50,39 +50,11 @@ export const generateSasToken = (permissions: string) => {
   return sasToken.startsWith("?") ? sasToken.substring(1) : sasToken;
 };
 
-class JSONLStream extends Readable {
-  private jsonObjects: object[];
-  private currentIndex: number;
-
-  constructor(jsonObjects: object[]) {
-    super();
-    this.jsonObjects = jsonObjects;
-    this.currentIndex = 0;
-  }
-
-  _read() {
-    while (this.currentIndex < this.jsonObjects.length) {
-      const obj = this.jsonObjects[this.currentIndex];
-      const jsonlStr = JSON.stringify(obj) + "\n";
-      this.currentIndex++;
-
-      // Push each JSONL string into the stream
-      if (!this.push(Buffer.from(jsonlStr, "utf-8"))) {
-        // If push returns false, stop pushing until the stream is drained
-        return;
-      }
-    }
-
-    // Once all data is pushed, close the stream
-    this.push(null);
-  }
-}
-
-export const uploadTrainingDataFile = async (contents: object[]) => {
+export const uploadJsonl = async (stream: Readable) => {
   const blobName = `${inverseDatePrefix()}-${uuidv4()}-training.jsonl`;
   const blobClient = containerClient.getBlockBlobClient(blobName);
 
-  await blobClient.uploadStream(new JSONLStream(contents));
+  await blobClient.uploadStream(stream);
 
   return blobName;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       immer:
         specifier: ^10.0.2
         version: 10.0.2
+      ix:
+        specifier: ^5.0.0
+        version: 5.0.0
       json-schema-to-typescript:
         specifier: ^13.0.2
         version: 13.0.2
@@ -3279,6 +3282,10 @@ packages:
     dependencies:
       '@types/node': 20.4.10
       form-data: 3.0.1
+
+  /@types/node@13.13.52:
+    resolution: {integrity: sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==}
+    dev: false
 
   /@types/node@18.16.0:
     resolution: {integrity: sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==}
@@ -6594,11 +6601,18 @@ packages:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: false
 
+  /ix@5.0.0:
+    resolution: {integrity: sha512-6LyyrHnvNrSy5pKtW/KA+KKusHrB223aBJCJlIGPN7QBfDkEEtNrAkAz9lLLShIcdJntq6BiPCHuKaCM/9wwXw==}
+    dependencies:
+      '@types/node': 13.13.52
+      tslib: 2.6.2
+    dev: false
+
   /jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.18.8
+      '@types/node': 20.4.10
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
This implements a new training data upload pattern that grabs 1000 rows from the database at a time, processes them, and then uploads them directly to Azure. That way we never have to have all of our training data in memory at once.

This is likely a pattern we'll have to implement in more places over time as datasets get larger.