### PR TITLE
Show only inference input/output tokens on models in the usage dashboard

### DIFF
--- a/app/prisma/migrations/20240106073022_record_whether_usage_log_is_billable/migration.sql
+++ b/app/prisma/migrations/20240106073022_record_whether_usage_log_is_billable/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "UsageLog" ADD COLUMN     "billable" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateIndex
+CREATE INDEX "FineTuneTestingEntry_fineTuneId_idx" ON "FineTuneTestingEntry"("fineTuneId");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -467,6 +467,7 @@ model FineTuneTestingEntry {
     @@unique([modelId, datasetEntryId])
     @@index([datasetEntryId])
     @@index([cacheKey])
+    @@index([fineTuneId])
 }
 
 enum DatasetEvalType {
@@ -583,6 +584,7 @@ model UsageLog {
     outputTokens Int
     cost         Float
     type         UsageType @default(EXTERNAL)
+    billable     Boolean   @default(true)
 
     fineTuneId String?   @db.Uuid
     fineTune   FineTune? @relation(fields: [fineTuneId], references: [id], onDelete: SetNull)

--- a/app/src/pages/admin/impersonate/index.tsx
+++ b/app/src/pages/admin/impersonate/index.tsx
@@ -1,5 +1,7 @@
 import { Card, HStack, Image, Text } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 import AsyncSelect from "react-select/async";
+
 import AppShell from "~/components/nav/AppShell";
 import { type RouterOutputs, api } from "~/utils/api";
 import { useHandledAsyncCallback } from "~/utils/hooks";
@@ -8,12 +10,14 @@ export default function Impersonate() {
   const impersonateMutation = api.adminUsers.impersonate.useMutation();
   const utils = api.useContext();
 
+  const router = useRouter();
+
   const [impersonate] = useHandledAsyncCallback(
     async (userId: string) => {
       await impersonateMutation.mutateAsync({ id: userId });
-      window.location.reload();
+      window.location.replace("/");
     },
-    [impersonateMutation],
+    [impersonateMutation, router],
   );
 
   const loadOptions = async (inputValue: string) => {

--- a/app/src/server/api/routers/projects.router.ts
+++ b/app/src/server/api/routers/projects.router.ts
@@ -71,11 +71,18 @@ export const projectsRouter = createTRPCRouter({
   get: protectedProcedure
     .input(z.object({ projectSlug: z.string() }))
     .query(async ({ input, ctx }) => {
-      const project = await prisma.project.findUniqueOrThrow({
+      const project = await prisma.project.findUnique({
         where: {
           slug: input.projectSlug,
         },
       });
+
+      if (!project) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No project matching the provided slug was found",
+        });
+      }
 
       await requireCanViewProject(project.id, ctx);
 

--- a/app/src/types/kysely-codegen.types.ts
+++ b/app/src/types/kysely-codegen.types.ts
@@ -330,6 +330,7 @@ export interface UsageLog {
   fineTuneId: string | null;
   createdAt: Generated<Timestamp>;
   projectId: string | null;
+  billable: Generated<boolean>;
 }
 
 export interface User {

--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -64,6 +64,7 @@ export const recordUsage = async ({
           inputTokens: usage?.inputTokens ?? 0,
           outputTokens: usage?.outputTokens ?? 0,
           cost: usage?.cost ?? 0,
+          billable: fineTune.provider === "openpipe",
         },
       })
       .catch((error) => captureException(error));


### PR DESCRIPTION
It's more useful to see input and output tokens from only inference usage logs in the usage dashboard.