### PR TITLE
Add default url for python sdk, remove empty tools

### DIFF
--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
@@ -16,7 +16,8 @@ const baseTabs: CodeTab[] = [
 "model": "openpipe:{{FINE_TUNE_MODEL_SLUG}}",
 "messages": {{TEMPLATED_MESSAGES}},
 "tool_choice": {{TEMPLATED_TOOL_CHOICE}},
-"tools": {{TEMPLATED_TOOLS}}
+"tools": {{TEMPLATED_TOOLS}},
+"temperature": 0
 }'`,
   },
   {
@@ -35,6 +36,7 @@ completion = client.chat.completions.create(
     messages={{TEMPLATED_MESSAGES}},
     tool_choice={{TEMPLATED_TOOL_CHOICE}},
     tools={{TEMPLATED_TOOLS}},
+    temperature=0,
     openpipe={
         "tags": {
             "prompt_id": "counting",
@@ -63,6 +65,7 @@ const completion = await client.chat.completions.create({
     messages: {{TEMPLATED_MESSAGES}},
     tool_choice: {{TEMPLATED_TOOL_CHOICE}},
     tools: {{TEMPLATED_TOOLS}},
+    temperature: 0,
 });
 
 console.log(completion?.choices[0]?.message);
@@ -93,7 +96,13 @@ const templateTabs = (
   const formattedTools = JSON.stringify(entry?.tools ?? []);
 
   return baseTabs.map((tab) => {
-    const templatedCode = tab.code;
+    let templatedCode = tab.code;
+
+    // if tools is empty, remove the tools line
+    if (!entry?.tools?.length) {
+      templatedCode = templatedCode.replace(/.*{{TEMPLATED_TOOL_CHOICE}}.*\n/g, "");
+      templatedCode = templatedCode.replace(/.*{{TEMPLATED_TOOLS}}.*\n/g, "");
+    }
 
     const tabFormattedMessages =
       tab.language === "bash"

--- a/client-libs/python/openpipe/shared.py
+++ b/client-libs/python/openpipe/shared.py
@@ -13,6 +13,7 @@ def configure_openpipe_clients(
     completions_client: Union[OpenAI, AsyncOpenAI],
     openpipe_options={},
 ):
+    completions_client.base_url = "https://app.openpipe.ai/api/v1"
     if os.environ.get("OPENPIPE_API_KEY"):
         reporting_client._client_wrapper._token = os.environ["OPENPIPE_API_KEY"]
         completions_client.api_key = os.environ["OPENPIPE_API_KEY"]

--- a/client-libs/python/openpipe/test_async_client.py
+++ b/client-libs/python/openpipe/test_async_client.py
@@ -335,6 +335,18 @@ async def test_async_with_tags():
     assert last_logged.tags["$sdk"] == "python"
 
 
+async def test_async_default_base_url():
+    default_client = AsyncOpenAI(api_key=os.environ["OPENPIPE_API_KEY"])
+
+    completion = await default_client.chat.completions.create(
+        model="openpipe:test-content-35",
+        messages=[{"role": "system", "content": "count to 10"}],
+        openpipe={"tags": {"promptId": "test_async_default_base_url"}},
+    )
+
+    assert completion.choices[0].message.content != None
+
+
 async def test_async_bad_openai_call():
     try:
         await client.chat.completions.create(


### PR DESCRIPTION
The last step before publishing the new Python SDK was adding a default base url for our completions client, which I did in this PR. Unrelatedly, it appears that OpenAI doesn't like it when you send an empty array of tools as part of completion request, so I removed tools from the inference code sample present on the fine-tune page.