### PR TITLE
Only deploy necessary arns

### DIFF
--- a/.github/workflows/app-prod.yaml
+++ b/.github/workflows/app-prod.yaml
@@ -3,10 +3,9 @@ name: Deploy Prod
 on:
   push:
     branches: [main]
-  
 
 # Only run workflow for the latest commit
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
@@ -32,18 +31,18 @@ jobs:
       - name: Install Pulumi deps
         run: npm install
         working-directory: infra
-      
+
       - name: Run Pulumi
         uses: pulumi/actions@v3
         with:
-          command: up
+          command: up --target 'urn:pulumi:prod::openpipe::awsx:ecr:Image$docker:index/image:Image::83d84553-container' --target urn:pulumi:prod::openpipe::kubernetes:apps/v1:Deployment::app-worker-pl-prod --target urn:pulumi:prod::openpipe::kubernetes:apps/v1:Deployment::app-pl-prod
           stack-name: openpipe/prod
           work-dir: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          
+
           # Lol I can't believe this is necessary but without it the AWS CLI fails when running on Azure with cryptic errors.
           # https://github.com/aws/aws-cli/issues/5234#issuecomment-705831465
           AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/app-prod.yaml
+++ b/.github/workflows/app-prod.yaml
@@ -35,7 +35,8 @@ jobs:
       - name: Run Pulumi
         uses: pulumi/actions@v3
         with:
-          command: up --target 'urn:pulumi:prod::openpipe::awsx:ecr:Image$docker:index/image:Image::83d84553-container' --target urn:pulumi:prod::openpipe::kubernetes:apps/v1:Deployment::app-worker-pl-prod --target urn:pulumi:prod::openpipe::kubernetes:apps/v1:Deployment::app-pl-prod
+          command: up
+          target: "urn:pulumi:prod::openpipe::awsx:ecr:Image$docker:index/image:Image::83d84553-container,urn:pulumi:prod::openpipe::kubernetes:apps/v1:Deployment::app-worker-pl-prod,urn:pulumi:prod::openpipe::kubernetes:apps/v1:Deployment::app-pl-prod"
           stack-name: openpipe/prod
           work-dir: infra
         env:

--- a/.github/workflows/app-stage.yaml
+++ b/.github/workflows/app-stage.yaml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to deploy'
+        description: "Branch to deploy"
         required: true
-        default: 'main'
+        default: "main"
 
 # Only run workflow for the latest commit
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
@@ -35,18 +35,18 @@ jobs:
       - name: Install Pulumi deps
         run: npm install
         working-directory: infra
-      
+
       - name: Run Pulumi
         uses: pulumi/actions@v3
         with:
-          command: up
+          command: up --target 'urn:pulumi:stage::openpipe::awsx:ecr:Image$docker:index/image:Image::a3532718-container' --target urn:pulumi:stage::openpipe::kubernetes:apps/v1:Deployment::app-worker-pl-stage --target urn:pulumi:stage::openpipe::kubernetes:apps/v1:Deployment::app-pl-stage
           stack-name: openpipe/stage
           work-dir: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          
+
           # Lol I can't believe this is necessary but without it the AWS fails with cryptic errors.
           # https://github.com/aws/aws-cli/issues/5234#issuecomment-705831465
           AWS_EC2_METADATA_DISABLED: true

--- a/.github/workflows/app-stage.yaml
+++ b/.github/workflows/app-stage.yaml
@@ -39,7 +39,8 @@ jobs:
       - name: Run Pulumi
         uses: pulumi/actions@v3
         with:
-          command: up --target 'urn:pulumi:stage::openpipe::awsx:ecr:Image$docker:index/image:Image::a3532718-container' --target urn:pulumi:stage::openpipe::kubernetes:apps/v1:Deployment::app-worker-pl-stage --target urn:pulumi:stage::openpipe::kubernetes:apps/v1:Deployment::app-pl-stage
+          command: up
+          target: "urn:pulumi:stage::openpipe::awsx:ecr:Image$docker:index/image:Image::a3532718-container,urn:pulumi:stage::openpipe::kubernetes:apps/v1:Deployment::app-worker-pl-stage,urn:pulumi:stage::openpipe::kubernetes:apps/v1:Deployment::app-pl-stage"
           stack-name: openpipe/stage
           work-dir: infra
         env:


### PR DESCRIPTION
Pulumi keeps trying to deploy more than it really needs to, so let's explicitly limit its scope.