### PR TITLE
Added: python QueryClient

### DIFF
--- a/client-libs/python/README.md
+++ b/client-libs/python/README.md
@@ -76,3 +76,18 @@ res = chain.invoke(
     {"query": "this is good"}
 )
 ```
+
+## Query client
+
+Query logged calls to process data in python.
+
+```python
+from openpipe.query_client import QueryClient, FilterCondition, QueryResponse
+
+client = QueryClient.create()
+res: QueryResponse = client.query_logged_calls(
+    filters=[
+        FilterCondition(field="chain_name", comparator="=", value="classify"),
+    ]
+)
+```

--- a/client-libs/python/openpipe/query_client/__init__.py
+++ b/client-libs/python/openpipe/query_client/__init__.py
@@ -1,0 +1,2 @@
+from .types import *
+from .client import QueryClient

--- a/client-libs/python/openpipe/query_client/client.py
+++ b/client-libs/python/openpipe/query_client/client.py
@@ -1,0 +1,41 @@
+from typing import Any, List, Optional
+
+from openpipe.api_client.client import AuthenticatedClient
+from openpipe.shared import configure_openpipe_client
+from .types import QueryResponse, FilterCondition
+
+
+class QueryClient:
+    def __init__(self, auth_client: AuthenticatedClient) -> None:
+        self._auth_client = auth_client
+
+    def query_logged_calls(
+        self, page: int = 1, pageSize: int = 10, filters: List[FilterCondition] = []
+    ) -> QueryResponse:
+        kwargs = {
+            "method": "post",
+            "url": "/query/logged-calls",
+            "json": {
+                "page": page,
+                "pageSize": pageSize,
+                "filters": list(map(lambda c: c.dict(), filters)),
+            },
+        }
+
+        response = self._auth_client.get_httpx_client().request(
+            **kwargs,
+        )
+        assert response.status_code == 200, response.text
+        return QueryResponse.parse_obj(response.json())
+
+    @staticmethod
+    def create(
+        api_key: Optional[str] = None, base_url: Optional[str] = None
+    ) -> "QueryClient":
+        openpipe_options = {}
+        if api_key:
+            openpipe_options["api_key"] = api_key
+        if base_url:
+            openpipe_options["base_url"] = base_url
+        auth_client = configure_openpipe_client(openpipe_options)
+        return QueryClient(auth_client=auth_client)

--- a/client-libs/python/openpipe/query_client/test_client.py
+++ b/client-libs/python/openpipe/query_client/test_client.py
@@ -1,0 +1,90 @@
+import pytest
+import json
+
+from typing import Any, Dict
+from httpx import Response
+
+from .client import QueryClient
+from .types import FilterCondition
+
+
+def test_sync_query_logged_calls():
+    mock_response_data = {
+        "calls": [
+            {
+                "id": "2a916e77-24c6-4aba-8487-0b1feeb8448b",
+                "requestedAt": "2023-12-14T07:09:58.233Z",
+                "receivedAt": "2023-12-14T07:09:59.689Z",
+                "reqPayload": {
+                    "n": 1,
+                    "model": "gpt-3.5-turbo",
+                    "stream": False,
+                    "messages": [
+                        {
+                            "role": "system",
+                            "content": "Classify user query into positive, negative or neutral.",
+                        },
+                        {"role": "user", "content": "this is good"},
+                    ],
+                    "temperature": 0.7,
+                },
+                "respPayload": {
+                    "id": "chatcmpl-8Va91m6BxoONTlUakBaVJXVYYKKGN",
+                    "model": "gpt-3.5-turbo-0613",
+                    "usage": {
+                        "total_tokens": 26,
+                        "prompt_tokens": 25,
+                        "completion_tokens": 1,
+                    },
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "Positive"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "created": 1702537799,
+                },
+                "inputTokens": 25,
+                "outputTokens": 1,
+                "cost": 3.95e-05,
+                "statusCode": 200,
+                "durationMs": 1456,
+                "model": "gpt-3.5-turbo",
+                "tags": {
+                    "chain_name": "classify",
+                    "any_key": "some",
+                    "$sdk": "python",
+                    "$sdk.version": "4.0.3",
+                },
+            },
+        ],
+        "count": 2,
+    }
+
+    auth_client = AuthClientMock(mock_response_data)
+    client = QueryClient(auth_client=auth_client)
+    resp = client.query_logged_calls(
+        filters=[
+            FilterCondition(field="chain_name", comparator="=", value="classify"),
+        ]
+    )
+    assert resp
+    assert len(resp.calls) == 1
+
+
+class ClientMock:
+    def __init__(self, mock_response_data: Dict[Any, Any]) -> None:
+        self.mock_response_data = mock_response_data
+
+    def request(self, **kwargs) -> Response:
+        return Response(status_code=200, content=json.dumps(self.mock_response_data))
+
+
+class AuthClientMock:
+    def __init__(self, mock_response_data: Dict[Any, Any]) -> None:
+        self.mock_response_data = mock_response_data
+
+    def get_httpx_client(self) -> ClientMock:
+        return ClientMock(self.mock_response_data)

--- a/client-libs/python/openpipe/query_client/types.py
+++ b/client-libs/python/openpipe/query_client/types.py
@@ -1,0 +1,65 @@
+import datetime
+
+from datetime import datetime
+from typing import Any, List, Optional
+from pydantic import BaseModel
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class Usage(BaseModel):
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+
+
+class Choice(BaseModel):
+    index: int
+    message: Message
+    finish_reason: str
+
+
+class ResponsePayload(BaseModel):
+    id: str
+    model: str
+    usage: Usage
+    object: str
+    choices: List[Choice]
+    created: int
+
+
+class RequestPayload(BaseModel):
+    n: int
+    model: str
+    stream: bool
+    messages: List[Message]
+    temperature: float
+
+
+class Call(BaseModel):
+    id: str
+    requestedAt: datetime
+    receivedAt: datetime
+    reqPayload: RequestPayload
+    respPayload: ResponsePayload
+    inputTokens: int
+    outputTokens: int
+    cost: float
+    statusCode: int
+    durationMs: int
+    model: str
+    tags: dict
+
+
+class QueryResponse(BaseModel):
+    calls: List[Call]
+    count: int
+
+
+class FilterCondition(BaseModel):
+    field: str
+    comparator: str
+    value: str


### PR DESCRIPTION
Rationale: Access logged calls from Python to create a dataset for further processing and advanced evaluation.

Example:
```python
from openpipe.query_client import QueryClient, FilterCondition, QueryResponse

client = QueryClient.create()
res: QueryResponse = client.query_logged_calls(
    filters=[
        FilterCondition(field="chain_name", comparator="=", value="classify"),
    ]
)
len(res.calls)
```