### PR TITLE
Access control tweaks

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/AddEvalModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/AddEvalModal.tsx
@@ -35,7 +35,7 @@ import { useFilters } from "~/components/Filters/useFilters";
 import InfoCircle from "~/components/InfoCircle";
 import { getOutputTitle } from "~/server/utils/getOutputTitle";
 import { ProjectLink } from "~/components/ProjectLink";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const mutation = api.datasetEvals.create.useMutation();
@@ -43,7 +43,7 @@ const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
 
   const selectedProject = useSelectedProject().data;
   const needsMissingOpenaiKey = !selectedProject?.condensedOpenAIKey;
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   const dataset = useDataset().data;
   const testingCount = useDatasetEntries().data?.totalTestingCount;
@@ -233,7 +233,7 @@ const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
             <Button colorScheme="gray" onClick={disclosure.onClose} minW={24}>
               Cancel
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="blue"
                 onClick={onCreationConfirm}
@@ -249,7 +249,7 @@ const AddEvalModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
               >
                 Create
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </HStack>
         </ModalFooter>
       </ModalContent>

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ConfigureComparisonModelsModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ConfigureComparisonModelsModal.tsx
@@ -28,14 +28,14 @@ import { useVisibleModelIds } from "./useVisibleModelIds";
 import { comparisonModels } from "~/utils/comparisonModels";
 import { getOutputTitle } from "~/server/utils/getOutputTitle";
 import { ProjectLink } from "~/components/ProjectLink";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const ConfigureComparisonModelsModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const dataset = useDataset().data;
 
   const selectedProject = useSelectedProject().data;
   const needsMissingOpenaiKey = !selectedProject?.condensedOpenAIKey;
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   const mutation = api.datasets.update.useMutation();
   const utils = api.useContext();
