### PR TITLE
Allow user to apply only certain pruning rules to a fine tune

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/DatasetContentTabs.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/DatasetContentTabs.tsx
@@ -6,6 +6,7 @@ import Settings from "./Settings/Settings";
 
 export const DATASET_GENERAL_TAB_KEY = "general";
 export const DATASET_EVALUATION_TAB_KEY = "evaluate";
+export const DATASET_SETTINGS_TAB_KEY = "settings";
 
 const tabs = [
   {
@@ -24,7 +25,7 @@ const tabs = [
     component: <Evaluation />,
   },
   {
-    key: "settings",
+    key: DATASET_SETTINGS_TAB_KEY,
     title: "Settings",
     component: <Settings />,
   },

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -102,9 +102,14 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
     if (disclosure.isOpen) {
       setSelectedBaseModel(visibleModels[0]);
       setModelSlug(humanId({ separator: "-", capitalize: false }));
-      setAppliedPruningRuleIds(pruningRules?.map((rule) => rule.id) ?? []);
     }
-  }, [disclosure.isOpen, pruningRules]);
+  }, [disclosure.isOpen]);
+
+  // Avoid resetting unrelated settings when pruning rules update
+  useEffect(
+    () => setAppliedPruningRuleIds(pruningRules?.map((rule) => rule.id) ?? []),
+    [pruningRules],
+  );
 
   const utils = api.useContext();
   const router = useRouter();
@@ -225,7 +230,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
                 >
                   <HStack>
                     <Text fontWeight="bold">Applied Pruning Rules</Text>{" "}
-                    <InfoCircle tooltipText="Use pruning rules to save tokens when sending inputs to your fine-tuned model." />
+                    <InfoCircle tooltipText="Use pruning rules to reduce the number of input token your fine-tuned model has to process." />
                   </HStack>
 
                   <VStack>

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -17,6 +17,8 @@ import {
   VStack,
   useDisclosure,
   type UseDisclosureReturn,
+  Collapse,
+  Checkbox,
 } from "@chakra-ui/react";
 import humanId from "human-id";
 import { useSession } from "next-auth/react";
@@ -24,6 +26,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { AiTwotoneThunderbolt } from "react-icons/ai";
+import { FiChevronUp, FiChevronDown } from "react-icons/fi";
 
 import ActionButton from "~/components/ActionButton";
 import InputDropdown from "~/components/InputDropdown";
@@ -40,9 +43,12 @@ import {
   useDatasetEntries,
   useHandledAsyncCallback,
   useIsMissingBetaAccess,
+  usePruningRules,
   useSelectedProject,
 } from "~/utils/hooks";
 import { getEntries } from "~/utils/utils";
+import InfoCircle from "~/components/InfoCircle";
+import { DATASET_SETTINGS_TAB_KEY } from "../DatasetContentTabs";
 
 const FineTuneButton = () => {
   const datasetEntries = useDatasetEntries().data;
@@ -74,12 +80,15 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const dataset = useDataset().data;
   const datasetEntries = useDatasetEntries().data;
   const selectedProject = useSelectedProject().data;
+  const pruningRules = usePruningRules().data;
 
   const session = useSession();
   const isMissingBetaAccess = useIsMissingBetaAccess();
 
   const [selectedBaseModel, setSelectedBaseModel] = useState<ProviderWithModel>(visibleModels[0]);
   const [modelSlug, setModelSlug] = useState(humanId({ separator: "-", capitalize: false }));
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [appliedPruningRuleIds, setAppliedPruningRuleIds] = useState<string[]>([]);
 
   const needsMissingOpenaiKey =
     !selectedProject?.condensedOpenAIKey && splitProvider(selectedBaseModel).provider === "openai";
@@ -93,8 +102,9 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
     if (disclosure.isOpen) {
       setSelectedBaseModel(visibleModels[0]);
       setModelSlug(humanId({ separator: "-", capitalize: false }));
+      setAppliedPruningRuleIds(pruningRules?.map((rule) => rule.id) ?? []);
     }
-  }, [disclosure.isOpen]);
+  }, [disclosure.isOpen, pruningRules]);
 
   const utils = api.useContext();
   const router = useRouter();
