### PR TITLE
Update pruning rule matches in chunks of 1000

### DIFF
--- a/app/src/server/tasks/importDatasetEntries.task.ts
+++ b/app/src/server/tasks/importDatasetEntries.task.ts
@@ -84,10 +84,9 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
         importId,
         authoringUserId,
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (e: any) {
+    } catch (e: unknown) {
       await updateDatasetFileUpload({
-        errorMessage: `Error preparing rows: ${e.message as string}`,
+        errorMessage: `Error preparing rows: ${(e as Error).message}`,
         status: "ERROR",
         visible: true,
       });

--- a/app/src/server/tasks/importDatasetEntries.task.ts
+++ b/app/src/server/tasks/importDatasetEntries.task.ts
@@ -101,24 +101,25 @@ export const importDatasetEntries = defineTask<ImportDatasetEntriesJob>({
 
     // split datasetEntriesToCreate into chunks of 1000 because if we try too many at once Prisma throws a `RangeError: Invalid string length`
     for (let i = 0; i < datasetEntriesToCreate.length; i += 1000) {
+      const chunk = datasetEntriesToCreate.slice(i, i + 1000);
       await prisma.datasetEntry.createMany({
-        data: datasetEntriesToCreate.slice(i, i + 1000),
+        data: chunk,
       });
+
+      await updatePruningRuleMatches(
+        datasetFileUpload.datasetId,
+        new Date(0),
+        chunk.map((entry) => entry.id),
+      );
+
+      await updateDatasetFileUpload({ progress: 70 + 25 * (i / datasetEntriesToCreate.length) });
     }
 
-    await updateDatasetFileUpload({ progress: 80 });
-
-    await updatePruningRuleMatches(
-      datasetFileUpload.datasetId,
-      new Date(0),
-      datasetEntriesToCreate.map((entry) => entry.id),
-    );
-
-    await updateDatasetFileUpload({ progress: 85 });
+    await updateDatasetFileUpload({ progress: 95 });
 
     await startDatasetTestJobs(datasetFileUpload.datasetId);
 
-    await updateDatasetFileUpload({ progress: 90 });
+    await updateDatasetFileUpload({ progress: 99 });
 
     await countDatasetEntryTokens.enqueue();
 


### PR DESCRIPTION
This helps us avoid updating pruning rules for all of our imported rows simultaneously in importDatasetEntries.

Centralizing the logic around creating many dataset entries is tricky because we need to run `updatePruningRuleMatches` once per batch of 1000 imported rows, but we should only run `startDatasetTestJobs` and `countDatasetEntryTokens` once per entire import. Running either of the latter tasks multiple times will result in inefficiencies and duplicate writes to the database.