### PR TITLE
Make long parse errors scrollable

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/General/UploadDataButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/UploadDataButton.tsx
@@ -165,7 +165,9 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
                   <Text fontSize={32} color="gray.500" fontWeight="bold">
                     Error
                   </Text>
-                  <Text color="gray.500">{validationError}</Text>
+                  <Text color="gray.500" maxH="160" overflowY="auto">
+                    {validationError}
+                  </Text>
                 </VStack>
                 <Text
                   as="span"

--- a/app/src/components/datasets/parseRowsToImport.ts
+++ b/app/src/components/datasets/parseRowsToImport.ts
@@ -74,7 +74,7 @@ export const validateRowToImport = (row: unknown): ParseError | RowToImport => {
     "output" in row &&
     isObject(row.output) &&
     !("content" in row.output) &&
-    "function_call" in row.output
+    ("function_call" in row.output || "tool_calls" in row.output)
   ) {
     // @ts-expect-error we're about to check this with Zod anyway
     row.output.content = null;


### PR DESCRIPTION
When our parse errors are especially long, we should make them scrollable instead of exceeding the bounds of the modal.
