### PR TITLE
Correctly redirect to default project settings page from docs

### DIFF
--- a/app/@types/nextjs-routes.d.ts
+++ b/app/@types/nextjs-routes.d.ts
@@ -36,7 +36,8 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/p/[projectSlug]/request-logs", { "projectSlug": string }>
     | DynamicRoute<"/p/[projectSlug]/settings", { "projectSlug": string }>
     | DynamicRoute<"/p/[projectSlug]/usage", { "projectSlug": string }>
-    | StaticRoute<"/sentry-example-page">;
+    | StaticRoute<"/sentry-example-page">
+    | StaticRoute<"/settings">;
 
   interface StaticRoute<Pathname> {
     pathname: Pathname;

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/ComparisonModals/HeadToHeadComparisonModal.tsx
@@ -249,13 +249,13 @@ const ComparisonRow = ({
         <Box
           w="full"
           position="relative"
-          h={
+          h={`${
             !expandable
-              ? innerOutputHeight
+              ? innerOutputHeight + 40
               : outputExpanded
               ? innerOutputHeight + 160
               : explanationHeight + VERTICAL_PADDING
-          }
+          }px`}
           transition="height 0.5s ease-in-out"
           overflow="hidden"
         >
@@ -332,6 +332,7 @@ const SelectedComparisonTable = ({
   return (
     <VStack w="full" position="relative" pb={8}>
       <Grid
+        w="full"
         display="grid"
         gridTemplateColumns={`1fr 1fr`}
         borderWidth={1}

--- a/app/src/pages/settings.tsx
+++ b/app/src/pages/settings.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useSession } from "next-auth/react";
+
+import { useProjectList } from "~/utils/hooks";
+
+const Settings = () => {
+  const router = useRouter();
+
+  const session = useSession();
+
+  const projectList = useProjectList().data;
+
+  useEffect(() => {
+    if (session.status === "loading") return;
+
+    const redirectProject = async () => {
+      if (!projectList) return;
+      const { projects, lastViewedProjectSlug } = projectList;
+      const redirectProjectSlug = lastViewedProjectSlug || projects[0]?.slug;
+      if (!redirectProjectSlug) return;
+      await router.push({
+        pathname: "/p/[projectSlug]/settings",
+        query: { projectSlug: redirectProjectSlug },
+      });
+    };
+
+    if (session.data?.user) {
+      void redirectProject();
+    } else {
+      void router.push("/account/signin");
+    }
+  }, [session.status, session.data, router, projectList]);
+
+  return null;
+};
+
+export default Settings;


### PR DESCRIPTION
When we updated how our project urls worked, we neglected to account for incoming links from docs.