### PR TITLE
Fix test set entry generation for GPT-3.5 fine-tunes

### DIFF
--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -16,9 +16,10 @@ import {
   convertToolCallInputToFunctionInput,
   convertToolCallMessageToFunction,
 } from "~/server/utils/convertFunctionCalls";
+import { TypedFineTune } from "~/types/dbColumns.types";
 
 export async function getCompletion2(
-  fineTune: FineTune,
+  fineTune: TypedFineTune,
   input: ChatCompletionCreateParams,
 ): Promise<ChatCompletion> {
   if (fineTune.pipelineVersion < 1 || fineTune.pipelineVersion > 2) {
@@ -32,7 +33,7 @@ export async function getCompletion2(
   const prunedMessages = pruneInputMessages(input.messages, stringsToPrune);
   const prunedInput = { messages: prunedMessages, ...omit(input, "messages") };
 
-  if (fineTune.baseModel === "GPT_3_5_TURBO") {
+  if (fineTune.provider === "openai") {
     const model = fineTune.openaiModelId;
 
     if (!model) throw new Error("No OpenAI model ID found");

--- a/app/src/server/fineTuningProviders/types.ts
+++ b/app/src/server/fineTuningProviders/types.ts
@@ -3,8 +3,8 @@ import { supportedModels as openpipeModels } from "./openpipe/types";
 import { supportedModels as openaiModels } from "./openai/types";
 
 export const baseModel = z.discriminatedUnion("provider", [
-  z.object({ provider: z.literal("openai"), baseModel: openaiModels }).passthrough(),
-  z.object({ provider: z.literal("openpipe"), baseModel: openpipeModels }).passthrough(),
+  z.object({ provider: z.literal("openai"), baseModel: openaiModels }),
+  z.object({ provider: z.literal("openpipe"), baseModel: openpipeModels }),
 ]);
 
 export type BaseModel = z.infer<typeof baseModel>;

--- a/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
@@ -6,16 +6,19 @@ import { captureFineTuneTrainingFinished } from "~/utils/analytics/serverAnalyti
 
 // import dayjs duration
 import dayjs from "dayjs";
+import { typedFineTune } from "~/types/dbColumns.types";
 
 export const checkFineTuneStatus = defineTask({
   id: "checkFineTuneStatus",
   handler: async () => {
-    const trainingFineTunes = await prisma.fineTune.findMany({
-      where: {
-        status: { in: ["TRAINING"] },
-        modalTrainingJobId: { not: null },
-      },
-    });
+    const trainingFineTunes = await prisma.fineTune
+      .findMany({
+        where: {
+          status: { in: ["TRAINING"] },
+          provider: "openpipe",
+        },
+      })
+      .then((fts) => fts.map(typedFineTune));
 
     await Promise.all(
       trainingFineTunes.map(async (ft) => {

--- a/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkOpenaiFineTuneStatus.task.ts
@@ -4,25 +4,26 @@ import { prisma } from "~/server/db";
 import defineTask from "../defineTask";
 import { startTestJobs } from "~/server/utils/startTestJobs";
 import { captureFineTuneTrainingFinished } from "~/utils/analytics/serverAnalytics";
+import { typedFineTune } from "~/types/dbColumns.types";
 
 const runOnce = async () => {
-  const trainingOpenaiFineTunes = await prisma.fineTune.findMany({
-    where: {
-      status: {
-        in: ["TRAINING"],
+  const trainingOpenaiFineTunes = await prisma.fineTune
+    .findMany({
+      where: {
+        status: {
+          in: ["TRAINING"],
+        },
+        provider: "openai",
       },
-      openaiTrainingJobId: {
-        not: null,
-      },
-    },
-    include: {
-      project: {
-        include: {
-          apiKeys: true,
+      include: {
+        project: {
+          include: {
+            apiKeys: true,
+          },
         },
       },
-    },
-  });
+    })
+    .then((fts) => fts.map(typedFineTune));
 
   await Promise.all(
     trainingOpenaiFineTunes.map(async (fineTune) => {

--- a/app/src/types/dbColumns.types.test.ts
+++ b/app/src/types/dbColumns.types.test.ts
@@ -1,0 +1,25 @@
+import { assertType, expect, test } from "vitest";
+import { typedFineTune } from "./dbColumns.types";
+
+test("typedFineTune", () => {
+  // assertType<null>(typedFineTune(null));
+
+  // expect(typedFineTune(null)).toEqual(null);
+  expect(typedFineTune({ provider: "openpipe", baseModel: "meta-llama/Llama-2-7b-hf" })).toEqual({
+    provider: "openpipe",
+    baseModel: "meta-llama/Llama-2-7b-hf",
+  });
+
+  // Checks to make sure the provider and model match
+  expect(() =>
+    typedFineTune({ provider: "openai", baseModel: "meta-llama/Llama-2-7b-hf" }),
+  ).toThrow();
+
+  // const a = await prisma.fineTune.findUnique({ where: { id: "123" } });
+  // typedFineTune(a);
+
+  // Assure it passes through other types
+  assertType<{
+    duck: string;
+  }>(typedFineTune({ provider: "openpipe", baseModel: "meta-llama/Llama-2-7b-hf", duck: "quack" }));
+});

--- a/app/src/utils/utils.test.ts
+++ b/app/src/utils/utils.test.ts
@@ -1,0 +1,17 @@
+import { assertType, test } from "vitest";
+import { passThroughNulls } from "./utils";
+
+test("passThroughNulls", () => {
+  const square = passThroughNulls((input: number): number => input * 2);
+
+  assertType<null>(square(null));
+  assertType<number>(square(10));
+  assertType<number | null>(square(Math.random() > 0.1 ? 1 : null));
+
+  const identityFunction = <T>(input: T): T => input;
+
+  assertType<null>(passThroughNulls(identityFunction)(null));
+
+  // This doesn't work! Need to fix `passThroughNulls` to work with generics.
+  // assertType<number>(passThroughNulls(identityFunction)(10));
+});

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -23,3 +23,15 @@ export const ensureDefaultExport = <T>(module: T) => {
 };
 
 export const getEntries = <T extends object>(obj: T) => Object.entries(obj) as Entries<T>;
+
+export function passThroughNulls<T extends (arg: any) => any>(
+  func: T,
+): ((arg: null) => null) &
+  ((arg: NonNullable<Parameters<T>[0]>) => ReturnType<T>) &
+  ((arg: Parameters<T>[0] | null) => ReturnType<T> | null) {
+  return (arg: Parameters<T>[0] | null) => {
+    if (arg === null) return null;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return func(arg as NonNullable<Parameters<T>[0]>);
+  };
+}


### PR DESCRIPTION
My recent change accidentally broke generating test-set entries for GPT-3.5 fine tunes. This fixes that, and also tightens up the typing for fine tunes in general. Tightening the typing is actually what led me to discover the bug!