### PR TITLE
Bump the current_pipeline version

### DIFF
--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -6,7 +6,7 @@ import type {
 import { z } from "zod";
 import { type TypedFineTune } from "./dbColumns.types";
 
-export const CURRENT_PIPELINE_VERSION: TypedFineTune["pipelineVersion"] = 2;
+export const CURRENT_PIPELINE_VERSION: TypedFineTune["pipelineVersion"] = 3;
 
 export type AtLeastOne<T> = readonly [T, ...T[]];
 


### PR DESCRIPTION
I think we've seen at this point that pipeline 3 is performing well -- let's make that the default for new models going forward.