### PR TITLE
Make sidebar collapsible

### DIFF
--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Tooltip,
   type BoxProps,
+  IconButton,
 } from "@chakra-ui/react";
 import Head from "next/head";
 import Link from "next/link";
@@ -18,6 +19,7 @@ import { BsGearFill, BsGithub, BsPersonCircle } from "react-icons/bs";
 import { IoStatsChartOutline, IoSpeedometerOutline } from "react-icons/io5";
 import { AiOutlineThunderbolt, AiOutlineDatabase } from "react-icons/ai";
 import { FaBalanceScale, FaReadme } from "react-icons/fa";
+import { FiChevronsLeft, FiChevronsRight } from "react-icons/fi";
 import { signIn, useSession } from "next-auth/react";
 
 import ProjectMenu from "./ProjectMenu";
@@ -25,11 +27,15 @@ import NavSidebarOption from "./NavSidebarOption";
 import IconLink from "./IconLink";
 import { BetaModal } from "../BetaModal";
 import { useIsMissingBetaAccess } from "~/utils/hooks";
+import { useAppStore } from "~/state/store";
 
 const Divider = (props: BoxProps) => <Box h="1px" bgColor="gray.300" w="full" {...props} />;
 
 const NavSidebar = () => {
   const user = useSession().data;
+
+  const sidebarExpanded = useAppStore((state) => state.sidebarExpanded);
+  const setSidebarExpanded = useAppStore((state) => state.setSidebarExpanded);
 
   return (
     <VStack
@@ -38,7 +44,8 @@ const NavSidebar = () => {
       px={2}
       pb={0}
       height="100%"
-      w={{ base: "56px", md: "240px" }}
+      w={{ base: "56px", md: sidebarExpanded ? "240px" : "56px" }}
+      transition="width 0.2s ease-in-out"
       overflow="hidden"
       borderRightWidth={1}
       borderColor="gray.300"
@@ -59,7 +66,7 @@ const NavSidebar = () => {
       <VStack align="flex-start" overflowY="auto" overflowX="hidden" flex={1}>
         {user != null && (
           <>
-            <ProjectMenu />
+            <ProjectMenu displayProjectName={sidebarExpanded} />
             <Divider />
             <IconLink icon={IoStatsChartOutline} label="Request Logs" href="/request-logs" />
             <IconLink icon={AiOutlineDatabase} label="Datasets" href="/datasets" />
@@ -72,12 +79,28 @@ const NavSidebar = () => {
                 fontSize="xs"
                 fontWeight="bold"
                 color="gray.500"
+                h={6}
                 display={{ base: "none", md: "flex" }}
               >
-                CONFIGURATION
+                {sidebarExpanded ? "CONFIGURATION" : ""}
               </Text>
               <IconLink icon={BsGearFill} label="Project Settings" href="/settings" />
               <IconLink icon={IoSpeedometerOutline} label="Usage" href="/usage" />
+              <IconButton
+                variant="ghost"
+                size="sm"
+                onClick={() => setSidebarExpanded(!sidebarExpanded)}
+                aria-label="Toggle sidebar expanded"
+                icon={
+                  <Icon
+                    as={sidebarExpanded ? FiChevronsLeft : FiChevronsRight}
+                    boxSize={6}
+                    strokeWidth={1.5}
+                  />
+                }
+                boxSize={10}
+                display={{ base: "none", md: "flex" }}
+              />
             </VStack>
           </>
         )}
@@ -102,7 +125,11 @@ const NavSidebar = () => {
       </VStack>
 
       <Divider />
-      <Flex flexDir={{ base: "column-reverse", md: "row" }} align="center" justify="center">
+      <Flex
+        flexDir={{ base: "column-reverse", md: sidebarExpanded ? "row" : "column-reverse" }}
+        align="center"
+        justify="center"
+      >
         <ChakraLink
           href="https://github.com/openpipe/openpipe"
           target="_blank"

--- a/app/src/components/nav/IconLink.tsx
+++ b/app/src/components/nav/IconLink.tsx
@@ -18,7 +18,7 @@ const IconLink = <T extends ProjectRoute>({
         <HStack w="full" justifyContent="space-between" p={2} color={color} {...props}>
           <HStack w="full" justifyContent="start">
             <Icon as={icon} boxSize={6} mr={2} />
-            <Text fontSize="sm" display={{ base: "none", md: "block" }}>
+            <Text fontSize="sm" display={{ base: "none", md: "block" }} whiteSpace="nowrap">
               {label}
             </Text>
           </HStack>

--- a/app/src/components/nav/ProjectMenu.tsx
+++ b/app/src/components/nav/ProjectMenu.tsx
@@ -25,7 +25,7 @@ import { useHandledAsyncCallback, useProjectList, useSelectedProject } from "~/u
 import { useRouter } from "next/router";
 import { useSession, signOut } from "next-auth/react";
 
-export default function ProjectMenu() {
+export default function ProjectMenu({ displayProjectName }: { displayProjectName: boolean }) {
   const router = useRouter();
   const utils = api.useContext();
 
@@ -65,7 +65,7 @@ export default function ProjectMenu() {
   return (
     <VStack w="full" alignItems="flex-start" spacing={0} py={1}>
       <Popover
-        placement="bottom"
+        placement="bottom-end"
         isOpen={popover.isOpen}
         onOpen={popover.onOpen}
         onClose={popover.onClose}
@@ -87,15 +87,17 @@ export default function ProjectMenu() {
               >
                 <Text>{selectedProject?.name[0]?.toUpperCase()}</Text>
               </Flex>
-              <Text
-                fontSize="sm"
-                display={{ base: "none", md: "block" }}
-                py={1}
-                flex={1}
-                fontWeight="bold"
-              >
-                {selectedProject?.name}
-              </Text>
+              {displayProjectName && (
+                <Text
+                  fontSize="sm"
+                  display={{ base: "none", md: "block" }}
+                  py={1}
+                  flex={1}
+                  fontWeight="bold"
+                >
+                  {selectedProject?.name}
+                </Text>
+              )}
               <Box mr={2}>{profileImage}</Box>
             </HStack>
           </NavSidebarOption>

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -24,6 +24,8 @@ export type State = {
   isRehydrated: boolean;
   isMounted: boolean;
   markMounted: () => void;
+  sidebarExpanded: boolean;
+  setSidebarExpanded: (expanded: boolean) => void;
   api: APIClient | null;
   setApi: (api: APIClient) => void;
   betaBannerDismissed: boolean;
@@ -49,6 +51,11 @@ const useBaseStore = create<State, [["zustand/persist", PersistedState], ["zusta
       markMounted: () =>
         set((state) => {
           state.isMounted = true;
+        }),
+      sidebarExpanded: true,
+      setSidebarExpanded: (expanded) =>
+        set((state) => {
+          state.sidebarExpanded = expanded;
         }),
       api: null,
       setApi: (api) =>


### PR DESCRIPTION
Sometimes, you really don't need the whole navigational sidebar.

Expanded sidebar:
<img width="442" alt="Screenshot 2024-01-08 at 7 22 09 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/c04d4e8b-1a9a-4aef-9050-9719a47683ef">


Collapsed sidebar:
<img width="365" alt="Screenshot 2024-01-08 at 7 22 21 AM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/8f12a92a-98a6-4ce4-b3ee-4c76dd2692af">