@@ -107,13 +117,14 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
       slug: modelSlug,
       baseModel: splitProvider(selectedBaseModel),
       datasetId: dataset.id,
+      pruningRuleIds: appliedPruningRuleIds,
     });
     if (maybeReportError(resp)) return;
 
     await utils.fineTunes.list.invalidate();
     await router.push({ pathname: "/fine-tunes" });
     disclosure.onClose();
-  }, [createFineTuneMutation, modelSlug, selectedBaseModel]);
+  }, [createFineTuneMutation, modelSlug, selectedBaseModel, appliedPruningRuleIds]);
 
   return (
     <Modal size={{ base: "xl", md: "2xl" }} {...disclosure}>
@@ -189,6 +200,73 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
                 . You'll receive an email at <b>{email}</b> when you're approved.
               </Text>
             )}
+            <VStack w="full" alignItems="flex-start" spacing={0}>
+              <Button
+                variant="unstyled"
+                color="blue.600"
+                onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
+              >
+                <HStack>
+                  <Text>Advanced Options</Text>
+                  <Icon as={showAdvancedOptions ? FiChevronUp : FiChevronDown} />
+                </HStack>
+              </Button>
+              <Collapse style={{ width: "100%" }} in={showAdvancedOptions} unmountOnExit={true}>
+                <VStack
+                  w="full"
+                  bgColor="orange.50"
+                  border="1px solid"
+                  borderColor="orange.300"
+                  borderRadius={4}
+                  p={4}
+                  alignItems="flex-start"
+                  pt={4}
+                  spacing={4}
+                >
+                  <HStack>
+                    <Text fontWeight="bold">Applied Pruning Rules</Text>{" "}
+                    <InfoCircle tooltipText="Use pruning rules to save tokens when sending inputs to your fine-tuned model." />
+                  </HStack>
+
+                  <VStack>
+                    {pruningRules?.map((rule, i) => (
+                      <Checkbox
+                        key={rule.id}
+                        colorScheme="orange"
+                        isChecked={appliedPruningRuleIds.includes(rule.id)}
+                        onChange={(e) =>
+                          setAppliedPruningRuleIds((ids) =>
+                            e.target.checked
+                              ? [...ids, rule.id]
+                              : ids.filter((id) => id !== rule.id),
+                          )
+                        }
+                      >
+                        <Text>Rule #{i + 1}</Text>
+                      </Checkbox>
+                    ))}
+                  </VStack>
+
+                  <Text>
+                    View available pruning rules or add a new one in your dataset's{" "}
+                    <Button
+                      variant="link"
+                      as={Link}
+                      colorScheme="blue"
+                      href={{
+                        pathname: `/datasets/[id]/[tab]`,
+                        query: { id: dataset?.id ?? "", tab: DATASET_SETTINGS_TAB_KEY },
+                      }}
+                      target="_blank"
+                      _hover={{ textDecor: "underline" }}
+                    >
+                      Settings
+                    </Button>{" "}
+                    tab.
+                  </Text>
+                </VStack>
+              </Collapse>
+            </VStack>
           </VStack>
         </ModalBody>
         <ModalFooter>

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -27,6 +27,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { AiTwotoneThunderbolt } from "react-icons/ai";
 import { FiChevronUp, FiChevronDown } from "react-icons/fi";
+import { type PruningRule } from "@prisma/client";
 
 import ActionButton from "~/components/ActionButton";
 import InputDropdown from "~/components/InputDropdown";
@@ -219,9 +220,9 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
               <Collapse style={{ width: "100%" }} in={showAdvancedOptions} unmountOnExit={true}>
                 <VStack
                   w="full"
-                  bgColor="orange.50"
+                  bgColor="gray.50"
                   border="1px solid"
-                  borderColor="orange.300"
+                  borderColor="gray.300"
                   borderRadius={4}
                   p={4}
                   alignItems="flex-start"
@@ -230,25 +231,24 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
                 >
                   <HStack>
                     <Text fontWeight="bold">Applied Pruning Rules</Text>{" "}