@@ -156,7 +156,7 @@ const ConfigureComparisonModelsModal = ({ disclosure }: { disclosure: UseDisclos
             <Button isDisabled={updateInProgress} onClick={reset}>
               Reset
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="orange"
                 ml={3}
@@ -170,7 +170,7 @@ const ConfigureComparisonModelsModal = ({ disclosure }: { disclosure: UseDisclos
               >
                 Confirm
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </ModalFooter>
         </ModalContent>
       </ModalOverlay>

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/DatasetEntryDrawer.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntryDrawer/DatasetEntryDrawer.tsx
@@ -30,7 +30,7 @@ import useKeepScrollAtBottom from "./useKeepScrollAtBottom";
 import InputEditor from "./InputEditor";
 import ToolsEditor from "./ToolsEditor";
 import OutputEditor from "./OutputEditor";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const CONTAINER_ID = "drawer-container";
 const CONTENT_ID = "drawer-content";
@@ -57,7 +57,7 @@ function DatasetEntryDrawer({
   );
   const [historyVisible, setHistoryVisible] = useState(false);
 
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   useEffect(() => {
     if (savedInputMessages && savedOutputMessage) {
@@ -132,12 +132,12 @@ function DatasetEntryDrawer({
             <HStack w="full" justifyContent="space-between" pr={12}>
               <Heading size="md">Dataset Entry</Heading>
               {datasetEntry && (
-                <AccessControl
-                  accessLevel="requireCanModifyProject"
+                <AccessCheck
+                  check="requireCanModifyProject"
                   accessDeniedText="Only project members can modify the training split of a dataset entry"
                 >
                   <EntrySplitDropdown split={datasetEntry.split} onChange={onUpdateSplit} />
-                </AccessControl>
+                </AccessCheck>
               )}
             </HStack>
           </VStack>
@@ -221,7 +221,7 @@ function DatasetEntryDrawer({
             >
               Reset
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 isLoading={savingInProgress}
                 isDisabled={isLoading || !hasUpdates || insufficientPermission}
@@ -230,7 +230,7 @@ function DatasetEntryDrawer({
               >
                 Save
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </HStack>
         </DrawerFooter>
       </DrawerContent>

--- a/app/src/components/datasets/DatasetContentTabs/General/DeleteButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DeleteButton.tsx
@@ -22,7 +22,7 @@ import { api } from "~/utils/api";
 import { useAppStore } from "~/state/store";
 import ActionButton from "~/components/ActionButton";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 
 const DeleteButton = () => {
   const selectedIds = useAppStore((s) => s.selectedDatasetEntries.selectedIds);
@@ -96,7 +96,7 @@ const DeleteDatasetEntriesModal = ({ disclosure }: { disclosure: UseDisclosureRe
             <Button colorScheme="gray" onClick={disclosure.onClose} minW={24}>
               Cancel
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="red"
                 onClick={deleteRows}
@@ -105,7 +105,7 @@ const DeleteDatasetEntriesModal = ({ disclosure }: { disclosure: UseDisclosureRe
               >
                 Delete
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </HStack>
         </ModalFooter>
       </ModalContent>

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -52,7 +52,7 @@ import { DATASET_SETTINGS_TAB_KEY } from "../DatasetContentTabs";
 import TrainingEntryMeter from "./TrainingEntryMeter";
 import { useFilters } from "~/components/Filters/useFilters";
 import { ProjectLink } from "~/components/ProjectLink";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const FineTuneButton = () => {
   const datasetEntries = useDatasetEntries().data;
@@ -101,7 +101,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
   const needsMissingBetaAccess =
     splitProvider(selectedBaseModel).provider === "openpipe" && isMissingBetaAccess;
 
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
   const numTrainingEntries = datasetEntries?.matchingTrainingCount || 0;
   const numTestingEntries = datasetEntries?.totalTestingCount || 0;
 
@@ -312,7 +312,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
             <Button colorScheme="gray" onClick={disclosure.onClose} minW={24}>
               Cancel
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="orange"
                 onClick={createFineTune}
@@ -329,7 +329,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
               >
                 Start Training
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </HStack>
         </ModalFooter>
       </ModalContent>

--- a/app/src/components/datasets/DatasetContentTabs/General/RelabelButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/RelabelButton.tsx
@@ -25,7 +25,7 @@ import ActionButton from "~/components/ActionButton";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
 import { useFilters } from "~/components/Filters/useFilters";
 import { GeneralFiltersDefaultFields } from "~/types/shared.types";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 import { ProjectLink } from "~/components/ProjectLink";
 
 const RelabelButton = () => {
@@ -53,7 +53,7 @@ const RelabelDatasetEntriesDialog = ({ disclosure }: { disclosure: UseDisclosure
 
   const selectedProject = useSelectedProject().data;
   const needsMissingOpenaiKey = !selectedProject?.condensedOpenAIKey;
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   const mutation = api.datasetEntries.relabel.useMutation();
   const utils = api.useContext();
@@ -143,7 +143,7 @@ const RelabelDatasetEntriesDialog = ({ disclosure }: { disclosure: UseDisclosure
             >
               Cancel
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="orange"
                 ml={3}
@@ -157,7 +157,7 @@ const RelabelDatasetEntriesDialog = ({ disclosure }: { disclosure: UseDisclosure
               >
                 Confirm
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialogOverlay>

--- a/app/src/components/datasets/DatasetContentTabs/General/UploadDataButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/UploadDataButton.tsx
@@ -26,7 +26,7 @@ import { api } from "~/utils/api";
 import ActionButton from "~/components/ActionButton";
 import { uploadDatasetEntryFile } from "~/utils/azure/website";
 import { formatFileSize } from "~/utils/utils";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 import {
   type RowToImport,
   parseRowsToImport,
@@ -127,7 +127,7 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
 
   const selectedProjectId = useSelectedProject().data?.id;
 
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   const [sendJSONL, sendingInProgress] = useHandledAsyncCallback(async () => {
     if (!selectedProjectId || !dataset || !file) return;
@@ -289,7 +289,7 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
               >
                 Cancel
               </Button>
-              <AccessControl accessLevel="requireCanModifyProject">
+              <AccessCheck check="requireCanModifyProject">
                 <Button
                   colorScheme="orange"
                   onClick={sendJSONL}
@@ -299,7 +299,7 @@ const UploadDataModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) =>
                 >
                   Upload
                 </Button>
-              </AccessControl>
+              </AccessCheck>
             </HStack>
           </HStack>
         </ModalFooter>

--- a/app/src/components/datasets/DatasetContentTabs/Settings/DatasetDangerZone.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Settings/DatasetDangerZone.tsx
@@ -5,14 +5,14 @@ import { api } from "~/utils/api";
 import { DeleteDatasetButton } from "./DeleteDatasetButton";
 import ContentCard from "~/components/ContentCard";
 import { useDataset, useHandledAsyncCallback } from "~/utils/hooks";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const DatasetDangerZone = () => {
   const dataset = useDataset().data;
 
   const [datasetNameToSave, setDatasetNameToSave] = useState(dataset?.name);
 
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   useEffect(() => {
     setDatasetNameToSave(dataset?.name);
@@ -50,7 +50,7 @@ const DatasetDangerZone = () => {
                 placeholder="unique-id"
               />
             </InputGroup>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="orange"
                 onClick={onSaveName}
@@ -63,7 +63,7 @@ const DatasetDangerZone = () => {
               >
                 Save
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </HStack>
         </VStack>
         <VStack w="full" alignItems="flex-start" spacing={4}>

--- a/app/src/components/datasets/DatasetContentTabs/Settings/DeleteDatasetDialog.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Settings/DeleteDatasetDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { api } from "~/utils/api";
 
 import { useHandledAsyncCallback } from "~/utils/hooks";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 
 const DeleteDatasetDialog = ({
   datasetId,
@@ -54,7 +54,7 @@ const DeleteDatasetDialog = ({
             <Button ref={cancelRef} onClick={disclosure.onClose}>
               Cancel
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="red"
                 isLoading={deletionInProgress}
@@ -63,7 +63,7 @@ const DeleteDatasetDialog = ({
               >
                 Delete
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialogOverlay>

--- a/app/src/components/datasets/DatasetContentTabs/Settings/DeletePruningRuleDialog.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Settings/DeletePruningRuleDialog.tsx
@@ -12,7 +12,7 @@ import {
 
 import { api, type RouterOutputs } from "~/utils/api";
 import { useDataset, useHandledAsyncCallback } from "~/utils/hooks";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 
 const DeletePruningRuleDialog = ({
   rule,
@@ -55,7 +55,7 @@ const DeletePruningRuleDialog = ({
             <Button ref={cancelRef} onClick={disclosure.onClose}>
               Cancel
             </Button>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="red"
                 isLoading={deletionInProgress}
@@ -64,7 +64,7 @@ const DeletePruningRuleDialog = ({
               >
                 Delete
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialogOverlay>

--- a/app/src/components/datasets/DatasetContentTabs/Settings/EditablePruningRule.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Settings/EditablePruningRule.tsx
@@ -5,7 +5,7 @@ import { BsTrash } from "react-icons/bs";
 import { useDataset, useHandledAsyncCallback } from "~/utils/hooks";
 import { api, type RouterOutputs } from "~/utils/api";
 import AutoResizeTextArea from "~/components/AutoResizeTextArea";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 import DeletePruningRuleDialog from "./DeletePruningRuleDialog";
 
 type PruningRule = RouterOutputs["pruningRules"]["list"][0];
@@ -75,11 +75,11 @@ const EditablePruningRule = ({ index, rule }: { index: number; rule: PruningRule
               >
                 Reset
               </Button>
-              <AccessControl accessLevel="requireCanModifyProject">
+              <AccessCheck check="requireCanModifyProject">
                 <Button colorScheme="orange" isLoading={updatingRule} onClick={updateRule}>
                   Save
                 </Button>
-              </AccessControl>
+              </AccessCheck>
             </HStack>
           )}
         </HStack>

--- a/app/src/components/datasets/DatasetContentTabs/Settings/PruningRuleCreator.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Settings/PruningRuleCreator.tsx
@@ -4,7 +4,7 @@ import { VStack, HStack, Text, Button } from "@chakra-ui/react";
 import { api } from "~/utils/api";
 import { useHandledAsyncCallback, useDataset } from "~/utils/hooks";
 import AutoResizeTextArea from "~/components/AutoResizeTextArea";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 
 const PruningRuleCreator = ({ index }: { index: number }) => {
   const dataset = useDataset().data;
@@ -33,7 +33,7 @@ const PruningRuleCreator = ({ index }: { index: number }) => {
 
   if (!showEditor) {
     return (
-      <AccessControl accessLevel="requireCanModifyProject" w="full">
+      <AccessCheck check="requireCanModifyProject" w="full">
         <Button
           variant="outline"
           color="gray.500"
@@ -44,7 +44,7 @@ const PruningRuleCreator = ({ index }: { index: number }) => {
         >
           Add New Rule
         </Button>
-      </AccessControl>
+      </AccessCheck>
     );
   }
 

--- a/app/src/components/evals/EvalContentTabs/Settings/Settings.tsx
+++ b/app/src/components/evals/EvalContentTabs/Settings/Settings.tsx
@@ -15,7 +15,7 @@ import { getOutputTitle } from "~/server/utils/getOutputTitle";
 import ContentCard from "~/components/ContentCard";
 import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 import { DATASET_EVALUATION_TAB_KEY } from "~/components/datasets/DatasetContentTabs/DatasetContentTabs";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const Settings = () => {
   const utils = api.useContext();
@@ -27,7 +27,7 @@ const Settings = () => {
   const setComparisonCriteria = useAppStore(
     (state) => state.evaluationsSlice.setComparisonCriteria,
   );
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   const [name, setName] = useState("");
   const [instructions, setInstructions] = useState("");
@@ -242,7 +242,7 @@ const Settings = () => {
               />
             </VStack>
             <HStack alignSelf="flex-end">
-              <AccessControl accessLevel="requireCanModifyProject">
+              <AccessCheck check="requireCanModifyProject">
                 <Button
                   colorScheme="red"
                   variant="outline"
@@ -251,11 +251,11 @@ const Settings = () => {
                 >
                   Delete
                 </Button>
-              </AccessControl>
+              </AccessCheck>
               <Button colorScheme="gray" onClick={reset} minW={24}>
                 Reset
               </Button>
-              <AccessControl accessLevel="requireCanModifyProject">
+              <AccessCheck check="requireCanModifyProject">
                 <Button
                   colorScheme="blue"
                   onClick={onSaveConfirm}
@@ -272,7 +272,7 @@ const Settings = () => {
                 >
                   Save
                 </Button>
-              </AccessControl>
+              </AccessCheck>
             </HStack>
           </VStack>
         </ContentCard>

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/DeleteFineTuneDialog.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/DeleteFineTuneDialog.tsx
@@ -18,7 +18,7 @@ import {
 import { api } from "~/utils/api";
 import { useHandledAsyncCallback } from "~/utils/hooks";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 
 const DeleteFineTuneDialog = ({
   fineTuneId,
@@ -35,7 +35,7 @@ const DeleteFineTuneDialog = ({
 
   const mutation = api.fineTunes.delete.useMutation();
   const utils = api.useContext();
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   const [onDeleteConfirm, deletionInProgress] = useHandledAsyncCallback(async () => {
     if (!fineTuneId) return;
@@ -80,7 +80,7 @@ const DeleteFineTuneDialog = ({
               <Button ref={cancelRef} onClick={disclosure.onClose}>
                 Cancel
               </Button>
-              <AccessControl accessLevel="requireCanModifyProject">
+              <AccessCheck check="requireCanModifyProject">
                 <Button
                   colorScheme="red"
                   isDisabled={slugToDelete !== `openpipe:${fineTuneSlug}` || insufficientPermission}
@@ -89,7 +89,7 @@ const DeleteFineTuneDialog = ({
                 >
                   Delete
                 </Button>
-              </AccessControl>
+              </AccessCheck>
             </HStack>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/FineTuneDangerZone.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/FineTuneDangerZone.tsx
@@ -12,7 +12,7 @@ import {
 } from "@chakra-ui/react";
 
 import { useFineTune } from "~/utils/hooks";
-import AccessControl, { useAccessControl } from "~/components/AccessControl";
+import AccessCheck, { useAccessCheck } from "~/components/AccessControl";
 import UpdateFineTuneSlugDialog from "./UpdateFineTuneSlugDialog";
 import DeleteFineTuneButton from "./DeleteFineTuneButton";
 import ContentCard from "~/components/ContentCard";
@@ -23,7 +23,7 @@ const FineTuneDangerZone = () => {
 
   const dialogDisclosure = useDisclosure();
 
-  const insufficientPermission = !useAccessControl("requireCanModifyProject").data;
+  const insufficientPermission = !useAccessCheck("requireCanModifyProject").access;
 
   if (!fineTune) return null;
 
@@ -54,7 +54,7 @@ const FineTuneDangerZone = () => {
                 }}
               />
             </InputGroup>
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <Button
                 colorScheme="orange"
                 onClick={dialogDisclosure.onOpen}
@@ -63,7 +63,7 @@ const FineTuneDangerZone = () => {
               >
                 Save
               </Button>
-            </AccessControl>
+            </AccessCheck>
           </HStack>
         </VStack>
         <UpdateFineTuneSlugDialog

--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -8,7 +8,7 @@ import { api } from "~/utils/api";
 import ViewEvaluationButton from "~/components/datasets/DatasetContentTabs/Evaluation/ViewEvaluationButton";
 import ViewDatasetButton from "~/components/datasets/ViewDatasetButton";
 import { modelInfo } from "~/server/fineTuningProviders/supportedModels";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 import FineTunePruningRules from "./FineTunePruningRules";
 import InferenceCodeTabs from "./InferenceCodeTabs/InferenceCodeTabs";
 
@@ -81,11 +81,11 @@ const General = () => {
                 {fineTune.errorMessage && (
                   <>
                     <Text color="gray.500">{fineTune.errorMessage}</Text>
-                    <AccessControl accessLevel="requireCanModifyProject">
+                    <AccessCheck check="requireCanModifyProject">
                       <Button variant="outline" size="xs" onClick={handleRestartTraining}>
                         Restart Training
                       </Button>
-                    </AccessControl>
+                    </AccessCheck>
                   </>
                 )}
               </HStack>

--- a/app/src/components/projectSettings/OpenaiApiKeyDisplay.tsx
+++ b/app/src/components/projectSettings/OpenaiApiKeyDisplay.tsx
@@ -4,7 +4,7 @@ import { BsPlus } from "react-icons/bs";
 import { useSelectedProject } from "~/utils/hooks";
 import UpdateOpenaiApiKeyModal from "./UpdateOpenaiApiKeyModal";
 import RemoveOpenaiApiKeyDialog from "./RemoveOpenaiApiKeyDialog";
-import AccessControl from "../AccessControl";
+import AccessCheck from "../AccessControl";
 
 const OpenaiApiKeyDisplay = () => {
   const { data: selectedProject } = useSelectedProject();
@@ -18,7 +18,7 @@ const OpenaiApiKeyDisplay = () => {
         <HStack>
           <Text color="gray.500">SAVED KEY</Text>
           <Text fontWeight="bold">{selectedProject.condensedOpenAIKey}</Text>
-          <AccessControl accessLevel="requireCanModifyProject">
+          <AccessCheck check="requireCanModifyProject">
             <Button
               variant="unstyled"
               textDecoration="underline"
@@ -37,17 +37,17 @@ const OpenaiApiKeyDisplay = () => {
             >
               Remove
             </Button>
-          </AccessControl>
+          </AccessCheck>
         </HStack>
       ) : (
-        <AccessControl accessLevel="requireCanModifyProject">
+        <AccessCheck check="requireCanModifyProject">
           <Button onClick={updateModalDisclosure.onOpen}>
             <HStack>
               <Icon as={BsPlus} boxSize={6} mr={-1} />
               <Text>Add a Key</Text>
             </HStack>
           </Button>
-        </AccessControl>
+        </AccessCheck>
       )}
       <UpdateOpenaiApiKeyModal disclosure={updateModalDisclosure} />
       <RemoveOpenaiApiKeyDialog disclosure={removeModalDisclosure} />

--- a/app/src/components/projectSettings/ProjectUserTable.tsx
+++ b/app/src/components/projectSettings/ProjectUserTable.tsx
@@ -7,13 +7,13 @@ import { useHandledAsyncCallback, useSelectedProject } from "~/utils/hooks";
 import { RemoveProjectUserDialog, type ProjectUser } from "./RemoveProjectUserDialog";
 import { api } from "~/utils/api";
 import { maybeReportError } from "~/utils/errorHandling/maybeReportError";
-import { useAccessControl } from "../AccessControl";
+import { useAccessCheck } from "../AccessControl";
 
 const ProjectUserTable = () => {
   const selectedProject = useSelectedProject().data;
   const session = useSession().data;
 
-  const isAdmin = useAccessControl("requireIsProjectAdmin").data;
+  const isAdmin = useAccessCheck("requireIsProjectAdmin").access;
 
   const utils = api.useContext();
 

--- a/app/src/pages/p/[projectSlug]/datasets/index.tsx
+++ b/app/src/pages/p/[projectSlug]/datasets/index.tsx
@@ -2,7 +2,7 @@ import { VStack, HStack, Text } from "@chakra-ui/react";
 import AppShell from "~/components/nav/AppShell";
 import DatasetsTable from "~/components/datasets/DatasetsTable";
 import NewDatasetButton from "~/components/datasets/NewDatasetButton";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 
 export default function DatasetsPage() {
   return (
@@ -12,9 +12,9 @@ export default function DatasetsPage() {
           <Text fontSize="2xl" fontWeight="bold">
             Datasets
           </Text>
-          <AccessControl accessLevel="requireCanModifyProject">
+          <AccessCheck check="requireCanModifyProject">
             <NewDatasetButton />
-          </AccessControl>
+          </AccessCheck>
         </HStack>
         <DatasetsTable />
       </VStack>

--- a/app/src/pages/p/[projectSlug]/request-logs/index.tsx
+++ b/app/src/pages/p/[projectSlug]/request-logs/index.tsx
@@ -12,7 +12,7 @@ import { api } from "~/utils/api";
 import { useLoggedCalls } from "~/utils/hooks";
 import { useFilters } from "~/components/Filters/useFilters";
 import ToggleFiltersButton from "~/components/ToggleFiltersButton";
-import AccessControl from "~/components/AccessControl";
+import AccessCheck from "~/components/AccessControl";
 
 const spin = keyframes`
   from { transform: rotate(0deg); }
@@ -50,9 +50,9 @@ export default function LoggedCalls() {
             />
           </HStack>
           <HStack w="full" justifyContent="flex-end">
-            <AccessControl accessLevel="requireCanModifyProject">
+            <AccessCheck check="requireCanModifyProject">
               <AddToDatasetButton />
-            </AccessControl>
+            </AccessCheck>
             <ExportButton />
             <ColumnVisibilityDropdown />
             <ToggleFiltersButton defaultShown />

--- a/app/src/pages/p/[projectSlug]/settings/index.tsx
+++ b/app/src/pages/p/[projectSlug]/settings/index.tsx
@@ -25,8 +25,8 @@ import AutoResizeTextArea from "~/components/AutoResizeTextArea";
 import ProjectUserTable from "~/components/projectSettings/ProjectUserTable";
 import { InviteProjectUserModal } from "~/components/projectSettings/InviteProjectUserModal";
 import OpenaiApiKeyDisplay from "~/components/projectSettings/OpenaiApiKeyDisplay";
-import AccessControl from "~/components/AccessControl";
 import InfoCircle from "~/components/InfoCircle";
+import AccessCheck from "~/components/AccessControl";
 
 export default function Settings() {
   const utils = api.useContext();
@@ -87,7 +87,7 @@ export default function Settings() {
               <Text fontWeight="bold" fontSize="xl">
                 Display Name
               </Text>
-              <AccessControl accessLevel="requireCanModifyProject" hideTooltip w={600}>
+              <AccessCheck check="requireCanModifyProject" hideTooltip w={600}>
                 <AutoResizeTextArea
                   w="full"
                   maxW={600}
@@ -95,8 +95,8 @@ export default function Settings() {
                   onChange={(e) => setName(e.target.value)}
                   borderColor="gray.300"
                 />
-              </AccessControl>
-              <AccessControl accessLevel="requireCanModifyProject">
+              </AccessCheck>
+              <AccessCheck check="requireCanModifyProject">
                 <Button
                   isDisabled={!name || name === selectedProject?.name}
                   colorScheme="orange"
@@ -109,7 +109,7 @@ export default function Settings() {
                 >
                   Rename Project
                 </Button>
-              </AccessControl>
+              </AccessCheck>
             </VStack>
             <Divider backgroundColor="gray.300" />
             <VStack w="full" alignItems="flex-start">
@@ -120,8 +120,8 @@ export default function Settings() {
               <Box mt={4} w="full">
                 <ProjectUserTable />
               </Box>
-              <AccessControl
-                accessLevel="requireIsProjectAdmin"
+              <AccessCheck
+                check="requireIsProjectAdmin"
                 accessDeniedText="Only admins can invite new members"
                 w="fit-content"
               >
@@ -138,7 +138,7 @@ export default function Settings() {
                   <Icon as={BsPlus} boxSize={5} />
                   <Text>Invite New Member</Text>
                 </Button>
-              </AccessControl>
+              </AccessCheck>
             </VStack>
             <Divider backgroundColor="gray.300" />
             <VStack alignItems="flex-start">
@@ -193,7 +193,7 @@ export default function Settings() {
                 <Text fontSize="sm">
                   Permanently delete your project and all of its data. This action cannot be undone.
                 </Text>
-                <AccessControl accessLevel="requireIsProjectAdmin">
+                <AccessCheck check="requireIsProjectAdmin">
                   <HStack
                     as={Button}
                     colorScheme="red"
@@ -208,7 +208,7 @@ export default function Settings() {
                       Delete {selectedProject?.name}
                     </Text>
                   </HStack>
-                </AccessControl>
+                </AccessCheck>
               </VStack>
             )}
           </VStack>


### PR DESCRIPTION
Ok so first of all sorry for just kinda doing a drive-by on your PR. I had checked it out to experiment with ways to get more type safety into the hook/component for when we add more args besides `projectId` and it sort of spiraled from there. I didn't actually make any improvements on that front, but I did make some other changes that I think are useful:

1. Pull the `accessDeniedText` from the `TRPCError` message. This means we'll have better messaging when we deny API actions and can reuse that messaging in the user-facing buttons as well.
2. Rename `accessLevel` to `accessCheck`. I think this is a more intuitive name for the concept since access checks aren't really well-ordered as levels.