### PR TITLE
Default stream to false

### DIFF
--- a/app/src/server/scripts/studio-prod.sh
+++ b/app/src/server/scripts/studio-prod.sh
@@ -9,4 +9,4 @@ source .env
 set +o allexport
 
 echo "Connecting to prod db"
-DATABASE_URL=$PROD_DATABASE_URL pnpm prisma studio
+DATABASE_URL=$PROD_DATABASE_URL pnpm prisma studio --port 5556

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -138,7 +138,7 @@ const chatCompletionInputStreaming = z.object({
 
 const chatCompletionInputNonStreaming = z.object({
   ...chatCompletionInputBase.shape,
-  stream: z.literal(false),
+  stream: z.literal(false).default(false),
 }) satisfies z.ZodType<ChatCompletionCreateParams, any, any>;
 
 export const chatCompletionInput = z.union([

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -122,7 +122,7 @@ test("base sdk ft content call", async () => {
   expect(lastLogged?.reqPayload).toMatchObject(payload);
   expect(completion.id).toMatchObject(lastLogged?.respPayload.id);
   expect(lastLogged?.tags).toMatchObject(tags);
-}, 10000);
+}, 100000);
 
 test("content streaming", async () => {
   const completion = await oaiClient.chat.completions.create({


### PR DESCRIPTION
Fixes a bug that occurred when validating request logs to be imported as dataset entries which didn't have stream explicitly set to true or false.