-                    <InfoCircle tooltipText="Use pruning rules to reduce the number of input token your fine-tuned model has to process." />
+                    <InfoCircle tooltipText="Use pruning rules to reduce the number of input tokens your fine-tuned model has to process." />
                   </HStack>
 
-                  <VStack>
+                  <VStack w="full" alignItems="flex-start">
                     {pruningRules?.map((rule, i) => (
-                      <Checkbox
+                      <PruningRuleOption
                         key={rule.id}
-                        colorScheme="orange"
-                        isChecked={appliedPruningRuleIds.includes(rule.id)}
-                        onChange={(e) =>
+                        index={i}
+                        rule={rule}
+                        selected={appliedPruningRuleIds.includes(rule.id)}
+                        toggleSelected={() =>
                           setAppliedPruningRuleIds((ids) =>
-                            e.target.checked
-                              ? [...ids, rule.id]
-                              : ids.filter((id) => id !== rule.id),
+                            appliedPruningRuleIds.includes(rule.id)
+                              ? ids.filter((id) => id !== rule.id)
+                              : [...ids, rule.id],
                           )
                         }
-                      >
-                        <Text>Rule #{i + 1}</Text>
-                      </Checkbox>
+                      />
                     ))}
                   </VStack>
 
@@ -292,5 +292,46 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
         </ModalFooter>
       </ModalContent>
     </Modal>
+  );
+};
+
+const PruningRuleOption = ({
+  index,
+  rule,
+  selected,
+  toggleSelected,
+}: {
+  index: number;
+  rule: Pick<PruningRule, "textToMatch">;
+  selected: boolean;
+  toggleSelected: () => void;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <VStack w="full" alignItems="flex-start" spacing={0}>
+      <HStack w="full" spacing={8}>
+        <Checkbox colorScheme="blue" isChecked={selected} onChange={toggleSelected}>
+          <Text>Rule #{index + 1}</Text>
+        </Checkbox>
+        <Button variant="unstyled" onClick={() => setExpanded(!expanded)}>
+          <HStack>
+            <Text>{expanded ? "Hide" : "Show"}</Text>
+            <Icon as={expanded ? FiChevronUp : FiChevronDown} />
+          </HStack>
+        </Button>
+      </HStack>
+      <Collapse style={{ width: "100%" }} in={expanded} unmountOnExit={true}>
+        <HStack
+          p={2}
+          bgColor="gray.100"
+          borderWidth={1}
+          borderRadius={4}
+          borderColor="gray.300"
+          w="full"
+        >
+          <Text as="i">"{rule.textToMatch}"</Text>
+        </HStack>
+      </Collapse>
+    </VStack>
   );
 };

--- a/app/src/modelProviders/fine-tuned/getCompletion-2.ts
+++ b/app/src/modelProviders/fine-tuned/getCompletion-2.ts
@@ -16,7 +16,7 @@ import {
   convertToolCallInputToFunctionInput,
   convertToolCallMessageToFunction,
 } from "~/server/utils/convertFunctionCalls";
-import { TypedFineTune } from "~/types/dbColumns.types";
+import { type TypedFineTune } from "~/types/dbColumns.types";
 
 export async function getCompletion2(
   fineTune: TypedFineTune,

--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -174,6 +174,7 @@ export const fineTunesRouter = createTRPCRouter({
                 fineTuneId: fineTune.id,
                 textToMatch: rule.textToMatch,
                 tokensInText: rule.tokensInText,
+                createdAt: rule.createdAt,
               },
             }),
           ),

--- a/app/src/server/utils/updatePruningRuleMatches.test.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.test.ts
@@ -1,10 +1,15 @@
-import { expect, it } from "vitest";
-import { type Prisma } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import { type DatasetEntrySplit, type Prisma } from "@prisma/client";
 import { type ChatCompletionMessageParam } from "openai/resources/chat";
 import { v4 as uuidv4 } from "uuid";
 
 import { prisma } from "~/server/db";
