### PR TITLE
Accept azure messages in chat completion route

### DIFF
--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -12,10 +12,9 @@ import { prisma } from "~/server/db";
 import {
   chatCompletionInputReqPayload,
   chatCompletionOutput,
-  chatMessageAzure,
+  chatMessage,
   functionCallInput,
   functionsInput,
-  normalizeAzureMessage,
   toolChoiceInput,
   toolsInput,
 } from "~/types/shared.types";
@@ -89,7 +88,7 @@ export const v1ApiRouter = createOpenApiRouter({
           .optional()
           .describe("DEPRECATED. Use the top-level fields instead"),
         model: z.string().optional(),
-        messages: z.array(chatMessageAzure).optional(),
+        messages: z.array(chatMessage).optional(),
         function_call: functionCallInput,
         functions: functionsInput,
         tool_choice: toolChoiceInput,
@@ -107,10 +106,7 @@ export const v1ApiRouter = createOpenApiRouter({
       const inputPayload =
         "reqPayload" in input
           ? chatCompletionInputReqPayload.parse(input.reqPayload)
-          : chatCompletionInputReqPayload.parse({
-              ...input,
-              messages: input.messages ? input.messages.map(normalizeAzureMessage) : undefined,
-            });
+          : chatCompletionInputReqPayload.parse(input);
 
       const modelSlug = inputPayload.model.replace("openpipe:", "");
       const fineTune = await prisma.fineTune.findUnique({

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -121,7 +121,7 @@ export const chatMessage = z.union([
 // Account for Azure API differences
 const chatCompletionAssistantMessageParamSchemaAzure = z.object({
   role: z.literal("assistant"),
-  // Azure API doesn't return content for function calls
+  // Azure API doesn't return null content when returning a function call
   content: z.union([z.string(), z.null()]).optional(),
   function_call: functionCallOutput.optional(),
   tool_calls: toolCallsOutput.optional(),

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -93,7 +93,7 @@ const chatCompletionUserMessageParamSchema = z.object({
 
 const chatCompletionAssistantMessageParamSchema = z.object({
   role: z.literal("assistant"),
-  content: z.union([z.string(), z.null()]),
+  content: z.union([z.string(), z.null()]).default(null),
   function_call: functionCallOutput.optional(),
   tool_calls: toolCallsOutput.optional(),
 });
@@ -117,31 +117,6 @@ export const chatMessage = z.union([
   chatCompletionToolMessageParamSchema,
   chatCompletionFunctionMessageParamSchema,
 ]) satisfies z.ZodType<ChatCompletionMessageParam, any, any>;
-
-// Account for Azure API differences
-const chatCompletionAssistantMessageParamSchemaAzure = z.object({
-  role: z.literal("assistant"),
-  // Azure API doesn't return null content when returning a function call
-  content: z.union([z.string(), z.null()]).optional(),
-  function_call: functionCallOutput.optional(),
-  tool_calls: toolCallsOutput.optional(),
-});
-
-export const chatMessageAzure = z.union([
-  chatMessage,
-  chatCompletionAssistantMessageParamSchemaAzure,
-]);
-
-export const normalizeAzureMessage = (
-  azureMessage: z.infer<typeof chatMessageAzure>,
-): ChatCompletionMessageParam => {
-  if (azureMessage.role !== "assistant") return azureMessage as ChatCompletionMessageParam;
-
-  return {
-    ...azureMessage,
-    content: azureMessage.content ?? null,
-  };
-};
 
 export const chatCompletionMessage = chatCompletionAssistantMessageParamSchema;
 


### PR DESCRIPTION
The cleanest way to handle Azure's omission of the `content` field in function call messages is to clean assistant messages by setting content to null when we process the message. We're already doing this when converting request logs to dataset entries, but we also need to do this when accepting assistant messages as input to our `/chat-completions` route.