### PR TITLE
Associate usage logs with projects

### DIFF
--- a/app/prisma/migrations/20240105075239_save_usage_logs_on_projects/migration.sql
+++ b/app/prisma/migrations/20240105075239_save_usage_logs_on_projects/migration.sql
@@ -1,0 +1,18 @@
+-- DropForeignKey
+ALTER TABLE "UsageLog" DROP CONSTRAINT "UsageLog_fineTuneId_fkey";
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "isHidden" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "UsageLog" ADD COLUMN     "projectId" UUID,
+ALTER COLUMN "fineTuneId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "UsageLog_projectId_createdAt_type_idx" ON "UsageLog"("projectId", "createdAt", "type");
+
+-- AddForeignKey
+ALTER TABLE "UsageLog" ADD CONSTRAINT "UsageLog_fineTuneId_fkey" FOREIGN KEY ("fineTuneId") REFERENCES "FineTune"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UsageLog" ADD CONSTRAINT "UsageLog_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -170,6 +170,7 @@ model Project {
     slug     String  @unique() @default(dbgenerated("nanoid()")) @db.VarChar(10)
     name     String  @default("Project 1")
     isPublic Boolean @default(false)
+    isHidden Boolean @default(false)
 
     personalProjectUserId String? @unique @db.Uuid
     personalProjectUser   User?   @relation(fields: [personalProjectUserId], references: [id], onDelete: Cascade)
@@ -182,6 +183,7 @@ model Project {
     loggedCalls            LoggedCall[]
     fineTunes              FineTune[]
     apiKeys                ApiKey[]
+    usageLogs              UsageLog[]
 }
 
 enum ProjectUserRole {
@@ -582,10 +584,14 @@ model UsageLog {
     cost         Float
     type         UsageType @default(EXTERNAL)
 
-    fineTuneId String   @db.Uuid
-    fineTune   FineTune @relation(fields: [fineTuneId], references: [id], onDelete: Cascade)
+    fineTuneId String?   @db.Uuid
+    fineTune   FineTune? @relation(fields: [fineTuneId], references: [id], onDelete: SetNull)
+
+    projectId String?  @db.Uuid
+    project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
     createdAt DateTime @default(now())
 
     @@index([fineTuneId, createdAt, type])
+    @@index([projectId, createdAt, type])
 }

--- a/app/src/components/ConditionallyEnable.tsx
+++ b/app/src/components/ConditionallyEnable.tsx
@@ -17,16 +17,27 @@ export const useAccessCheck = (accessCheck: AccessCheck) => {
 
 const ConditionallyEnable = (
   props: {
-    accessRequired: AccessCheck;
+    accessRequired?: AccessCheck;
     accessDeniedText?: string;
     checks?: [boolean, string][];
     hideTooltip?: boolean;
   } & TooltipProps,
 ) => {
-  const { accessRequired, accessDeniedText, checks, hideTooltip, children, ...rest } = props;
+  const {
+    accessRequired = "requireNothing",
+    accessDeniedText,
+    checks = [],
+    hideTooltip,
+    children,
+    ...rest
+  } = props;
 
   const accessCheck = useAccessCheck(accessRequired);
-  const failingCheck = checks?.find(([check]) => !check);
+  const selectedProjectNotHidden = useSelectedProject().data?.isHidden !== true;
+  const failingCheck = [
+    [selectedProjectNotHidden, "This project is archived. No further changes can be made."],
+    ...checks,
+  ]?.find(([check]) => !check);
 
   const disableChildren = !accessCheck.access || !!failingCheck;
   const tooltipText = !accessCheck.access

--- a/app/src/server/scripts/backfillTrainingUsageLogs.ts
+++ b/app/src/server/scripts/backfillTrainingUsageLogs.ts
@@ -18,6 +18,7 @@ const fineTunesToBackfill = await kysely
   .where("ftte.prunedInputTokens", "is", null)
   .select([
     "ft.id",
+    "ft.projectId",
     "ft.provider",
     "ft.baseModel",
     "ft.createdAt",
@@ -143,6 +144,7 @@ for (let i = 0; i < fineTunesToBackfill.length; i++) {
     await prisma.usageLog.create({
       data: {
         fineTuneId: typedFT.id,
+        projectId: typedFT.projectId,
         type: "TRAINING",
         inputTokens: totalInputTokens,
         outputTokens: totalOutputTokens,

--- a/app/src/server/scripts/backfillUsageLogsProjectIds.ts
+++ b/app/src/server/scripts/backfillUsageLogsProjectIds.ts
@@ -1,0 +1,44 @@
+import { sql } from "kysely";
+
+import { kysely } from "../db";
+
+console.log("Backfilling usage log project ids");
+
+const numUsageLogsToBackfill = await kysely
+  .selectFrom("UsageLog as ul")
+  .where("ul.projectId", "is", null)
+  .select(sql<number>`count(*)::int`.as("numLogs"))
+  .executeTakeFirst();
+
+console.log(`Found usage logs to backfill: ${numUsageLogsToBackfill?.numLogs ?? 0}`);
+
+// process one batch of 10000 usage logs at a time
+let total = 0;
+while (true) {
+  const ids = await kysely
+    .selectFrom("UsageLog as ul")
+    .where("ul.projectId", "is", null)
+    .select("ul.id")
+    .limit(1000)
+    .execute()
+    .then((rows) => rows.map((row) => row.id));
+
+  if (!ids.length) break;
+
+  await kysely
+    .updateTable("UsageLog as ul")
+    .set((eb) => ({
+      projectId: eb
+        .selectFrom("FineTune as ft")
+        .whereRef("ft.id", "=", "ul.fineTuneId")
+        .select("ft.projectId")
+        .limit(1),
+    }))
+    .where("ul.id", "in", ids)
+    .execute();
+
+  total += ids.length;
+  console.log(`Processed ${total}/${numUsageLogsToBackfill?.numLogs ?? 0}`);
+}
+
+console.log("Done!");

--- a/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
+++ b/app/src/server/tasks/fineTuning/checkFineTuneStatus.task.ts
@@ -64,6 +64,7 @@ export const checkFineTuneStatus = defineTask({
               data: {
                 type: "TRAINING",
                 fineTuneId: typedFT.id,
+                projectId: typedFT.projectId,
                 inputTokens: totalInputTokens,
                 outputTokens: totalOutputTokens,
                 cost: calculateCost(typedFT, totalInputTokens + totalOutputTokens, 0, 0),

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -166,6 +166,7 @@ export const generateTestSetEntry = defineTask<GenerateTestSetEntryJob>({
           await prisma.usageLog.create({
             data: {
               fineTuneId: fineTune.id,
+              projectId: fineTune.projectId,
               type: UsageType.TESTING,
               inputTokens,
               outputTokens,

--- a/app/src/types/kysely-codegen.types.ts
+++ b/app/src/types/kysely-codegen.types.ts
@@ -276,6 +276,7 @@ export interface Project {
   name: Generated<string>;
   slug: Generated<string>;
   isPublic: Generated<boolean>;
+  isHidden: Generated<boolean>;
 }
 
 export interface ProjectUser {
@@ -326,8 +327,9 @@ export interface UsageLog {
   outputTokens: number;
   cost: number;
   type: Generated<"EXTERNAL" | "TESTING" | "TRAINING">;
-  fineTuneId: string;
+  fineTuneId: string | null;
   createdAt: Generated<Timestamp>;
+  projectId: string | null;
 }
 
 export interface User {


### PR DESCRIPTION
Saving usage logs directly on projects will make it easier to load usage for a specific project's dashboard.