-import { updatePruningRuleMatches } from "./updatePruningRuleMatches";
+import { getStringsToPrune, pruneInputMessages } from "~/utils/pruningRules";
+import {
+  copyPruningRulesForFineTune,
+  insertTrainingDataPruningRuleMatches,
+  updatePruningRuleMatches,
+} from "./updatePruningRuleMatches";
 
 const input1: ChatCompletionMessageParam[] = [
   {
@@ -53,7 +58,11 @@ const createProject = async (datasetId: string) => {
 
 const datasetId = uuidv4();
 
-const createDatasetEntry = async (datasetId: string, messages: ChatCompletionMessageParam[]) => {
+const createDatasetEntry = async (
+  datasetId: string,
+  messages: ChatCompletionMessageParam[],
+  split: DatasetEntrySplit = "TRAIN",
+) => {
   return await prisma.datasetEntry.create({
     data: {
       messages: messages as unknown as Prisma.InputJsonValue,
@@ -61,7 +70,7 @@ const createDatasetEntry = async (datasetId: string, messages: ChatCompletionMes
       inputTokens: 0,
       outputTokens: 0,
       datasetId,
-      split: "TRAIN",
+      split,
       sortKey: "_",
       importId: "_",
       provenance: "UPLOAD",
@@ -75,6 +84,28 @@ const createPruningRule = async (datasetId: string, textToMatch: string) => {
       datasetId,
       textToMatch,
       tokensInText: 0,
+    },
+  });
+};
+
+const createFineTune = async (projectId: string, datasetId: string) => {
+  return await prisma.fineTune.create({
+    data: {
+      slug: "test",
+      baseModel: "OpenPipe/mistral-7b-1212",
+      projectId,
+      datasetId,
+      provider: "openai",
+      pipelineVersion: 2,
+    },
+  });
+};
+
+const createFineTuneTrainingEntry = async (fineTuneId: string, datasetEntryId: string) => {
+  return await prisma.fineTuneTrainingEntry.create({
+    data: {
+      fineTuneId,
+      datasetEntryId,
     },
   });
 };
@@ -120,4 +151,80 @@ it("matches string with newline", async () => {
       },
     }),
   ).toBe(1);
+});
+
+describe("fine tune pruning rules", () => {
+  it("matches basic string", async () => {
+    const project = await createProject(datasetId);
+
+    const [datasetEntry, rule] = await Promise.all([
+      createDatasetEntry(datasetId, input1),
+      createPruningRule(
+        datasetId,
+        "The user is testing multiple scenarios against the same prompt",
+      ),
+    ]);
+
+    await updatePruningRuleMatches(datasetId, new Date(0));
+
+    const fineTune = await createFineTune(project.id, datasetId);
+
+    await copyPruningRulesForFineTune(fineTune.id, [rule.id]);
+
+    expect(
+      await prisma.pruningRule.count({
+        where: {
+          fineTuneId: fineTune.id,
+        },
+      }),
+    ).toBe(1);
+
+    await createFineTuneTrainingEntry(fineTune.id, datasetEntry.id);
+
+    await insertTrainingDataPruningRuleMatches(fineTune.id);
+
+    // Make sure there are a total of 4 scenarios for exp2
+    expect(
+      await prisma.pruningRuleMatch.count({
+        where: {
+          pruningRule: {
+            fineTuneId: fineTune.id,
+          },
+        },
+      }),
+    ).toBe(1);
+  });
+
+  it("properly prunes input", async () => {
+    const project = await createProject(datasetId);
+
+    const [datasetEntry, rule] = await Promise.all([
+      createDatasetEntry(datasetId, input1),
+      createPruningRule(
+        datasetId,
+        "The user is testing multiple scenarios against the same prompt",
+      ),
+    ]);
+
+    await updatePruningRuleMatches(datasetId, new Date(0));
+
+    const fineTune = await createFineTune(project.id, datasetId);
+
+    await copyPruningRulesForFineTune(fineTune.id, [rule.id]);
+
+    await createFineTuneTrainingEntry(fineTune.id, datasetEntry.id);
+
+    await insertTrainingDataPruningRuleMatches(fineTune.id);
+
+    const stringsToPrune = await getStringsToPrune(fineTune.id);
+
+    expect(stringsToPrune).toEqual([
+      "The user is testing multiple scenarios against the same prompt",
+    ]);
+
+    const prunedMessages = pruneInputMessages(input1, stringsToPrune);
+
+    const manuallyPrunedContent = (input1[0]?.content as string).replace("The user is testing", "");
+    expect(prunedMessages[0]?.content).toEqual(manuallyPrunedContent);
+  });
 });

--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -50,7 +50,7 @@ export const updatePruningRuleMatches = async (
 
     const ruleTextToMatch = escapeLikeString(allPruningRules[i]?.textToMatch);
 
-    // Insert PruningRuleMatch entries based on a select statement
+    // Insert PruningRuleMatch entries
     await kysely
       .insertInto("PruningRuleMatch")
       .columns(["id", "pruningRuleId", "datasetEntryId"])
@@ -70,6 +70,53 @@ export const updatePruningRuleMatches = async (
           .select(() => [
             sql`uuid_generate_v4()`.as("id"),
             sql`${allPruningRules[i]?.id}`.as("pruningRuleId"),
+            "DatasetEntry.id as datasetEntryId",
+          ]),
+      )
+      .execute();
+  }
+};
+
+export const insertTrainingDataPruningRuleMatches = async (fineTuneId: string) => {
+  const pruningRules = await prisma.pruningRule.findMany({
+    where: {
+      fineTuneId,
+    },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  });
+
+  await prisma.pruningRuleMatch.deleteMany({
+    where: {
+      pruningRuleId: {
+        in: pruningRules.map((pr) => pr.id),
+      },
+    },
+  });
+
+  for (let i = 0; i < pruningRules.length; i++) {
+    let prunedInput = sql`CAST("DatasetEntry"."messages" AS TEXT)`;
+
+    // For each rule to update, find all the dataset entries with matching prompts, after previous rules have been applied
+    for (let j = 0; j < i; j++) {
+      prunedInput = sql`REPLACE(${prunedInput}, ${escapeString(pruningRules[j]?.textToMatch)}, '')`;
+    }
+
+    const ruleTextToMatch = escapeLikeString(pruningRules[i]?.textToMatch);
+
+    // Insert PruningRuleMatch entries
+    await kysely
+      .insertInto("PruningRuleMatch")
+      .columns(["id", "pruningRuleId", "datasetEntryId"])
+      .expression((eb) =>
+        eb
+          .selectFrom("FineTuneTrainingEntry")
+          .where("FineTuneTrainingEntry.fineTuneId", "=", fineTuneId)
+          .innerJoin("DatasetEntry", "FineTuneTrainingEntry.datasetEntryId", "DatasetEntry.id")
+          .where("DatasetEntry.outdated", "=", false)
+          .where(sql`${prunedInput} LIKE ${"%" + ruleTextToMatch + "%"}`)
+          .select(() => [
+            sql`uuid_generate_v4()`.as("id"),
+            sql`${pruningRules[i]?.id}`.as("pruningRuleId"),
             "DatasetEntry.id as datasetEntryId",
           ]),
       )

--- a/client-libs/typescript/src/codegen/services/DefaultService.ts
+++ b/client-libs/typescript/src/codegen/services/DefaultService.ts
@@ -71,7 +71,7 @@ export class DefaultService {
                     })> | 'null' | null);
                 } | {
                     role: 'assistant';
-                    content: (string | 'null' | null);
+                    content?: (string | 'null' | null);
                     function_call?: {
                         name: string;
                         arguments: string;
@@ -141,7 +141,7 @@ export class DefaultService {
                 })> | 'null' | null);
             } | {
                 role: 'assistant';
-                content: (string | 'null' | null);
+                content?: (string | 'null' | null);
                 function_call?: {
                     name: string;
                     arguments: string;
@@ -200,7 +200,7 @@ export class DefaultService {
             index: number;
             message: {
                 role: 'assistant';
-                content: (string | 'null' | null);
+                content?: (string | 'null' | null);
                 function_call?: {
                     name: string;
                     arguments: string;


### PR DESCRIPTION
It's useful to compare performance between models both with and without pruning rules. We'll now allow users to determine which pruning rules should be applied to the model they want to train.

Training modal:
<img width="811" alt="Screenshot 2023-12-18 at 4 04 37 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/1254b61d-00c8-4adc-af33-6ff617d1b94a">

