### PR TITLE
Record successful calls with status 200

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -88,7 +88,7 @@
     "nextjs-routes": "^2.0.1",
     "nodemailer": "^6.9.4",
     "openai": "^4.17.1",
-    "openpipe": "0.6.5",
+    "openpipe": "0.6.6",
     "openpipe-dev": "workspace:^",
     "openskill": "^3.1.0",
     "pg": "^8.11.2",

--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -81,6 +81,7 @@ export const recordUsage = async ({
       reqPayload: inputPayload,
       respPayload: completion,
       tags,
+      statusCode: 200,
     });
   }
 };

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -71,7 +71,7 @@ test("simple openai content call", async () => {
   expect(lastLogged?.reqPayload).toMatchObject(payload);
   expect(completion).toMatchObject(lastLogged?.respPayload);
   expect(lastLogged?.tags).toMatchObject({ promptId: "simple openai content call" });
-});
+}, 10000);
 
 test("simple ft content call", async () => {
   const payload: ChatCompletionCreateParams = {

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -11,6 +11,7 @@ import mergeChunks from "./mergeChunks";
 
 dotenv.config();
 
+// const BASE_URL = "https://app.openpipe.ai/api/v1";
 // const BASE_URL = "https://app.openpipestage.com/api/v1";
 const BASE_URL = "http://localhost:3000/api/v1";
 

--- a/client-libs/typescript/src/openai/mergeChunks.ts
+++ b/client-libs/typescript/src/openai/mergeChunks.ts
@@ -25,9 +25,11 @@ export default function mergeChunks(
           ...c,
           delta: {
             ...c.delta,
-            function_call: {
-              ...c.delta.function_call,
-            },
+            function_call: c.delta.function_call
+              ? {
+                  ...c.delta.function_call,
+                }
+              : undefined,
             tool_calls: c.delta.tool_calls?.map((tc) => ({
               ...tc,
               function: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: ^4.17.1
         version: 4.17.1(encoding@0.1.13)
       openpipe:
-        specifier: 0.6.5
-        version: 0.6.5
+        specifier: 0.6.6
+        version: 0.6.6
       openpipe-dev:
         specifier: workspace:^
         version: link:../client-libs/typescript
@@ -7656,8 +7656,8 @@ packages:
       oidc-token-hash: 5.0.3
     dev: false
 
-  /openpipe@0.6.5:
-    resolution: {integrity: sha512-rYDdj8kLTDvo6wr8Iyo9VZsqnj5OW81mjbrcCpqrPU5F2Kd6nxkOFh/oUktuhR33HdBDaFzQ8VMBLxeDbSVMAg==}
+  /openpipe@0.6.6:
+    resolution: {integrity: sha512-9CV7v/cCrIr3qY5q0+Btj0AOGm3BGMuH5NbBER3j1EB0h/fiBRJWrRpdEdLD8y5YqvlqmA2tgFh/qpZMzX6Qkg==}
     dependencies:
       encoding: 0.1.13
       form-data: 4.0.0


### PR DESCRIPTION
We now correctly report calls created on our /chat/completions route, but I forgot to record a successful status along with the call. This PR fixes that mistake.