### PR TITLE
Fit long email in project menu

### DIFF
--- a/app/src/components/nav/ProjectMenu.tsx
+++ b/app/src/components/nav/ProjectMenu.tsx
@@ -103,6 +103,7 @@ export default function ProjectMenu() {
         <PopoverContent
           _focusVisible={{ outline: "unset" }}
           w={220}
+          minW="fit-content"
           ml={{ base: 2, md: 0 }}
           boxShadow="0 0 40px 4px rgba(0, 0, 0, 0.1);"
           fontSize="sm"


### PR DESCRIPTION
Before:
<img width="277" alt="Screenshot 2024-01-07 at 10 23 47 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/f2b1879d-37e6-42ee-b176-eefc67cf004f">

After:
<img width="266" alt="Screenshot 2024-01-07 at 10 23 24 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/4d0663d3-ae27-4445-a5b1-7f6e5f1123d7">
