### PR TITLE
Sort output based on the average score against only visible models

### DIFF
--- a/app/src/server/api/routers/datasetEntries.router.ts
+++ b/app/src/server/api/routers/datasetEntries.router.ts
@@ -576,7 +576,20 @@ export const datasetEntriesRouter = createTRPCRouter({
               eb
                 .selectFrom("DatasetEvalDatasetEntry as dede")
                 .where("dede.datasetEvalId", "=", sortOrder.evalId)
-                .leftJoin("DatasetEvalResult as der", "der.datasetEvalDatasetEntryId", "dede.id")
+                .leftJoin(
+                  (eb) =>
+                    eb
+                      .selectFrom("DatasetEvalResult as der")
+                      .innerJoin(
+                        "DatasetEvalOutputSource as comparisonDeos",
+                        "comparisonDeos.id",
+                        "der.comparisonOutputSourceId",
+                      )
+                      .where("comparisonDeos.modelId", "in", visibleModelIds)
+                      .selectAll("der")
+                      .as("der"),
+                  (join) => join.onRef("der.datasetEvalDatasetEntryId", "=", "dede.id"),
+                )
                 .leftJoin(
                   "DatasetEvalOutputSource as deos",
                   "deos.id",


### PR DESCRIPTION
Previously we were ordering the output based on the average score of a column of output compared against all other models included in the selected eval. Now we'll determine the output order based only on the scores relative to visible models.