### PR TITLE
Hide field comparison by default

### DIFF
--- a/app/src/components/ContentTabs.tsx
+++ b/app/src/components/ContentTabs.tsx
@@ -6,10 +6,12 @@ import { useRouter, type NextRouter } from "next/router";
 const ContentTabs = ({
   tabs,
   headerProps,
+  rightHeader,
   trackTabInUrl = true,
 }: {
   tabs: { key: string; title: string; component: React.ReactElement }[];
   headerProps?: StackProps;
+  rightHeader?: React.ReactElement;
   trackTabInUrl?: boolean;
 }) => {
   const [borderPosition, setBorderPosition] = useState({ left: "0", width: "0" });
@@ -42,27 +44,30 @@ const ContentTabs = ({
   return (
     <>
       <VStack w="full" alignItems="flex-start" spacing={0} pb={8} {...headerProps}>
-        <HStack position="relative">
-          {tabs.map((tab) => (
-            <TabHeader
-              key={tab.key}
-              title={tab.title}
-              isSelected={activeTabKey === tab.key}
-              onClick={() => handleTabChange(tab.key)}
-              ref={(el) => {
-                if (el) headersRef.current[tab.key] = el;
-              }}
+        <HStack w="full" justifyContent="space-between">
+          <HStack position="relative">
+            {tabs.map((tab) => (
+              <TabHeader
+                key={tab.key}
+                title={tab.title}
+                isSelected={activeTabKey === tab.key}
+                onClick={() => handleTabChange(tab.key)}
+                ref={(el) => {
+                  if (el) headersRef.current[tab.key] = el;
+                }}
+              />
+            ))}
+            <Box
+              position="absolute"
+              bottom="0"
+              left={borderPosition.left}
+              w={borderPosition.width}
+              h="2px"
+              bg="blue.500"
+              transition="all 0.3s"
             />
-          ))}
-          <Box
-            position="absolute"
-            bottom="0"
-            left={borderPosition.left}
-            w={borderPosition.width}
-            h="2px"
-            bg="blue.500"
-            transition="all 0.3s"
-          />
+          </HStack>
+          {rightHeader}
         </HStack>
         <Divider />
       </VStack>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvalVisibilityDropdown.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvalVisibilityDropdown.tsx
@@ -102,11 +102,7 @@ const EvalVisibilityDropdown = () => {
                 borderBottomWidth={1}
               >
                 <Text mr={16}>{option.label}</Text>
-                <Switch
-                  isChecked={visibleEvalIds.includes(option.key)}
-                  onChange={() => toggleEvalVisiblity(option.key)}
-                  size="sm"
-                />
+                <Switch isChecked={visibleEvalIds.includes(option.key)} size="sm" />
               </HStack>
             ))}
             <HStack

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/useVisibleEvalIds.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/useVisibleEvalIds.tsx
@@ -1,4 +1,4 @@
-import { useQueryParam, JsonParam, withDefault } from "use-query-params";
+import { useQueryParam, JsonParam, withDefault, encodeQueryParams } from "use-query-params";
 
 import { useDataset } from "~/utils/hooks";
 
@@ -101,4 +101,19 @@ export const useVisibleEvalIds = () => {
     },
     ensureEvalShown,
   };
+};
+
+export const constructVisibleEvalIdsQueryParams = (hthEvalIds: string[]): Record<string, any> => {
+  const queryParams = {
+    visibleEvals: {
+      hthEvalIds,
+      showFieldComparison: false,
+    },
+  };
+
+  const encodedParams = encodeQueryParams({ visibleEvals: JsonParam }, queryParams);
+
+  return Object.fromEntries(
+    Object.entries(encodedParams).map(([key, value]) => [key, value?.toString()]),
+  );
 };

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/useVisibleEvalIds.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/useVisibleEvalIds.tsx
@@ -7,25 +7,25 @@ export const EMPTY_EVALS_KEY = "_empty_";
 export const useVisibleEvalIds = () => {
   const dataset = useDataset().data;
   const [visibleEvals, setVisibleEvals] = useQueryParam<{
-    hthEvalIds: string[];
+    headToHeadEvalIds: string[];
     showFieldComparison: boolean;
   }>(
     "visibleEvals",
     withDefault(JsonParam, {
-      hthEvalIds: [],
+      headToHeadEvalIds: [],
       showFieldComparison: false,
     }),
   );
 
-  const hthEvalIds = visibleEvals.hthEvalIds;
-  const setVisibleHthEvalIds = (newVisibleEvalIds: string[]) => {
+  const headToHeadEvalIds = visibleEvals.headToHeadEvalIds;
+  const setVisibleHeadToHeadEvalIds = (newVisibleEvalIds: string[]) => {
     setVisibleEvals({
-      hthEvalIds: newVisibleEvalIds,
+      headToHeadEvalIds: newVisibleEvalIds,
       showFieldComparison: visibleEvals.showFieldComparison,
     });
   };
 
-  const allHthEvalIds =
+  const allHeadToHeadEvalIds =
     dataset?.datasetEvals
       .filter((datasetEval) => datasetEval.type === "HEAD_TO_HEAD")
       ?.map((datasetEval) => datasetEval.id) || [];
@@ -36,54 +36,57 @@ export const useVisibleEvalIds = () => {
       ?.map((datasetEval) => datasetEval.id) || [];
 
   const ensureEvalShown = (evalId: string) => {
-    if (hthEvalIds.length === 0 || hthEvalIds.includes(evalId)) return;
-    if (hthEvalIds.includes(EMPTY_EVALS_KEY)) {
-      setVisibleHthEvalIds([evalId]);
+    if (headToHeadEvalIds.length === 0 || headToHeadEvalIds.includes(evalId)) return;
+    if (headToHeadEvalIds.includes(EMPTY_EVALS_KEY)) {
+      setVisibleHeadToHeadEvalIds([evalId]);
     } else {
-      setVisibleHthEvalIds([...hthEvalIds, evalId]);
+      setVisibleHeadToHeadEvalIds([...headToHeadEvalIds, evalId]);
     }
   };
 
   const toggleEvalVisiblity = (evalId: string) => {
     if (allFieldComparisonEvalIds.includes(evalId)) {
       setVisibleEvals({
-        hthEvalIds,
+        headToHeadEvalIds,
         showFieldComparison: !visibleEvals.showFieldComparison,
       });
       return;
     }
 
-    if (hthEvalIds.length === 0) {
+    if (headToHeadEvalIds.length === 0) {
       // All evals were visible, so we're only hiding this one.
-      if (allHthEvalIds.length === 1) {
+      if (allHeadToHeadEvalIds.length === 1) {
         // There's only one eval, so we're hiding all of them.
-        setVisibleHthEvalIds([EMPTY_EVALS_KEY]);
+        setVisibleHeadToHeadEvalIds([EMPTY_EVALS_KEY]);
       } else {
-        setVisibleHthEvalIds(allHthEvalIds.filter((id) => id != evalId));
+        setVisibleHeadToHeadEvalIds(allHeadToHeadEvalIds.filter((id) => id != evalId));
       }
-    } else if (hthEvalIds.includes(EMPTY_EVALS_KEY)) {
+    } else if (headToHeadEvalIds.includes(EMPTY_EVALS_KEY)) {
       // All evals were hidden, so we're only showing this one.
-      setVisibleHthEvalIds([evalId]);
-    } else if (hthEvalIds.length === allHthEvalIds.length - 1 && !hthEvalIds.includes(evalId)) {
+      setVisibleHeadToHeadEvalIds([evalId]);
+    } else if (
+      headToHeadEvalIds.length === allHeadToHeadEvalIds.length - 1 &&
+      !headToHeadEvalIds.includes(evalId)
+    ) {
       // This was the only hidden eval, so we're now showing all of them
-      setVisibleHthEvalIds([]);
-    } else if (hthEvalIds.length === 1 && hthEvalIds.includes(evalId)) {
+      setVisibleHeadToHeadEvalIds([]);
+    } else if (headToHeadEvalIds.length === 1 && headToHeadEvalIds.includes(evalId)) {
       // This is the only visible eval, so we're hiding it.
-      setVisibleHthEvalIds([EMPTY_EVALS_KEY]);
-    } else if (hthEvalIds.includes(evalId)) {
+      setVisibleHeadToHeadEvalIds([EMPTY_EVALS_KEY]);
+    } else if (headToHeadEvalIds.includes(evalId)) {
       // This eval was visible, so we're hiding it.
-      setVisibleHthEvalIds(hthEvalIds.filter((id) => id !== evalId));
-    } else if (!hthEvalIds.includes(evalId)) {
+      setVisibleHeadToHeadEvalIds(headToHeadEvalIds.filter((id) => id !== evalId));
+    } else if (!headToHeadEvalIds.includes(evalId)) {
       // This eval was hidden, so we're showing it.
-      setVisibleHthEvalIds([...hthEvalIds, evalId]);
+      setVisibleHeadToHeadEvalIds([...headToHeadEvalIds, evalId]);
     }
   };
 
-  let completeVisibleEvalIds = hthEvalIds;
-  if (hthEvalIds.includes(EMPTY_EVALS_KEY)) {
+  let completeVisibleEvalIds = headToHeadEvalIds;
+  if (headToHeadEvalIds.includes(EMPTY_EVALS_KEY)) {
     completeVisibleEvalIds = [];
-  } else if (hthEvalIds.length === 0) {
-    completeVisibleEvalIds = allHthEvalIds;
+  } else if (headToHeadEvalIds.length === 0) {
+    completeVisibleEvalIds = allHeadToHeadEvalIds;
   }
 
   if (visibleEvals.showFieldComparison) {
@@ -95,7 +98,7 @@ export const useVisibleEvalIds = () => {
     toggleEvalVisiblity,
     toggleFieldComparisonVisiblity: () => {
       setVisibleEvals({
-        hthEvalIds,
+        headToHeadEvalIds,
         showFieldComparison: !visibleEvals.showFieldComparison,
       });
     },
@@ -103,10 +106,12 @@ export const useVisibleEvalIds = () => {
   };
 };
 
-export const constructVisibleEvalIdsQueryParams = (hthEvalIds: string[]): Record<string, any> => {
+export const constructVisibleEvalIdsQueryParams = (
+  headToHeadEvalIds: string[],
+): Record<string, any> => {
   const queryParams = {
     visibleEvals: {
-      hthEvalIds,
+      headToHeadEvalIds,
       showFieldComparison: false,
     },
   };

--- a/app/src/components/evals/EvalContentTabs/EvalContentTabs.tsx
+++ b/app/src/components/evals/EvalContentTabs/EvalContentTabs.tsx
@@ -1,6 +1,7 @@
 import Results from "./Results/Results";
 import Settings from "./Settings/Settings";
 import ContentTabs from "~/components/ContentTabs";
+import ViewTestOutputButton from "./ViewTestOutputButton";
 
 export const EVAL_RESULTS_TAB_KEY = "results";
 export const EVAL_SETTINGS_TAB_KEY = "settings";
@@ -18,6 +19,6 @@ const tabs = [
   },
 ];
 
-const EvalContentTabs = () => <ContentTabs tabs={tabs} />;
+const EvalContentTabs = () => <ContentTabs tabs={tabs} rightHeader={<ViewTestOutputButton />} />;
 
 export default EvalContentTabs;

--- a/app/src/components/evals/EvalContentTabs/Results/Results.tsx
+++ b/app/src/components/evals/EvalContentTabs/Results/Results.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useLayoutEffect, useState } from "react";
+import React, { useMemo, useLayoutEffect, useState, useEffect } from "react";
 import {
   Badge,
   Box,
@@ -12,7 +12,9 @@ import {
   Thead,
   Tr,
   VStack,
+  HStack,
   useToken,
+  Tooltip,
 } from "@chakra-ui/react";
 import chroma from "chroma-js";
 import { type RouterOutputs } from "~/utils/api";
@@ -26,14 +28,33 @@ import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 import { DATASET_EVALUATION_TAB_KEY } from "~/components/datasets/DatasetContentTabs/DatasetContentTabs";
 
 const Results = () => {
-  const datasetEval = useDatasetEval().data;
+  const [refetchInterval, setRefetchInterval] = useState(0);
+  const datasetEval = useDatasetEval(refetchInterval).data;
+
+  const { completedComparisons, totalComparisons } = datasetEval?.results.completionCount || {};
+
+  const isComplete = completedComparisons === totalComparisons;
+
+  useEffect(() => setRefetchInterval(isComplete ? 0 : 3000), [isComplete]);
 
   if (!datasetEval) return null;
 
   return (
     <VStack w="full" alignItems="flex-start" spacing={12} pb={16}>
       <VStack alignItems="flex-start" w="full">
-        <Heading size="md">Overall Performance</Heading>
+        <HStack w="full" justifyContent="space-between">
+          <Heading size="md">Overall Performance</Heading>
+          {!isComplete && (
+            <Tooltip label="Evaluation running" fontSize="sm" shouldWrapChildren maxW={80}>
+              <HStack>
+                <Box borderRadius={8} bgColor="yellow.500" boxSize={3} />
+                <Text>
+                  {completedComparisons}/{totalComparisons}
+                </Text>
+              </HStack>
+            </Tooltip>
+          )}
+        </HStack>
         <ContentCard w="full" p={0}>
           <Table size="sm">
             <Thead>

--- a/app/src/components/evals/EvalContentTabs/ViewTestOutputButton.tsx
+++ b/app/src/components/evals/EvalContentTabs/ViewTestOutputButton.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@chakra-ui/react";
+import Link from "next/link";
+
+import { useDatasetEval } from "~/utils/hooks";
+import { constructVisibleModelIdsQueryParams } from "~/components/datasets/DatasetContentTabs/Evaluation/useVisibleModelIds";
+import { constructVisibleEvalIdsQueryParams } from "~/components/datasets/DatasetContentTabs/Evaluation/useVisibleEvalIds";
+import { DATASET_EVALUATION_TAB_KEY } from "~/components/datasets/DatasetContentTabs/DatasetContentTabs";
+import { constructFiltersQueryParams } from "~/components/Filters/useFilters";
+import { EvaluationFiltersDefaultFields } from "~/types/shared.types";
+
+const ViewTestOutputButton = () => {
+  const datasetEval = useDatasetEval().data;
+
+  const visibleModelIdsQueryParams = constructVisibleModelIdsQueryParams(
+    datasetEval?.outputSources.map((outputSource) => outputSource.modelId) ?? [],
+  );
+
+  const visibleEvalIdsQueryParams = constructVisibleEvalIdsQueryParams([datasetEval?.id ?? ""]);
+
+  const filtersQueryParams = constructFiltersQueryParams([
+    {
+      id: Date.now().toString(),
+      field: EvaluationFiltersDefaultFields.EvalApplied,
+      comparator: "=",
+      value: datasetEval?.id ?? "",
+    },
+  ]);
+
+  if (!datasetEval) return null;
+
+  return (
+    <Button
+      as={Link}
+      variant="link"
+      colorScheme="blue"
+      href={{
+        pathname: "/datasets/[id]/[tab]",
+        query: {
+          id: datasetEval.datasetId,
+          tab: DATASET_EVALUATION_TAB_KEY,
+          ...visibleModelIdsQueryParams,
+          ...visibleEvalIdsQueryParams,
+          ...filtersQueryParams,
+        },
+      }}
+    >
+      View Output
+    </Button>
+  );
+};
+
+export default ViewTestOutputButton;

--- a/app/src/server/api/routers/datasetEvals.router.ts
+++ b/app/src/server/api/routers/datasetEvals.router.ts
@@ -53,25 +53,43 @@ export const datasetEvalsRouter = createTRPCRouter({
       .innerJoin("DatasetEntry as de", "de.id", "dede.datasetEntryId")
       .leftJoin("FineTune as ft", (join) => join.onRef(sql`ft.id::text`, "=", "deos.modelId"))
       .where("de.outdated", "=", false)
-      .where("dede.datasetEvalId", "=", input.id)
-      .select((eb) => [
-        "deos.modelId as modelId1",
-        "ft.slug as slug1",
-        eb.fn.avg<number>("der.score").as("winRate"),
-        sql<number>`count(case when der.score = 1 then 1 end)::int`.as("wins"),
-        sql<number>`count(case when der.score = .5 then 1 end)::int`.as("ties"),
-        sql<number>`count(case when der.score = 0 then 1 end)::int`.as("losses"),
-      ]);
+      .where("dede.datasetEvalId", "=", input.id);
 
-    const [leaderboard, headToHead] = await Promise.all([
-      resultsBaseQuery.groupBy(["modelId1", "slug1"]).orderBy("winRate", "desc").execute(),
+    const [leaderboard, headToHead, completionCount] = await Promise.all([
+      resultsBaseQuery
+        .select((eb) => [
+          "deos.modelId as modelId1",
+          "ft.slug as slug1",
+          eb.fn.avg<number>("der.score").as("winRate"),
+          sql<number>`count(case when der.score = 1 then 1 end)::int`.as("wins"),
+          sql<number>`count(case when der.score = .5 then 1 end)::int`.as("ties"),
+          sql<number>`count(case when der.score = 0 then 1 end)::int`.as("losses"),
+        ])
+        .groupBy(["modelId1", "slug1"])
+        .orderBy("winRate", "desc")
+        .execute(),
 
       resultsBaseQuery
         .innerJoin("DatasetEvalOutputSource as deos2", "deos2.id", "der.comparisonOutputSourceId")
         .leftJoin("FineTune as ft2", (join) => join.onRef(sql`ft2.id::text`, "=", "deos2.modelId"))
-        .select(["deos2.modelId as modelId2", "ft2.slug as slug2"])
+        .select((eb) => [
+          "deos.modelId as modelId1",
+          "ft.slug as slug1",
+          eb.fn.avg<number>("der.score").as("winRate"),
+          "deos2.modelId as modelId2",
+          "ft2.slug as slug2",
+        ])
         .groupBy(["modelId1", "slug1", "modelId2", "slug2"])
         .execute(),
+
+      resultsBaseQuery
+        .select([
+          sql<number>`count(case when der.status = 'COMPLETE' or der.status = 'ERROR' then 1 end)::int`.as(
+            "completedResults",
+          ),
+          sql<number>`count(*)::int`.as("totalResults"),
+        ])
+        .executeTakeFirst(),
     ]);
 
     return {
@@ -80,6 +98,11 @@ export const datasetEvalsRouter = createTRPCRouter({
       results: {
         leaderboard,
         headToHead,
+        completionCount: {
+          // divide by 2 because each comparison has two results
+          completedComparisons: (completionCount?.completedResults ?? 0) / 2,
+          totalComparisons: (completionCount?.totalResults ?? 0) / 2,
+        },
       },
     };
   }),

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -298,11 +298,11 @@ export const useFineTune = () => {
   return fineTune;
 };
 
-export const useDatasetEval = () => {
+export const useDatasetEval = (refetchInterval?: number) => {
   const router = useRouter();
   return api.datasetEvals.get.useQuery(
     { id: router.query.id as string },
-    { enabled: !!router.query.id },
+    { enabled: !!router.query.id, refetchInterval },
   );
 };
 


### PR DESCRIPTION
We now default to only showing the head-to-head evals.

Also, I added a button at the top right of the eval tabs that takes the user to the dataset evaluations view with filters applied such that only output relevant to that eval is visible.

Finally, we now show the number of complete comparisons and poll for updated results on the Results tab until all comparisons are complete.