### PR TITLE
Add copiable code block to ft page

### DIFF
--- a/app/src/components/FormattedJson.tsx
+++ b/app/src/components/FormattedJson.tsx
@@ -1,29 +1,14 @@
-import { Box, IconButton, useToast } from "@chakra-ui/react";
+import { Box, IconButton } from "@chakra-ui/react";
 import { CopyIcon } from "lucide-react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { atelierCaveLight } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import stringify from "json-stringify-pretty-compact";
 
+import { useCopyToClipboard } from "~/utils/useCopyToClipboard";
+
 const FormattedJson = ({ json }: { json: any }) => {
   const jsonString = stringify(json, { maxLength: 40 });
-  const toast = useToast();
-
-  const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      toast({
-        title: "Copied to clipboard",
-        status: "success",
-        duration: 2000,
-      });
-    } catch (err) {
-      toast({
-        title: "Failed to copy to clipboard",
-        status: "error",
-        duration: 2000,
-      });
-    }
-  };
+  const copyToClipboard = useCopyToClipboard();
 
   return (
     <Box position="relative" fontSize="sm" borderRadius="md" overflow="hidden">

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -92,9 +92,11 @@ const General = () => {
         <FineTunePruningRules />
         <FineTuneDangerZone />
       </VStack>
-      <Box position="sticky" top={8} pl={{ base: 0, md: 8 }}>
-        <InferenceCodeTabs />
-      </Box>
+      {fineTune.status === "DEPLOYED" && (
+        <Box position="sticky" top={8} pl={{ base: 0, md: 8 }}>
+          <InferenceCodeTabs />
+        </Box>
+      )}
     </Flex>
   );
 };

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -1,4 +1,4 @@
-import { VStack, HStack, Text, Button, Heading } from "@chakra-ui/react";
+import { VStack, HStack, Text, Button, Heading, Box, Flex } from "@chakra-ui/react";
 import { useFineTune, useHandledAsyncCallback } from "~/utils/hooks";
 import ContentCard from "~/components/ContentCard";
 import FineTuneDangerZone from "./FineTuneDangerZone";
@@ -9,6 +9,7 @@ import ViewEvaluationButton from "~/components/datasets/DatasetContentTabs/Evalu
 import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 import { modelInfo } from "~/server/fineTuningProviders/supportedModels";
 import FineTunePruningRules from "./FineTunePruningRules";
