### PR TITLE
Allow log exporting without beta permissions

### DIFF
--- a/app/src/components/requestLogs/ExportButton.tsx
+++ b/app/src/components/requestLogs/ExportButton.tsx
@@ -38,7 +38,6 @@ const ExportButton = () => {
         label="Export"
         icon={BiExport}
         isDisabled={!totalNumLogsSelected}
-        requireBeta
       />
       <ExportLogsModal disclosure={disclosure} />
     </>


### PR DESCRIPTION
Now that we've simplified the export process, any user should be able to export their logs.