### PR TITLE
Fall back to gpt-4-1106-preview for long judgements

### DIFF
--- a/app/src/components/evals/EvalContentTabs/Settings/DeleteEvalDialog.tsx
+++ b/app/src/components/evals/EvalContentTabs/Settings/DeleteEvalDialog.tsx
@@ -11,11 +11,13 @@ import {
   Text,
   type UseDisclosureReturn,
 } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 
 import { useAppStore } from "~/state/store";
 import { api } from "~/utils/api";
 import { useDatasetEval, useHandledAsyncCallback } from "~/utils/hooks";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
+import { DATASET_EVALUATION_TAB_KEY } from "~/components/datasets/DatasetContentTabs/DatasetContentTabs";
 
 const DeleteEvalDialog = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const cancelRef = useRef<HTMLButtonElement>(null);
@@ -27,6 +29,8 @@ const DeleteEvalDialog = ({ disclosure }: { disclosure: UseDisclosureReturn }) =
 
   const utils = api.useContext();
 
+  const router = useRouter();
+
   const [onDeleteConfirm, deleteInProgress] = useHandledAsyncCallback(async () => {
     if (!selectedProjectId || !datasetEval?.id) return;
     const resp = await deleteMutation.mutateAsync({ id: datasetEval.id });
@@ -37,6 +41,11 @@ const DeleteEvalDialog = ({ disclosure }: { disclosure: UseDisclosureReturn }) =
     disclosure.onClose();
 
     await utils.datasetEvals.list.invalidate({ projectId: selectedProjectId });
+
+    await router.push({
+      pathname: "/datasets/[id]/[tab]",
+      query: { id: datasetEval.datasetId, tab: DATASET_EVALUATION_TAB_KEY },
+    });
   }, [deleteMutation, selectedProjectId, datasetEval?.id, disclosure.onClose]);
 
   if (!datasetEval) return null;

--- a/app/src/server/tasks/evaluateTestSetEntries.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntries.task.ts
@@ -16,6 +16,7 @@ import { isEqual, shuffle } from "lodash-es";
 import { chatCompletionMessage } from "~/types/shared.types";
 import { truthyFilter } from "~/utils/utils";
 import { calculateQueryDelay } from "./generateTestSetEntry.task";
+import { countOpenAIChatTokens } from "~/utils/countTokens";
 
 type EvalKey = {
   datasetEvalDatasetEntryId: string;
@@ -355,6 +356,12 @@ const constructJudgementInput = (
       role: "user",
       content: `Remember to pay attention to the user's instructions: ${instructions}`,
     });
+  }
+
+  const approximateTokens = countOpenAIChatTokens("gpt-4-0613", input.messages);
+
+  if (approximateTokens > 7168) {
+    input.model = "gpt-4-1106-preview";
   }
 
   return input;

--- a/app/src/server/tasks/evaluateTestSetEntries.task.ts
+++ b/app/src/server/tasks/evaluateTestSetEntries.task.ts
@@ -29,7 +29,7 @@ export type EvaluateTestSetEntriesJob = EvalKey & {
   numPreviousTries?: number;
 };
 
-const MAX_TRIES = 25;
+const MAX_TRIES = 50;
 
 export const evaluateTestSetEntries = defineTask<EvaluateTestSetEntriesJob>({
   id: "evaluateTestSetEntries",

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -31,7 +31,7 @@ export type GenerateTestSetEntryJob = {
 const MAX_TRIES = 25;
 
 const MIN_DELAY = 500; // milliseconds
-const MAX_DELAY = 15000; // milliseconds
+const MAX_DELAY = 30000; // milliseconds
 
 export function calculateQueryDelay(numPreviousTries: number): number {
   const baseDelay = Math.min(MAX_DELAY, MIN_DELAY * Math.pow(2, numPreviousTries));


### PR DESCRIPTION
While gpt-4-1106-preview has slightly worse performance than gpt-4-0613 as a judge, it's still pretty reliable and much cheaper than gpt-4-32k-0613. Let's fall back to gpt-4-1106-preview for evaluations that might exceed gpt-4-0613's context window.