### PR TITLE
Add default values for newly required fields

### DIFF
--- a/app/src/pages/p/[projectSlug]/settings/index.tsx
+++ b/app/src/pages/p/[projectSlug]/settings/index.tsx
@@ -172,9 +172,10 @@ export default function Settings() {
             <VStack alignItems="flex-start">
               <Subtitle>OpenAI API Key</Subtitle>
               <Text fontSize="sm">
-                Add your OpenAI API key to fine-tune GPT-3.5 Turbo models through OpenPipe. This key
-                is not necessary to use OpenPipe with OpenAI base models such as GPT-4 or GPT-3.5
-                Turbo or fine-tuned Llama2 models.
+                Add your OpenAI API key to fine-tune GPT-3.5 Turbo models through OpenPipe, or to
+                run your OpenAI calls through OpenPipe servers. This key is not necessary to
+                asynchronously collect OpenAI logs or to run inference on fine-tuned Llama2 and
+                Mistral models.
               </Text>
             </VStack>
             <OpenaiApiKeyDisplay />

--- a/app/src/server/utils/comparatorToSqlExpression.ts
+++ b/app/src/server/utils/comparatorToSqlExpression.ts
@@ -30,11 +30,13 @@ export const dateComparatorToSqlExpression = (
   const [start, end] = value;
   let startDate: string;
   let endDate: string;
-  try {
-    startDate = new Date(start).toISOString();
-    endDate = new Date(end).toISOString();
-  } catch (e) {
-    throw new Error("Failed to parse start and end dates");
+  if (comparator === "BEFORE" || comparator === "AFTER" || comparator === "RANGE") {
+    try {
+      startDate = new Date(start).toISOString();
+      endDate = new Date(end).toISOString();
+    } catch (e) {
+      throw new Error("Failed to parse start and end dates");
+    }
   }
   return (reference: RawBuilder<unknown>): Expression<SqlBool> => {
     switch (comparator) {

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -46,8 +46,8 @@ export const toolChoiceInput = z
     z.literal("none"),
     z.literal("auto"),
     z.object({
-      type: z.literal("function"),
-      function: z.object({ name: z.string() }),
+      type: z.literal("function").default("function"),
+      function: z.object({ name: z.string() }).default({ name: "" }),
     }),
   ])
   .optional();
@@ -63,7 +63,7 @@ export const toolsInput = z
 
 const chatCompletionSystemMessageParamSchema = z.object({
   role: z.literal("system"),
-  content: z.string(),
+  content: z.string().default(""),
 });
 
 const chatCompletionContentPartSchema = z.union([
@@ -82,7 +82,7 @@ const chatCompletionContentPartSchema = z.union([
 
 const chatCompletionUserMessageParamSchema = z.object({
   role: z.literal("user"),
-  content: z.union([z.string(), z.array(chatCompletionContentPartSchema)]),
+  content: z.union([z.string(), z.array(chatCompletionContentPartSchema)]).default(""),
 });
 
 const chatCompletionAssistantMessageParamSchema = z.object({
@@ -94,7 +94,7 @@ const chatCompletionAssistantMessageParamSchema = z.object({
 
 const chatCompletionToolMessageParamSchema = z.object({
   role: z.literal("tool"),
-  content: z.string(),
+  content: z.string().default(""),
   tool_call_id: z.string(),
 });
 
@@ -186,7 +186,8 @@ export const chatCompletionOutput = z.object({
             )
             .nullable(),
         })
-        .nullable(),
+        .nullable()
+        .default(null),
     }),
   ),
   usage: z

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -11,8 +11,8 @@ export type AtLeastOne<T> = readonly [T, ...T[]];
 
 export const functionCallOutput = z
   .object({
-    name: z.string(),
-    arguments: z.string(),
+    name: z.string().default(""),
+    arguments: z.string().default(""),
   })
   .optional();
 


### PR DESCRIPTION
Some more newly required OpenAI fields need default values in our zod validators in order for request logs to properly convert into dataset entries.