### PR TITLE
Make dataset entry tools visible and editable

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/JsonEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/JsonEditor.tsx
@@ -1,0 +1,117 @@
+import { useRef, useMemo, useEffect, useLayoutEffect, useState } from "react";
+import { VStack, Box } from "@chakra-ui/react";
+
+import { useAppStore } from "~/state/store";
+import { type CreatedEditor } from "~/state/sharedArgumentsEditor.slice";
+
+const JsonEditor = ({ value, onEdit }: { value: string; onEdit: (newValue: string) => void }) => {
+  const monaco = useAppStore.use.sharedArgumentsEditor.monaco();
+  const editorRef = useRef<CreatedEditor | null>(null);
+  const editorId = useMemo(() => `editor_${Math.random().toString(36).substring(7)}`, []);
+
+  const [editor, setEditor] = useState<CreatedEditor | null>(null);
+
+  useLayoutEffect(() => {
+    const container = document.getElementById(editorId) as HTMLElement;
+
+    let newEditor: CreatedEditor | null = null;
+    if (container && monaco) {
+      newEditor = monaco.editor.create(container, {
+        language: "json",
+        theme: "customTheme",
+        lineNumbers: "off",
+        minimap: { enabled: false },
+        wrappingIndent: "indent",
+        wrappingStrategy: "advanced",
+        wordWrap: "on",
+        folding: false,
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 0,
+        },
+        wordWrapBreakAfterCharacters: "",
+        wordWrapBreakBeforeCharacters: "",
+        quickSuggestions: true,
+        renderLineHighlight: "none",
+        fontSize: 14,
+        scrollBeyondLastLine: false,
+      });
+
+      setEditor(newEditor);
+    }
+    return () => {
+      if (newEditor) newEditor.dispose();
+    };
+  }, [!!monaco, editorId]);
+
+  useEffect(() => {
+    if (editor) {
+      const container = document.getElementById(editorId) as HTMLElement;
+
+      editor.setValue(value);
+
+      editorRef.current = editor;
+
+      const updateHeight = () => {
+        container.style.height = `${editor.getContentHeight()}px`;
+        editor.layout();
+      };
+
+      const attemptDocumentFormat = () => {
+        const action = editor.getAction("editor.action.formatDocument");
+        if (action) {
+          action
+            .run()
+            .then(updateHeight)
+            .catch((error) => {
+              console.error("Error running formatDocument:", error);
+            });
+          return true;
+        }
+        return false;
+      };
+
+      editor.onDidBlurEditorText(() => {
+        onEdit(editor.getValue());
+
+        attemptDocumentFormat();
+      });
+
+      // Interval function to check for action availability
+      const checkForActionInterval = setInterval(() => {
+        const formatted = attemptDocumentFormat();
+        if (formatted) {
+          clearInterval(checkForActionInterval); // Clear the interval once the action is found and run
+        }
+      }, 100); // Check every 100ms
+
+      // Add content change listener
+      const contentChangeListener = editor.onDidChangeModelContent(updateHeight);
+
+      const resizeObserver = new ResizeObserver(() => {
+        editor.layout();
+      });
+      resizeObserver.observe(container);
+
+      return () => {
+        contentChangeListener.dispose();
+        resizeObserver.disconnect();
+      };
+    }
+  }, [editor, editorId, value, onEdit]);
+
+  return (
+    <VStack
+      borderRadius={4}
+      border="1px solid"
+      borderColor="gray.200"
+      w="full"
+      py={1}
+      bgColor="white"
+    >
+      <Box id={editorId} w="full" />
+    </VStack>
+  );
+};
+
+export default JsonEditor;

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/ToolsEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/ToolsEditor.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { HStack, VStack, Icon, Text, Link } from "@chakra-ui/react";
+import { FiChevronUp, FiChevronDown } from "react-icons/fi";
+
+import JsonEditor from "./JsonEditor";
+
+const ToolsEditor = ({ value, onEdit }: { value: string; onEdit: (newValue: string) => void }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <VStack w="full" alignItems="flex-start">
+      <HStack w="full" cursor="pointer" onClick={() => setExpanded(!expanded)}>
+        <Text fontWeight="bold" fontSize="xl">
+          Tools
+        </Text>
+        <Icon as={expanded ? FiChevronUp : FiChevronDown} />
+      </HStack>
+      {expanded && (
+        <>
+          <JsonEditor value={value} onEdit={onEdit} />
+          <Link
+            href="https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools"
+            target="_blank"
+            color="blue.500"
+            _hover={{ color: "blue.800", textDecoration: "underline" }}
+          >
+            Learn more
+          </Link>
+        </>
+      )}
+    </VStack>
+  );
+};
+
+export default ToolsEditor;

--- a/app/src/server/utils/datasetEntryCreation/copyEntryWithUpdates.ts
+++ b/app/src/server/utils/datasetEntryCreation/copyEntryWithUpdates.ts
@@ -15,6 +15,7 @@ export const copyEntryWithUpdates = async (
   updates: {
     split?: "TRAIN" | "TEST";
     messages?: Prisma.JsonValue;
+    tools?: Prisma.JsonValue;
     output?: Prisma.JsonValue;
   },
 ) => {
@@ -39,10 +40,10 @@ export const copyEntryWithUpdates = async (
 
   const inputFields = typedDatasetEntry({
     messages: updates.messages ?? prevEntry.messages,
+    tools: updates.tools ?? prevEntry.tools ?? undefined,
+    tool_choice: prevEntry.tool_choice ?? undefined,
     functions: prevEntry.functions ?? undefined,
     function_call: prevEntry.function_call ?? undefined,
-    tool_choice: prevEntry.tool_choice ?? undefined,
-    tools: prevEntry.tools ?? undefined,
     response_format: prevEntry.response_format ?? undefined,
   });
 


### PR DESCRIPTION
A couple users have asked to see the tools associated with a specific dataset entry, so we'll make them visible, and also allow them to be edited.

Collapsed:
<img width="875" alt="Screenshot 2023-12-12 at 12 29 40 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/86677ac8-5d1c-4e6b-8349-f00345741cd9">


Expanded:
<img width="866" alt="Screenshot 2023-12-12 at 12 31 35 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/0bd3f655-81f0-40db-9596-bfb09a951b5c">

