### PR TITLE
Adjust tick width to length of values

### DIFF
--- a/app/src/components/dashboard/UsageGraph.tsx
+++ b/app/src/components/dashboard/UsageGraph.tsx
@@ -40,19 +40,34 @@ export default function UsageGraph() {
     ["gray.500", "orange.500", "blue.500", "gray.900"],
   );
 
+  const longestRequestsLabelLength = data
+    .map((c) => c.Requests.toString())
+    .reduce((acc, cur) => (cur.length > acc ? cur.length : acc), 0);
+
+  const longestTotalSpendLabelLength = data
+    .map((c) => c["Total Spend"].toFixed(2))
+    .reduce((acc, cur) => (cur.length > acc ? cur.length : acc), 0);
+
   return (
     <ResponsiveContainer width="100%" height={400}>
-      <LineChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+      <LineChart data={data} margin={{ top: 5, right: 24, left: 4, bottom: 5 }}>
         <XAxis dataKey="period" tickFormatter={(str: string) => dayjs(str).format("MMM D")} />
-        <YAxis yAxisId="left" dataKey="Requests" orientation="left" stroke={requestsColor} />
+        <YAxis
+          yAxisId="left"
+          dataKey="Requests"
+          orientation="left"
+          stroke={requestsColor}
+          width={longestRequestsLabelLength * 10}
+        />
         <YAxis
           yAxisId="right"
           dataKey="Total Spend"
           orientation="right"
           type="number"
-          tickMargin={4}
+          tickMargin={6}
           tickFormatter={(value: number) => "$" + value.toFixed(2)}
           stroke={totalSpendColor}
+          width={longestTotalSpendLabelLength * 10}
         />
         <Tooltip />
         <Legend />


### PR DESCRIPTION
Some of our users' usage is now literally off the charts (or at least the charts' tick marks) so let's dynamically calculate the size of those ticks.

Before:
<img width="1190" alt="Screenshot 2024-01-12 at 2 05 27 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/8dba611b-6d38-4f01-aa1b-9a4608994f4f">


After:
<img width="1190" alt="Screenshot 2024-01-12 at 2 04 52 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/192931bf-0aae-48eb-b585-bd1ae2dc65a4">