+import InferenceCodeTabs from "./InferenceCodeTabs/InferenceCodeTabs";
 
 const General = () => {
   const fineTune = useFineTune().data;
@@ -25,8 +26,15 @@ const General = () => {
   if (!fineTune) return null;
 
   return (
-    <VStack w="full" h="full">
-      <VStack w="full" alignItems="flex-start" spacing={4} pb={12}>
+    <Flex
+      h="fit-content"
+      position="relative"
+      w="full"
+      alignItems="flex-start"
+      pb={12}
+      flexDir={{ base: "column", md: "row" }}
+    >
+      <VStack w="full" alignItems="flex-start" spacing={4}>
         <ContentCard>
           <VStack w="full" alignItems="flex-start" spacing={4} bgColor="white">
             <Heading size="md" pb={4}>
@@ -84,7 +92,10 @@ const General = () => {
         <FineTunePruningRules />
         <FineTuneDangerZone />
       </VStack>
-    </VStack>
+      <Box position="sticky" top={8} pl={{ base: 0, md: 8 }}>
+        <InferenceCodeTabs />
+      </Box>
+    </Flex>
   );
 };
 

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import {
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  HStack,
+  IconButton,
+  useToast,
+  Text,
+  Tooltip,
+} from "@chakra-ui/react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { tomorrowNightBright } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { CopyIcon } from "lucide-react";
+
+export type CodeTab = {
+  title: string;
+  code: string;
+  language: string;
+};
+
+const CopiableCodeTabs = ({ tabs }: { tabs: CodeTab[] }) => {
+  const [tabIndex, setTabIndex] = useState(0);
+
+  const toast = useToast();
+
+  const copyToClipboard = async (text?: string) => {
+    try {
+      await navigator.clipboard.writeText(text as string);
+      toast({
+        title: "Copied to clipboard",
+        status: "success",
+        duration: 2000,
+      });
+    } catch (err) {
+      toast({
+        title: "Failed to copy to clipboard",
+        status: "error",
+        duration: 2000,
+      });
+    }
+  };
+
+  return (
+    <Tabs
+      index={tabIndex}
+      onChange={setTabIndex}
+      variant="unstyled"
+      colorScheme="blue"
+      bgColor="black"
+      borderTopLeftRadius={4}
+      borderTopRightRadius={4}
+      overflowY="hidden"
+      minW={600}
+    >
+      <HStack w="full" justifyContent="space-between">
+        <TabList>
+          {tabs.map((tab, i) => (
+            <StyledTab key={i} title={tab.title} />
+          ))}
+        </TabList>
+        <Tooltip label="Copy" placement="bottom" bgColor="orange.500" borderRadius={8}>
+          <IconButton
+            aria-label="Copy"
+            icon={<CopyIcon />}
+            size="xs"
+            marginRight={4}
+            bgColor="transparent"
+            color="gray.500"
+            _hover={{
+              color: "white",
+            }}
+            onClick={() => void copyToClipboard(tabs[tabIndex]?.code)}
+          />
+        </Tooltip>
+      </HStack>
+      <TabPanels bgColor="white">
+        {tabs.map((tab, i) => (
+          <TabPanel key={i} p={0} maxW={600} overflow="auto" bgColor="gray.900">
+            <CodeBlock code={tab.code} language={tab.language} />
+          </TabPanel>
+        ))}
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+const StyledTab = ({ title }: { title: string }) => {
+  const [isHovered, setIsHovered] = useState(false);
+  return (
+    <Tab
+      color="white"
+      borderColor="black"
+      borderBottomWidth={1}
+      _selected={{ color: "orange.500", borderColor: "orange.500" }}
+      _hover={{ color: "orange.500" }}
+      transition={"all 0s"}
+      px={4}
+      py={3}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Text py={0.5} px={2} borderRadius={8} bgColor={isHovered ? "gray.700" : undefined}>
+        {title}
+      </Text>
+    </Tab>
+  );
+};
+
+const CodeBlock = ({ code, language }: { code: string; language: string }) => {
+  return (
+    <SyntaxHighlighter
+      language={language}
+      style={tomorrowNightBright}
+      customStyle={{
+        backgroundColor: "#171923",
+        padding: "32px",
+      }}
+    >
+      {code}
+    </SyntaxHighlighter>
+  );
+};
+
+export default CopiableCodeTabs;

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import SyntaxHighlighter from "react-syntax-highlighter";
-import { tomorrowNightBright } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { srcery } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import { CopyIcon } from "lucide-react";
 
 import { useCopyToClipboard } from "~/utils/useCopyToClipboard";
@@ -97,10 +97,11 @@ const CodeBlock = ({ code, language }: { code: string; language: string }) => {
   return (
     <SyntaxHighlighter
       language={language}
-      style={tomorrowNightBright}
+      style={srcery}
       customStyle={{
         backgroundColor: "#171923",
         padding: "32px",
+        fontSize: "14px",
       }}
     >
       {code}

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
@@ -7,13 +7,14 @@ import {
   TabPanel,
   HStack,
   IconButton,
-  useToast,
   Text,
   Tooltip,
 } from "@chakra-ui/react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightBright } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import { CopyIcon } from "lucide-react";
+
+import { useCopyToClipboard } from "~/utils/useCopyToClipboard";
 
 export type CodeTab = {
   title: string;
@@ -24,24 +25,7 @@ export type CodeTab = {
 const CopiableCodeTabs = ({ tabs }: { tabs: CodeTab[] }) => {
   const [tabIndex, setTabIndex] = useState(0);
 
-  const toast = useToast();
-
-  const copyToClipboard = async (text?: string) => {
-    try {
-      await navigator.clipboard.writeText(text as string);
-      toast({
-        title: "Copied to clipboard",
-        status: "success",
-        duration: 2000,
-      });
-    } catch (err) {
-      toast({
-        title: "Failed to copy to clipboard",
-        status: "error",
-        duration: 2000,
-      });
-    }
-  };
+  const copyToClipboard = useCopyToClipboard();
 
   return (
     <Tabs

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/CopiableCodeTabs.tsx
@@ -34,8 +34,7 @@ const CopiableCodeTabs = ({ tabs }: { tabs: CodeTab[] }) => {
       variant="unstyled"
       colorScheme="blue"
       bgColor="black"
-      borderTopLeftRadius={4}
-      borderTopRightRadius={4}
+      borderRadius="md"
       overflowY="hidden"
       minW={600}
     >
@@ -45,7 +44,7 @@ const CopiableCodeTabs = ({ tabs }: { tabs: CodeTab[] }) => {
             <StyledTab key={i} title={tab.title} />
           ))}
         </TabList>
-        <Tooltip label="Copy" placement="bottom" bgColor="orange.500" borderRadius={8}>
+        <Tooltip label="Copy" placement="bottom" bgColor="blue.500" borderRadius={8}>
           <IconButton
             aria-label="Copy"
             icon={<CopyIcon />}
@@ -78,8 +77,8 @@ const StyledTab = ({ title }: { title: string }) => {
       color="white"
       borderColor="black"
       borderBottomWidth={1}
-      _selected={{ color: "orange.500", borderColor: "orange.500" }}
-      _hover={{ color: "orange.500" }}
+      _selected={{ color: "blue.500", borderColor: "blue.500" }}
+      _hover={{ color: "blue.500" }}
       transition={"all 0s"}
       px={4}
       py={3}

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+
+import { type RouterOutputs } from "~/utils/api";
+import { useFineTune, useSelectedProject, useTrainingEntries } from "~/utils/hooks";
+import CopiableCodeTabs, { type CodeTab } from "./CopiableCodeTabs";
+
+const baseTabs: CodeTab[] = [
+  {
+    title: "cURL",
+    language: "bash",
+    code: `curl --request POST \\
+--url https://app.openpipe.ai/api/v1/chat/completions \\
+--header 'Authorization: Bearer {{TEMPLATED_OPENPIPE_API_KEY}}' \\
+--header 'Content-Type: application/json' \\
+--data '{
+"model": "openpipe:{{FINE_TUNE_MODEL_SLUG}}",
+"messages": {{TEMPLATED_MESSAGES}},
+"tool_choice": {{TEMPLATED_TOOL_CHOICE}},
+"tools": {{TEMPLATED_TOOLS}}
+}'`,
+  },
+  {
+    title: "Python",
+    language: "python",
+    code: `from openpipe import OpenAI
+
+client = OpenAI(
+  openpipe={"api_key": "{{TEMPLATED_OPENPIPE_API_KEY}}"}
+)
+
+completion = client.chat.completions.create(
+    model="openpipe:{{FINE_TUNE_MODEL_SLUG}}",
+    messages={{TEMPLATED_MESSAGES}},
+    tool_choice={{TEMPLATED_TOOL_CHOICE}},
+    tools={{TEMPLATED_TOOLS}},
+    openpipe={
+        "tags": {
+            "prompt_id": "counting",
+            "any_key": "any_value"
+        }
+    },
+)
+
+print(completion.choices[0].message)`,
+  },
+  {
+    title: "JavaScript",
+    language: "javascript",
+    code: `import OpenAI from "openpipe/openai";
+
+const client = new OpenAI({
+    openpipe: {
+        apiKey: "{{TEMPLATED_OPENPIPE_API_KEY}}",
+    }
+});
+
+const completion = await client.chat.completions.create({
+    model: "openpipe:{{FINE_TUNE_MODEL_SLUG}}",
+    messages: {{TEMPLATED_MESSAGES}},
+    tool_choice: {{TEMPLATED_TOOL_CHOICE}},
+    tools: {{TEMPLATED_TOOLS}},
+});
+
+console.log(completion?.choices[0]?.message);
+`,
+  },
+];
+
+const templateTabs = (
+  apiKey: string,
+  modelSlug: string,
+  entry?: RouterOutputs["datasetEntries"]["listTrainingEntries"]["entries"][number]["datasetEntry"],
+): CodeTab[] => {
+  let formattedMessages = "";
+
+  if (entry?.messages) {
+    const messages = entry.messages || [
+      {
+        role: "system",
+        content: "Count to 10",
+      },
+    ];
+    // add a tab to all but the first line
+    formattedMessages = JSON.stringify(messages, null, 4);
+  }
+
+  const formattedToolChoice = JSON.stringify(entry?.tool_choice ?? "auto", null, 4);
+
+  const formattedTools = JSON.stringify(entry?.tools ?? []);
+
+  return baseTabs.map((tab) => {
+    const templatedCode = tab.code;
+
+    const tabFormattedMessages =
+      tab.language === "bash"
+        ? formattedMessages.replace(/'/g, `'"'"'`)
+        : formattedMessages.replace(/\n/g, "\n    ");
+    const tabFormattedToolChoice =
+      tab.language === "bash"
+        ? formattedToolChoice.replace(/'/g, `'"'"'`)
+        : formattedToolChoice.replace(/\n/g, "\n    ");
+    const tabFormattedTools =
+      tab.language === "bash" ? formattedTools.replace(/'/g, `'"'"'`) : formattedTools;
+
+    return {
+      ...tab,
+      code: templatedCode
+        .replace("{{TEMPLATED_OPENPIPE_API_KEY}}", apiKey)
+        .replace("{{FINE_TUNE_MODEL_SLUG}}", modelSlug)
+        .replace("{{TEMPLATED_TOOL_CHOICE}}", tabFormattedToolChoice.replace(/`/g, "\\`"))
+        .replace("{{TEMPLATED_TOOLS}}", tabFormattedTools.replace(/`/g, "\\`"))
+        .replace("{{TEMPLATED_MESSAGES}}", tabFormattedMessages.replace(/`/g, "\\`")),
+    };
+  });
+};
+
+const InferenceCodeTabs = () => {
+  const project = useSelectedProject().data;
+  const fineTune = useFineTune().data;
+  const datasetEntries = useTrainingEntries().data;
+
+  const templatedTabs = useMemo(() => {
+    const entry = datasetEntries?.entries[0];
+
+    return templateTabs(project?.openpipeApiKey || "", fineTune?.slug || "", entry?.datasetEntry);
+  }, [project?.openpipeApiKey, fineTune?.slug, datasetEntries?.entries]);
+
+  return <CopiableCodeTabs tabs={templatedTabs} />;
+};
+
+export default InferenceCodeTabs;

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
@@ -22,7 +22,9 @@ const baseTabs: CodeTab[] = [
   {
     title: "Python",
     language: "python",
-    code: `from openpipe import OpenAI
+    code: `# pip install openpipe
+
+from openpipe import OpenAI
 
 client = OpenAI(
   openpipe={"api_key": "{{TEMPLATED_OPENPIPE_API_KEY}}"}
@@ -46,7 +48,9 @@ print(completion.choices[0].message)`,
   {
     title: "JavaScript",
     language: "javascript",
-    code: `import OpenAI from "openpipe/openai";
+    code: `// npm install openpipe
+
+import OpenAI from "openpipe/openai";
 
 const client = new OpenAI({
     openpipe: {

--- a/app/src/utils/useCopyToClipboard.ts
+++ b/app/src/utils/useCopyToClipboard.ts
@@ -1,0 +1,24 @@
+import { useToast } from "@chakra-ui/react";
+
+export const useCopyToClipboard = () => {
+  const toast = useToast();
+
+  const copyToClipboard = async (text?: string) => {
+    try {
+      await navigator.clipboard.writeText(text as string);
+      toast({
+        title: "Copied to clipboard",
+        status: "success",
+        duration: 2000,
+      });
+    } catch (err) {
+      toast({
+        title: "Failed to copy to clipboard",
+        status: "error",
+        duration: 2000,
+      });
+    }
+  };
+
+  return copyToClipboard;
+};


### PR DESCRIPTION
It's nice to be able to try out your fine-tuned model without digging through the docs on running inference. Let's include a copiable code block that provides runnable code in `cURL`, `Python`, and `Javascript` form.

Fine Tune General tab:
<img width="1792" alt="Screenshot 2023-12-27 at 2 25 33 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/22b6e1b2-2c36-4294-8da0-a7fa5954171b">
