### PR TITLE
Record project id on external logs

### DIFF
--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -59,6 +59,7 @@ export const recordUsage = async ({
       .create({
         data: {
           fineTuneId: fineTune.id,
+          projectId: fineTune.projectId,
           type: UsageType.EXTERNAL,
           inputTokens: usage?.inputTokens ?? 0,
           outputTokens: usage?.outputTokens ?? 0,


### PR DESCRIPTION
I _may_ have forgotten to record project id on all new external logs 😆 .