### PR TITLE
Show pruning rules in fine-tune general tab

### DIFF
--- a/app/src/components/fineTunes/FineTuneContentTabs/General/FineTunePruningRules.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/FineTunePruningRules.tsx
@@ -1,0 +1,53 @@
+import { VStack, Text, Heading, HStack } from "@chakra-ui/react";
+
+import { useFineTune } from "~/utils/hooks";
+import ContentCard from "~/components/ContentCard";
+
+const FineTunePruningRules = () => {
+  const fineTune = useFineTune().data;
+
+  if (!fineTune) return null;
+
+  const pruningRules = fineTune.pruningRules;
+
+  return (
+    <ContentCard>
+      <VStack spacing={8} alignItems="flex-start">
+        <Heading size="md" fontWeight="bold">
+          Pruning Rules
+        </Heading>
+        {fineTune.pruningRules.length ? (
+          <VStack spacing={4} w="full" alignItems="flex-start">
+            <Text as="i">
+              Future changes to pruning rules for the{" "}
+              <Text as="span" fontWeight="bold">
+                {fineTune.datasetName}
+              </Text>{" "}
+              dataset will not affect this model. The rule numbers provided below are specific to
+              this model, and are not guaranteed to match pruning rule numbers in the dataset view.
+            </Text>
+            {pruningRules.map((rule, index) => (
+              <VStack alignItems="flex-start" w="full" key={index}>
+                <Text fontWeight="bold">Rule #{index + 1}</Text>
+                <HStack
+                  backgroundColor="gray.50"
+                  borderColor="gray.200"
+                  borderWidth={1}
+                  borderRadius={4}
+                  p={2}
+                  w="full"
+                >
+                  <Text w="full">{rule.textToMatch}</Text>
+                </HStack>
+              </VStack>
+            ))}
+          </VStack>
+        ) : (
+          <Text as="i">This model has no pruning rules.</Text>
+        )}
+      </VStack>
+    </ContentCard>
+  );
+};
+
+export default FineTunePruningRules;

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/FineTunePruningRules.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/FineTunePruningRules.tsx
@@ -23,8 +23,9 @@ const FineTunePruningRules = () => {
               <Text as="span" fontWeight="bold">
                 {fineTune.datasetName}
               </Text>{" "}
-              dataset will not affect this model. The rule numbers provided below are specific to
-              this model, and are not guaranteed to match pruning rule numbers in the dataset view.
+              dataset will not affect <Text as="b">openpipe:{fineTune.slug}</Text>. The rule numbers
+              provided below are specific to this model, and may not match pruning rule numbers in
+              the dataset view.
             </Text>
             {pruningRules.map((rule, index) => (
               <VStack alignItems="flex-start" w="full" key={index}>

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -8,6 +8,7 @@ import { api } from "~/utils/api";
 import ViewEvaluationButton from "~/components/datasets/DatasetContentTabs/Evaluation/ViewEvaluationButton";
 import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 import { modelInfo } from "~/server/fineTuningProviders/supportedModels";
+import FineTunePruningRules from "./FineTunePruningRules";
 
 const General = () => {
   const fineTune = useFineTune().data;
@@ -59,10 +60,6 @@ const General = () => {
               )}
             </HStack>
             <HStack>
-              <Text w={180}>Pruning Rules</Text>
-              <Text color="gray.500">{fineTune.numPruningRules}</Text>
-            </HStack>
-            <HStack>
               <Text w={180}>Created At</Text>
               <Text color="gray.500">{dayjs(fineTune.createdAt).format("MMMM D h:mm A")}</Text>
             </HStack>
@@ -84,6 +81,7 @@ const General = () => {
             </HStack>
           </VStack>
         </ContentCard>
+        <FineTunePruningRules />
         <FineTuneDangerZone />
       </VStack>
     </VStack>

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -25,8 +25,8 @@ const General = () => {
   if (!fineTune) return null;
 
   return (
-    <VStack w="full" h="full" justifyContent="space-between" pb={12}>
-      <VStack w="full" alignItems="flex-start" spacing={4}>
+    <VStack w="full" h="full">
+      <VStack w="full" alignItems="flex-start" spacing={4} pb={12}>
         <ContentCard>
           <VStack w="full" alignItems="flex-start" spacing={4} bgColor="white">
             <Heading size="md" pb={4}>


### PR DESCRIPTION
After pruning rules have been applied to a fine-tuned model, users need a way to view them.

Fine tune general tab:
<img width="1792" alt="Screenshot 2023-12-18 at 5 44 13 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/b2c9a608-6ff9-45ae-875c-a42314d9871b">
