### PR TITLE
Show the oldest projects first

### DIFF
--- a/app/src/server/api/routers/projects.router.ts
+++ b/app/src/server/api/routers/projects.router.ts
@@ -31,7 +31,8 @@ export const projectsRouter = createTRPCRouter({
         eb.onRef("pu.projectId", "=", "p.id").on("pu.userId", "=", userId),
       )
       .selectAll("p")
-      .orderBy("pu.createdAt", "asc")
+      .orderBy("pu.role", "asc")
+      .orderBy("p.createdAt", "asc")
       .execute();
 
     if (!projects.length) {

--- a/app/src/server/api/routers/projects.router.ts
+++ b/app/src/server/api/routers/projects.router.ts
@@ -1,5 +1,6 @@
 import { type Prisma } from "@prisma/client";
 import { TRPCError } from "@trpc/server";
+import { sql } from "kysely";
 import { jsonArrayFrom, jsonObjectFrom } from "kysely/helpers/postgres";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
@@ -31,7 +32,13 @@ export const projectsRouter = createTRPCRouter({
         eb.onRef("pu.projectId", "=", "p.id").on("pu.userId", "=", userId),
       )
       .selectAll("p")
-      .orderBy("pu.role", "asc")
+      .orderBy(
+        () =>
+          sql`CASE
+        WHEN "pu"."role" = 'VIEWER' THEN 1
+        ELSE 0
+      END`,
+      )
       .orderBy("p.createdAt", "asc")
       .execute();
 


### PR DESCRIPTION
The oldest projects that one is an admin of should come before your personal project in the project menu, because those are the projects that you are most likely to spend most of your time within.