### PR TITLE
Properly report null json values

### DIFF
--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -230,10 +230,10 @@ export const v1ApiRouter = createOpenApiRouter({
             model,
             receivedAt: new Date(input.receivedAt),
             reqPayload: (input.reqPayload === null
-              ? Prisma.DbNull
+              ? Prisma.JsonNull
               : input.reqPayload) as Prisma.InputJsonValue,
             respPayload: (input.respPayload === null
-              ? Prisma.DbNull
+              ? Prisma.JsonNull
               : input.respPayload) as Prisma.InputJsonValue,
             statusCode: input.statusCode,
             errorMessage: input.errorMessage,

--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -1,4 +1,4 @@
-import { UsageType, type Prisma } from "@prisma/client";
+import { UsageType, Prisma } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
 import { type ChatCompletion, type ChatCompletionCreateParams } from "openai/resources/chat";
 import { v4 as uuidv4 } from "uuid";
@@ -221,25 +221,36 @@ export const v1ApiRouter = createOpenApiRouter({
         }
       }
 
-      await prisma.loggedCall.create({
-        data: {
-          id: newLoggedCallId,
-          projectId: ctx.key.projectId,
-          requestedAt: new Date(input.requestedAt),
-          model,
-          receivedAt: new Date(input.receivedAt),
-          reqPayload: input.reqPayload as Prisma.InputJsonValue,
-          respPayload: input.respPayload as Prisma.InputJsonValue,
-          statusCode: input.statusCode,
-          errorMessage: input.errorMessage,
-          durationMs: input.receivedAt - input.requestedAt,
-          inputTokens: usage?.inputTokens,
-          outputTokens: usage?.outputTokens,
-          cost: usage?.cost,
-          completionId: respPayload.success ? respPayload.data.id : null,
-          migrated: true,
-        },
-      });
+      try {
+        await prisma.loggedCall.create({
+          data: {
+            id: newLoggedCallId,
+            projectId: ctx.key.projectId,
+            requestedAt: new Date(input.requestedAt),
+            model,
+            receivedAt: new Date(input.receivedAt),
+            reqPayload: (input.reqPayload === null
+              ? Prisma.DbNull
+              : input.reqPayload) as Prisma.InputJsonValue,
+            respPayload: (input.respPayload === null
+              ? Prisma.DbNull
+              : input.respPayload) as Prisma.InputJsonValue,
+            statusCode: input.statusCode,
+            errorMessage: input.errorMessage,
+            durationMs: input.receivedAt - input.requestedAt,
+            inputTokens: usage?.inputTokens,
+            outputTokens: usage?.outputTokens,
+            cost: usage?.cost,
+            completionId: respPayload.success ? respPayload.data.id : null,
+            migrated: true,
+          },
+        });
+      } catch (e) {
+        throw new TRPCError({
+          message: `Failed to create logged call: ${(e as Error).message}`,
+          code: "BAD_REQUEST",
+        });
+      }
 
       await createTags(ctx.key.projectId, newLoggedCallId, input.tags);
       return { status: "ok" };

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -34,8 +34,8 @@ test("basic call", async () => {
   });
   await completion.openpipe.reportingFinished;
   const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.modelResponse?.reqPayload).toMatchObject(payload);
-  expect(completion).toMatchObject(lastLogged?.modelResponse?.respPayload);
+  expect(lastLogged?.reqPayload).toMatchObject(payload);
+  expect(completion).toMatchObject(lastLogged?.respPayload);
   expect(lastLogged?.tags).toMatchObject({ promptId: "test" });
 });
 
@@ -62,8 +62,8 @@ test("streaming", async () => {
   const lastLogged = await lastLoggedCall();
   await completion.openpipe.reportingFinished;
 
-  expect(merged).toMatchObject(lastLogged?.modelResponse?.respPayload);
-  expect(lastLogged?.modelResponse?.reqPayload.messages).toMatchObject([
+  expect(merged).toMatchObject(lastLogged?.respPayload);
+  expect(lastLogged?.reqPayload.messages).toMatchObject([
     { role: "system", content: "count to 3" },
   ]);
 });
@@ -79,10 +79,10 @@ test("bad call streaming", async () => {
     // @ts-expect-error need to check for error type
     await e.openpipe.reportingFinished;
     const lastLogged = await lastLoggedCall();
-    expect(lastLogged?.modelResponse?.errorMessage).toEqual(
+    expect(lastLogged?.errorMessage).toEqual(
       "404 The model `gpt-3.5-turbo-blaster` does not exist",
     );
-    expect(lastLogged?.modelResponse?.statusCode).toEqual(404);
+    expect(lastLogged?.statusCode).toEqual(404);
   }
 });
 
@@ -98,9 +98,7 @@ test("bad call", async () => {
     // @ts-expect-error need to check for error type
     await e.openpipe.reportingFinished;
     const lastLogged = await lastLoggedCall();
-    expect(lastLogged?.modelResponse?.errorMessage).toEqual(
-      "404 The model `gpt-3.5-turbo-buster` does not exist",
-    );
-    expect(lastLogged?.modelResponse?.statusCode).toEqual(404);
+    expect(lastLogged?.errorMessage).toEqual("404 The model `gpt-3.5-turbo-buster` does not exist");
+    expect(lastLogged?.statusCode).toEqual(404);
   }
 });

--- a/client-libs/typescript/src/openai/report.test.ts
+++ b/client-libs/typescript/src/openai/report.test.ts
@@ -1,0 +1,45 @@
+import dotenv from "dotenv";
+import { test } from "vitest";
+import OpenAI from "../openai";
+import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
+import { OPClient } from "../codegen";
+
+dotenv.config();
+
+const oaiClient = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  openpipe: {
+    apiKey: process.env.OPENPIPE_API_KEY,
+    baseUrl: "http://localhost:3000/api/v1",
+  },
+});
+
+const opClient = new OPClient({
+  BASE: "http://localhost:3000/api/v1",
+  TOKEN: process.env.OPENPIPE_API_KEY,
+});
+
+test("reports null response payload", async () => {
+  const payload: ChatCompletionCreateParams = {
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "system", content: "count to 3" }],
+  };
+
+  const resp = await opClient.default.report({
+    requestedAt: Date.now(),
+    receivedAt: Date.now(),
+    reqPayload: payload,
+    respPayload: null,
+  });
+});
+
+test("reports invalid request payload", async () => {
+  const payload: ChatCompletionCreateParams = {
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "system", content: "count to 3" }],
+  };
+
+  const completionResp = await oaiClient.chat.completions.create({
+    ...payload,
+  });
+});


### PR DESCRIPTION
If the user sends or OpenAI returns a null json value, we need to translate it to Prisma's own special version of null in order to save it in the database.