### PR TITLE
Only show completed comparisons as completed

### DIFF
--- a/app/src/components/fineTunes/FineTunesTable.tsx
+++ b/app/src/components/fineTunes/FineTunesTable.tsx
@@ -39,7 +39,16 @@ const FineTunesTable = ({}) => {
                     </Link>
                   </Td>
                   <Td>{dayjs(fineTune.createdAt).format("MMMM D h:mm A")}</Td>
-                  <Td>{displayBaseModel(fineTune.baseModel)}</Td>
+                  <Td>
+                    <Text
+                      color="orange.500"
+                      fontWeight="bold"
+                      fontSize="xs"
+                      textTransform="uppercase"
+                    >
+                      {displayBaseModel(fineTune.baseModel)}
+                    </Text>
+                  </Td>
                   <Td>{fineTune.numTrainingEntries.toLocaleString()}</Td>
                   <Td>
                     <ViewDatasetButton

--- a/app/src/server/api/routers/datasetEvals.router.ts
+++ b/app/src/server/api/routers/datasetEvals.router.ts
@@ -84,7 +84,7 @@ export const datasetEvalsRouter = createTRPCRouter({
 
       resultsBaseQuery
         .select([
-          sql<number>`count(case when der.status = 'COMPLETE' or der.status = 'ERROR' then 1 end)::int`.as(
+          sql<number>`count(case when der.status = 'COMPLETE' then 1 end)::int`.as(
             "completedResults",
           ),
           sql<number>`count(*)::int`.as("totalResults"),


### PR DESCRIPTION
Previously, we were counting both completed and errored eval results as completed in the results tab counter. Now we'll only display the completed results.