### PR TITLE
Add indexes to speed up queries

### DIFF
--- a/app/prisma/migrations/20240108170921_add_fine_tune_training_entry_and_logged_call_tag_indexes/migration.sql
+++ b/app/prisma/migrations/20240108170921_add_fine_tune_training_entry_and_logged_call_tag_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "FineTuneTrainingEntry_fineTuneId_idx" ON "FineTuneTrainingEntry"("fineTuneId");
+
+-- CreateIndex
+CREATE INDEX "LoggedCallTag_name_projectId_idx" ON "LoggedCallTag"("name", "projectId");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -255,6 +255,7 @@ model LoggedCallTag {
 
     @@unique([loggedCallId, name])
     @@index(loggedCallId)
+    @@index([name, projectId])
     @@index([projectId, name])
     @@index([projectId, name, value])
 }
@@ -430,6 +431,7 @@ model FineTuneTrainingEntry {
     @@unique([datasetEntryId, fineTuneId])
     @@index([datasetEntryId, fineTuneId])
     @@index([fineTuneId, createdAt, id])
+    @@index([fineTuneId])
 }
 
 enum ComparisonModel {


### PR DESCRIPTION
Listing fine tune training entries and assembling a list of logged call tags for a project should be much faster with these changes.