### PR TITLE
Make requestedAt and receivedAt optional

### DIFF
--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -195,6 +195,9 @@ export const v1ApiRouter = createOpenApiRouter({
     )
     .output(z.object({ status: z.union([z.literal("ok"), z.literal("error")]) }))
     .mutation(async ({ input, ctx }) => {
+      // Zod default messes up the generated OpenAPI spec, so we do it manually
+      if (!input.requestedAt) input.requestedAt = Date.now();
+
       const reqPayload = await reqValidator.spa(input.reqPayload);
       const respPayload = await respValidator.spa(input.respPayload);
 
@@ -226,7 +229,7 @@ export const v1ApiRouter = createOpenApiRouter({
           data: {
             id: newLoggedCallId,
             projectId: ctx.key.projectId,
-            requestedAt: new Date(input.requestedAt ?? Date.now()),
+            requestedAt: new Date(input.requestedAt),
             model,
             receivedAt: input.receivedAt ? new Date(input.receivedAt) : undefined,
             reqPayload: (input.reqPayload === null
@@ -237,10 +240,7 @@ export const v1ApiRouter = createOpenApiRouter({
               : input.respPayload) as Prisma.InputJsonValue,
             statusCode: input.statusCode,
             errorMessage: input.errorMessage,
-            durationMs:
-              input.requestedAt && input.receivedAt
-                ? input.receivedAt - input.requestedAt
-                : undefined,
+            durationMs: input.receivedAt ? input.receivedAt - input.requestedAt : undefined,
             inputTokens: usage?.inputTokens,
             outputTokens: usage?.outputTokens,
             cost: usage?.cost,

--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -179,7 +179,7 @@ export const v1ApiRouter = createOpenApiRouter({
     .input(
       z.object({
         requestedAt: z.number().describe("Unix timestamp in milliseconds"),
-        receivedAt: z.number().describe("Unix timestamp in milliseconds"),
+        receivedAt: z.number().optional().describe("Unix timestamp in milliseconds"),
         reqPayload: z.unknown().describe("JSON-encoded request payload"),
         respPayload: z.unknown().optional().describe("JSON-encoded response payload"),
         statusCode: z.number().optional().describe("HTTP status code of response"),
@@ -228,7 +228,7 @@ export const v1ApiRouter = createOpenApiRouter({
             projectId: ctx.key.projectId,
             requestedAt: new Date(input.requestedAt),
             model,
-            receivedAt: new Date(input.receivedAt),
+            receivedAt: input.receivedAt ? new Date(input.receivedAt) : undefined,
             reqPayload: (input.reqPayload === null
               ? Prisma.JsonNull
               : input.reqPayload) as Prisma.InputJsonValue,
@@ -237,7 +237,7 @@ export const v1ApiRouter = createOpenApiRouter({
               : input.respPayload) as Prisma.InputJsonValue,
             statusCode: input.statusCode,
             errorMessage: input.errorMessage,
-            durationMs: input.receivedAt - input.requestedAt,
+            durationMs: input.receivedAt ? input.receivedAt - input.requestedAt : undefined,
             inputTokens: usage?.inputTokens,
             outputTokens: usage?.outputTokens,
             cost: usage?.cost,

--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -178,7 +178,7 @@ export const v1ApiRouter = createOpenApiRouter({
     })
     .input(
       z.object({
-        requestedAt: z.number().describe("Unix timestamp in milliseconds"),
+        requestedAt: z.number().optional().describe("Unix timestamp in milliseconds"),
         receivedAt: z.number().optional().describe("Unix timestamp in milliseconds"),
         reqPayload: z.unknown().describe("JSON-encoded request payload"),
         respPayload: z.unknown().optional().describe("JSON-encoded response payload"),
@@ -226,7 +226,7 @@ export const v1ApiRouter = createOpenApiRouter({
           data: {
             id: newLoggedCallId,
             projectId: ctx.key.projectId,
-            requestedAt: new Date(input.requestedAt),
+            requestedAt: new Date(input.requestedAt ?? Date.now()),
             model,
             receivedAt: input.receivedAt ? new Date(input.receivedAt) : undefined,
             reqPayload: (input.reqPayload === null
@@ -237,7 +237,10 @@ export const v1ApiRouter = createOpenApiRouter({
               : input.respPayload) as Prisma.InputJsonValue,
             statusCode: input.statusCode,
             errorMessage: input.errorMessage,
-            durationMs: input.receivedAt ? input.receivedAt - input.requestedAt : undefined,
+            durationMs:
+              input.requestedAt && input.receivedAt
+                ? input.receivedAt - input.requestedAt
+                : undefined,
             inputTokens: usage?.inputTokens,
             outputTokens: usage?.outputTokens,
             cost: usage?.cost,

--- a/client-libs/openapi.json
+++ b/client-libs/openapi.json
@@ -1256,9 +1256,6 @@
                     "default": {}
                   }
                 },
-                "required": [
-                  "requestedAt"
-                ],
                 "additionalProperties": false
               }
             }

--- a/client-libs/openapi.json
+++ b/client-libs/openapi.json
@@ -1257,8 +1257,7 @@
                   }
                 },
                 "required": [
-                  "requestedAt",
-                  "receivedAt"
+                  "requestedAt"
                 ],
                 "additionalProperties": false
               }

--- a/client-libs/typescript/src/codegen/services/DefaultService.ts
+++ b/client-libs/typescript/src/codegen/services/DefaultService.ts
@@ -239,7 +239,7 @@ export class DefaultService {
             /**
              * Unix timestamp in milliseconds
              */
-            requestedAt: number;
+            requestedAt?: number;
             /**
              * Unix timestamp in milliseconds
              */

--- a/client-libs/typescript/src/codegen/services/DefaultService.ts
+++ b/client-libs/typescript/src/codegen/services/DefaultService.ts
@@ -243,7 +243,7 @@ export class DefaultService {
             /**
              * Unix timestamp in milliseconds
              */
-            receivedAt: number;
+            receivedAt?: number;
             /**
              * JSON-encoded request payload
              */


### PR DESCRIPTION
Users who want to upload request logs manually don't always have accurate `requestedAt` and `receivedAt` timestamps.