### PR TITLE
Expand input drawer by default

### DIFF
--- a/app/src/components/InputDropdown.tsx
+++ b/app/src/components/InputDropdown.tsx
@@ -44,6 +44,7 @@ const InputDropdown = <T,>({
         <InputGroup
           cursor="pointer"
           w={getDisplayLabel(selectedOption).length * 9 + 110}
+          borderRadius={8}
           {...inputGroupProps}
         >
           <Input

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/InputEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/InputEditor.tsx
@@ -35,8 +35,8 @@ const InputEditor = ({
           Input Messages
         </Text>
         <Button variant="ghost" color="gray.500" onClick={() => setExpanded(!expanded)}>
-          <HStack spacing={0}>
-            <Text>{expanded ? "Collapse" : "Expand"}</Text>
+          <HStack spacing={1}>
+            <Text>{expanded ? "Hide" : "Show"}</Text>
             <Icon as={expanded ? FiChevronUp : FiChevronDown} boxSize={5} mt={0.5} />
           </HStack>
         </Button>

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/InputEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/InputEditor.tsx
@@ -16,7 +16,7 @@ const InputEditor = ({
   setInputMessagesToSave: (inputMessagesToSave: ChatCompletionMessageParam[]) => void;
   matchedRules?: RouterOutputs["datasetEntries"]["get"]["matchedRules"];
 }) => {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
 
   return (
     <VStack
@@ -36,7 +36,7 @@ const InputEditor = ({
         </Text>
         <Button variant="ghost" color="gray.500" onClick={() => setExpanded(!expanded)}>
           <HStack spacing={0}>
-            <Text>{expanded ? "Hide" : "Show"}</Text>
+            <Text>{expanded ? "Collapse" : "Expand"}</Text>
             <Icon as={expanded ? FiChevronUp : FiChevronDown} boxSize={5} mt={0.5} />
           </HStack>
         </Button>

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/OutputEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/OutputEditor.tsx
@@ -31,8 +31,8 @@ const OutputEditor = ({
           Output
         </Text>
         <Button variant="ghost" color="gray.500" onClick={() => setExpanded(!expanded)}>
-          <HStack spacing={0}>
-            <Text>{expanded ? "Collapse" : "Expand"}</Text>
+          <HStack spacing={1}>
+            <Text>{expanded ? "Hide" : "Show"}</Text>
             <Icon as={expanded ? FiChevronUp : FiChevronDown} boxSize={5} mt={0.5} />
           </HStack>
         </Button>

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/OutputEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/OutputEditor.tsx
@@ -32,7 +32,7 @@ const OutputEditor = ({
         </Text>
         <Button variant="ghost" color="gray.500" onClick={() => setExpanded(!expanded)}>
           <HStack spacing={0}>
-            <Text>{expanded ? "Hide" : "Show"}</Text>
+            <Text>{expanded ? "Collapse" : "Expand"}</Text>
             <Icon as={expanded ? FiChevronUp : FiChevronDown} boxSize={5} mt={0.5} />
           </HStack>
         </Button>

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/ToolsEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/ToolsEditor.tsx
@@ -30,8 +30,8 @@ const ToolsEditor = ({
           Tools
         </Text>
         <Button variant="ghost" color="gray.500" onClick={() => setExpanded(!expanded)}>
-          <HStack spacing={0}>
-            <Text>{expanded ? "Collapse" : "Expand"}</Text>
+          <HStack spacing={1}>
+            <Text>{expanded ? "Hide" : "Show"}</Text>
             <Icon as={expanded ? FiChevronUp : FiChevronDown} boxSize={5} mt={0.5} />
           </HStack>
         </Button>

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/ToolsEditor.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/ToolsEditor.tsx
@@ -31,7 +31,7 @@ const ToolsEditor = ({
         </Text>
         <Button variant="ghost" color="gray.500" onClick={() => setExpanded(!expanded)}>
           <HStack spacing={0}>
-            <Text>{expanded ? "Hide" : "Show"}</Text>
+            <Text>{expanded ? "Collapse" : "Expand"}</Text>
             <Icon as={expanded ? FiChevronUp : FiChevronDown} boxSize={5} mt={0.5} />
           </HStack>
         </Button>


### PR DESCRIPTION
Most of the time when you open a dataset entry, you want to see its input messages. Let's expand those by default.