### PR TITLE
Upsert new cache entries

### DIFF
--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -271,8 +271,10 @@ export const v1ApiRouter = createOpenApiRouter({
             tags,
           }).catch((e) => captureException(e));
           if (useCache && !cachedCompletion) {
-            await prisma.cachedResponse.create({
-              data: {
+            await prisma.cachedResponse.upsert({
+              where: { projectId_cacheKey: { projectId: key.projectId, cacheKey } },
+              update: {},
+              create: {
                 cacheKey,
                 modelId,
                 completionId: completion.id,

--- a/app/src/server/utils/parseTags.ts
+++ b/app/src/server/utils/parseTags.ts
@@ -16,7 +16,7 @@ export function parseTags(tags: unknown, keepNulls?: true) {
       continue;
     }
     if (typeof value !== "string" && value !== null) {
-      throw new Error(`Tag ${key} must be a string or null`);
+      throw new Error(`Tag ${key} must be a string, number, boolean, or null`);
     }
     parsedTags[key] = value;
   }

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -56,7 +56,7 @@ const functionBody = {
 
 const lastLoggedCall = async () => opClient.default.localTestingOnlyGetLatestLoggedCall();
 
-const randomLetters = () => Math.random().toString(36).substring(7);
+const randomLetters = Math.random().toString(36).substring(7);
 
 test("simple openai content call", async () => {
   const payload: ChatCompletionCreateParams = {
@@ -93,11 +93,17 @@ test("simple ft content call", async () => {
 
 test("openai call caches", async () => {
   const payload: ChatCompletionCreateParams = {
-    model: "gpt-3.5-turbo",
+    model: "openpipe:test-content-35",
     messages: [{ role: "system", content: `${randomLetters} count to 3` }],
   };
-  await oaiClient.chat.completions.create(payload);
-  await oaiClient.chat.completions.create(payload);
+  await oaiClient.chat.completions.create({
+    ...payload,
+    openpipe: { tags: { promptId: "openai call caches (no cache)" } },
+  });
+  await oaiClient.chat.completions.create({
+    ...payload,
+    openpipe: { tags: { promptId: "openai call caches (no cache)" } },
+  });
 
   await sleep(100);
   let lastLogged = await lastLoggedCall();
@@ -106,16 +112,16 @@ test("openai call caches", async () => {
 
   await oaiClient.chat.completions.create({
     ...payload,
-    openpipe: { cache: true },
+    openpipe: { cache: true, tags: { promptId: "openai call caches" } },
   });
   await oaiClient.chat.completions.create({
     ...payload,
-    openpipe: { cache: true },
+    openpipe: { cache: true, tags: { promptId: "openai call caches" } },
   });
   await sleep(100);
   lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.cacheHit).toBe(false);
+  expect(lastLogged?.cacheHit).toBe(true);
 }, 100000);
 
 test("base sdk openai content call", async () => {


### PR DESCRIPTION
Upserting new cache entries will avoid rare race conditions in which the same cache entry is added from two different requests simultaneously.