### PR TITLE
Sort fine-tunes just by date

### DIFF
--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -36,7 +36,6 @@ export const fineTunesRouter = createTRPCRouter({
             "numTrainingEntries",
           ),
         ])
-        .orderBy("d.createdAt", "desc")
         .orderBy("ft.createdAt", "desc")
         .execute();
 

--- a/trainer/src/trainer/main.py
+++ b/trainer/src/trainer/main.py
@@ -14,7 +14,7 @@ def cache_model_weights():
     snapshot_download("OpenPipe/mistral-ft-optimized-1218")
     snapshot_download("mistralai/Mistral-7B-v0.1")
     snapshot_download("meta-llama/Llama-2-7b-hf")
-    snapshot_download("meta-llama/Llama-2-13b-hf")
+    # snapshot_download("meta-llama/Llama-2-13b-hf")
 
     print("Model weights cached")
 


### PR DESCRIPTION
A user got confused because their newest fine tune was showing up low on the list because it was for an old dataset. Let's just sort the fine-tunes page by fine-tune date; if they want to see them grouped by dataset they can go to the datasets page.