### PR TITLE
Record duration for requests to /chat/completions route

### DIFF
--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -106,6 +106,8 @@ export const v1ApiRouter = createOpenApiRouter({
       let completion: ChatCompletion | Stream<ChatCompletionChunk>;
       let fineTune: FineTune | undefined = undefined;
 
+      const requestedAt = Date.now();
+
       if (inputPayload.model.startsWith("openpipe:")) {
         const modelSlug = inputPayload.model.replace("openpipe:", "");
         fineTune =
@@ -178,6 +180,8 @@ export const v1ApiRouter = createOpenApiRouter({
         const [recordStream, outputStream] = completion.tee();
         void recordUsage({
           projectId: key.projectId,
+          requestedAt,
+          receivedAt: Date.now(),
           inputPayload,
           completion: recordStream,
           logRequest,
@@ -188,6 +192,8 @@ export const v1ApiRouter = createOpenApiRouter({
       } else {
         void recordUsage({
           projectId: key.projectId,
+          requestedAt,
+          receivedAt: Date.now(),
           inputPayload,
           completion,
           logRequest,

--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -21,6 +21,8 @@ import { type BaseModel } from "~/server/fineTuningProviders/types";
 
 export const recordUsage = async ({
   projectId,
+  requestedAt,
+  receivedAt,
   inputPayload,
   completion,
   logRequest,
@@ -28,6 +30,8 @@ export const recordUsage = async ({
   tags,
 }: {
   projectId: string;
+  requestedAt: number;
+  receivedAt: number;
   inputPayload: z.infer<typeof chatCompletionInput>;
   completion: unknown;
   logRequest?: boolean;
@@ -77,7 +81,8 @@ export const recordUsage = async ({
     await recordLoggedCall({
       projectId,
       usage,
-      requestedAt: Date.now(),
+      requestedAt,
+      receivedAt,
       reqPayload: inputPayload,
       respPayload: completion,
       tags,

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {

--- a/client-libs/typescript/src/openai.ts
+++ b/client-libs/typescript/src/openai.ts
@@ -108,7 +108,7 @@ class WrappedCompletions extends openai.OpenAI.Chat.Completions {
         headers: {
           ...options?.headers,
           "op-log-request": openpipe.logRequest ? "true" : "false",
-          "op-tags": JSON.stringify(openpipe.tags ?? {}),
+          "op-tags": JSON.stringify(getTags(openpipe)),
         },
       });
     }

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -8,6 +8,7 @@ import assert from "assert";
 import OpenAI from "../openai";
 import { OPClient } from "../codegen";
 import mergeChunks from "./mergeChunks";
+import { getTags } from "../shared";
 
 dotenv.config();
 
@@ -60,9 +61,10 @@ test("simple openai content call", async () => {
     model: "gpt-3.5-turbo",
     messages: [{ role: "system", content: "count to 3" }],
   };
+  const openpipeOptions = { tags: { promptId: "simple openai content call" } };
   const completion = await oaiClient.chat.completions.create({
     ...payload,
-    openpipe: { tags: { promptId: "simple openai content call" } },
+    openpipe: openpipeOptions,
   });
 
   await completion.openpipe?.reportingFinished;
@@ -70,7 +72,7 @@ test("simple openai content call", async () => {
   const lastLogged = await lastLoggedCall();
   expect(lastLogged?.reqPayload).toMatchObject(payload);
   expect(completion).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.tags).toMatchObject({ promptId: "simple openai content call" });
+  expect(lastLogged?.tags).toMatchObject(getTags(openpipeOptions));
 }, 10000);
 
 test("simple ft content call", async () => {
@@ -169,6 +171,7 @@ test("function call streaming", async () => {
     functions: [functionBody],
     stream: true,
   };
+  const openpipeOptions = { tags: { promptId: "function call streaming" } };
   const completion = await oaiClient.chat.completions.create({
     ...payload,
     openpipe: {


### PR DESCRIPTION
This change ensures request duration is always recorded for requests to the `/chat/completions` route.