### PR TITLE
Reload the volume if we can't find a model's weights

### DIFF
--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -30,8 +30,8 @@ export type GenerateTestSetEntryJob = {
 
 const MAX_TRIES = 25;
 
-const MIN_DELAY = 500; // milliseconds
-const MAX_DELAY = 30000; // milliseconds
+const MIN_DELAY = 1000; // 1 second
+const MAX_DELAY = 6 * 60 * 60 * 1000; // 6 hours
 
 export function calculateQueryDelay(numPreviousTries: number): number {
   const baseDelay = Math.min(MAX_DELAY, MIN_DELAY * Math.pow(2, numPreviousTries));

--- a/app/src/types/shared.types.ts
+++ b/app/src/types/shared.types.ts
@@ -6,7 +6,7 @@ import type {
 import { z } from "zod";
 import { type TypedFineTune } from "./dbColumns.types";
 
-export const CURRENT_PIPELINE_VERSION: TypedFineTune["pipelineVersion"] = 2;
+export const CURRENT_PIPELINE_VERSION: TypedFineTune["pipelineVersion"] = 3;
 
 export type AtLeastOne<T> = readonly [T, ...T[]];
 


### PR DESCRIPTION
It turns out you have to explicitly reload a volume once you've made changes to it. So long-lived inference workers weren't seeing the weights from models trained after they started.

This also slows down the retry schedule for inference so it runs over several days, not just 12 minutes. It's more likely that we'll fix whatever issue is causing the completions to fail over a longer horizon.