### PR TITLE
Local and production tests environment setup

### DIFF
--- a/client-libs/typescript/.env.example
+++ b/client-libs/typescript/.env.example
@@ -1,0 +1,10 @@
+ENVIRONMENT=production
+# ENVIRONMENT=local
+
+OPENAI_API_KEY=your-openai-api-key
+
+OPENPIPE_API_KEY_LOCAL=openpipe-local-api-key
+OPENPIPE_API_KEY_PROD=openpipe-prod-api-key
+
+OPENPIPE_BASE_URL_LOCAL=http://localhost:3000/api/v1/
+OPENPIPE_BASE_URL_PROD=https://app.openpipe.ai/api/v1/

--- a/client-libs/typescript/src/openai/http.test.ts
+++ b/client-libs/typescript/src/openai/http.test.ts
@@ -1,19 +1,10 @@
-import dotenv from "dotenv";
 import { test, expect } from "vitest";
-import OpenAI from "../openai";
-import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
-import { OPClient } from "../codegen";
+import { OPENPIPE_API_URL, OPENPIPE_API_KEY } from "./setup";
 
-dotenv.config();
-
-const OPENAI_BASE_URL = "https://api.openai.com/v1/chat/completions";
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
-
-const OPENPIPE_API_URL = "http://localhost:3000/api/v1/chat/completions";
-const OPENPIPE_API_KEY = process.env.OPENPIPE_API_KEY;
+const OPENPIPE_API_CHAT_COMPLETIONS_URL = OPENPIPE_API_URL + "chat/completions";
 
 test("fetches non-streamed output", async () => {
-  const response = await fetch(OPENPIPE_API_URL, {
+  const response = await fetch(OPENPIPE_API_CHAT_COMPLETIONS_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -32,7 +23,7 @@ test("fetches non-streamed output", async () => {
 });
 
 test("bad tags", async () => {
-  const response = await fetch(OPENPIPE_API_URL, {
+  const response = await fetch(OPENPIPE_API_CHAT_COMPLETIONS_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -9,29 +9,26 @@ import OpenAI from "../openai";
 import { OPClient } from "../codegen";
 import mergeChunks from "./mergeChunks";
 import { getTags } from "../shared";
+import { OPENPIPE_API_KEY, OPENPIPE_API_URL } from "./setup";
 
 dotenv.config();
 
-// const BASE_URL = "https://app.openpipe.ai/api/v1";
-// const BASE_URL = "https://app.openpipestage.com/api/v1";
-const BASE_URL = "http://localhost:3000/api/v1";
-
 const baseClient = new BaseOpenAI({
-  apiKey: process.env.OPENPIPE_API_KEY,
-  baseURL: BASE_URL,
+  apiKey: OPENPIPE_API_KEY,
+  baseURL: OPENPIPE_API_URL,
 });
 
 const oaiClient = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
   openpipe: {
-    apiKey: process.env.OPENPIPE_API_KEY,
-    baseUrl: BASE_URL,
+    apiKey: OPENPIPE_API_KEY,
+    baseUrl: OPENPIPE_API_URL,
   },
 });
 
 const opClient = new OPClient({
-  BASE: BASE_URL,
-  TOKEN: process.env.OPENPIPE_API_KEY,
+  BASE: OPENPIPE_API_URL,
+  TOKEN: OPENPIPE_API_KEY,
 });
 
 const functionCall = { name: "get_current_weather" };

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -9,7 +9,7 @@ import OpenAI from "../openai";
 import { OPClient } from "../codegen";
 import mergeChunks from "./mergeChunks";
 import { getTags } from "../shared";
-import { OPENPIPE_API_KEY, OPENPIPE_API_URL } from "./setup";
+import { OPENPIPE_API_KEY, OPENPIPE_API_URL, TEST_LAST_LOGGED } from "./setup";
 
 dotenv.config();
 
@@ -68,10 +68,12 @@ test("simple openai content call", async () => {
 
   await completion.openpipe?.reportingFinished;
 
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.reqPayload).toMatchObject(payload);
-  expect(completion).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.tags).toMatchObject(getTags(openpipeOptions));
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload).toMatchObject(payload);
+    expect(completion).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.tags).toMatchObject(getTags(openpipeOptions));
+  }
 }, 10000);
 
 test("simple ft content call", async () => {
@@ -83,9 +85,12 @@ test("simple ft content call", async () => {
 
   await sleep(100);
   await completion.openpipe?.reportingFinished;
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
-  expect(completion).toMatchObject(lastLogged?.respPayload);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+    expect(completion).toMatchObject(lastLogged?.respPayload);
+  }
 }, 100000);
 
 test("openai call caches", async () => {
@@ -103,22 +108,26 @@ test("openai call caches", async () => {
   });
 
   await sleep(100);
-  let lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.cacheHit).toBe(false);
+  if (TEST_LAST_LOGGED) {
+    let lastLogged = await lastLoggedCall();
 
-  await oaiClient.chat.completions.create({
-    ...payload,
-    openpipe: { cache: true, tags: { promptId: "openai call caches" } },
-  });
-  await oaiClient.chat.completions.create({
-    ...payload,
-    openpipe: { cache: true, tags: { promptId: "openai call caches" } },
-  });
-  await sleep(100);
-  lastLogged = await lastLoggedCall();
+    expect(lastLogged?.cacheHit).toBe(false);
 
-  expect(lastLogged?.cacheHit).toBe(true);
+    await oaiClient.chat.completions.create({
+      ...payload,
+      openpipe: { cache: true, tags: { promptId: "openai call caches" } },
+    });
+    await oaiClient.chat.completions.create({
+      ...payload,
+      openpipe: { cache: true, tags: { promptId: "openai call caches" } },
+    });
+    await sleep(100);
+
+    lastLogged = await lastLoggedCall();
+
+    expect(lastLogged?.cacheHit).toBe(true);
+  }
 }, 100000);
 
 test("base sdk openai content call", async () => {
@@ -131,9 +140,11 @@ test("base sdk openai content call", async () => {
   });
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.reqPayload).toMatchObject(payload);
-  expect(completion.id).toMatchObject(lastLogged?.respPayload.id);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload).toMatchObject(payload);
+    expect(completion.id).toMatchObject(lastLogged?.respPayload.id);
+  }
 }, 10000);
 
 test("base sdk ft content call", async () => {
@@ -150,10 +161,12 @@ test("base sdk ft content call", async () => {
   });
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.reqPayload).toMatchObject(payload);
-  expect(completion.id).toMatchObject(lastLogged?.respPayload.id);
-  expect(lastLogged?.tags).toMatchObject(tags);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload).toMatchObject(payload);
+    expect(completion.id).toMatchObject(lastLogged?.respPayload.id);
+    expect(lastLogged?.tags).toMatchObject(tags);
+  }
 }, 100000);
 
 test("content streaming", async () => {
@@ -169,11 +182,13 @@ test("content streaming", async () => {
   }
 
   await completion.openpipe?.reportingFinished;
-  const lastLogged = await lastLoggedCall();
-  expect(merged).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.reqPayload.messages).toMatchObject([
-    { role: "system", content: "count to 3" },
-  ]);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject([
+      { role: "system", content: "count to 3" },
+    ]);
+  }
 });
 
 test("base sdk content streaming", async () => {
@@ -191,9 +206,12 @@ test("base sdk content streaming", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(merged).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.reqPayload.messages).toMatchObject(input.messages);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(input.messages);
+  }
 }, 10000);
 
 test("function call streaming", async () => {
@@ -217,9 +235,12 @@ test("function call streaming", async () => {
   }
 
   await completion.openpipe?.reportingFinished;
-  const lastLogged = await lastLoggedCall();
-  expect(merged).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+  }
 });
 
 test("base sdk function call streaming", async () => {
@@ -247,9 +268,12 @@ test("base sdk function call streaming", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(merged).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+  }
 });
 
 test("tool call streaming", async () => {
@@ -277,9 +301,12 @@ test("tool call streaming", async () => {
   }
 
   await completion.openpipe?.reportingFinished;
-  const lastLogged = await lastLoggedCall();
-  expect(merged).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+  }
 });
 
 test("base sdk tool call streaming", async () => {
@@ -312,9 +339,12 @@ test("base sdk tool call streaming", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(merged).toMatchObject(lastLogged?.respPayload);
-  expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+  }
 });
 
 test("logs streamed request for base model", async () => {
@@ -330,8 +360,10 @@ test("logs streamed request for base model", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+  }
 }, 10000);
 
 test("base sdk logs streamed request for base model", async () => {
@@ -347,8 +379,11 @@ test("base sdk logs streamed request for base model", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+  }
 }, 10000);
 
 test("does not log streamed request if asked not to", async () => {
@@ -367,8 +402,11 @@ test("does not log streamed request if asked not to", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).not.toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).not.toEqual(merged?.id);
+  }
 }, 10000);
 
 test("base sdk does not log streamed request if asked not to", async () => {
@@ -386,8 +424,11 @@ test("base sdk does not log streamed request if asked not to", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).not.toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).not.toEqual(merged?.id);
+  }
 }, 10000);
 
 test("35 ft streaming", async () => {
@@ -404,8 +445,11 @@ test("35 ft streaming", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+  }
 }, 10000);
 
 test("base sdk 35 ft streaming", async () => {
@@ -429,8 +473,11 @@ test("base sdk 35 ft streaming", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+  }
 }, 10000);
 
 test("defaults to recording for fine-tuned models", async () => {
@@ -447,8 +494,11 @@ test("defaults to recording for fine-tuned models", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).toEqual(merged?.id);
+  }
 }, 10000);
 
 test("base sdk defaults to not recording for fine-tuned models", async () => {
@@ -469,8 +519,11 @@ test("base sdk defaults to not recording for fine-tuned models", async () => {
   }
 
   await sleep(100);
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.respPayload.id).not.toEqual(merged?.id);
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.respPayload.id).not.toEqual(merged?.id);
+  }
 }, 10000);
 
 test.skip("mistral ft streaming", async () => {
@@ -502,11 +555,14 @@ test("bad call streaming", async () => {
     assert("openpipe" in e);
     // @ts-expect-error need to check for error type
     await e.openpipe.reportingFinished;
-    const lastLogged = await lastLoggedCall();
-    expect(lastLogged?.errorMessage).toEqual(
-      "404 The model `gpt-3.5-turbo-blaster` does not exist",
-    );
-    expect(lastLogged?.statusCode).toEqual(404);
+
+    if (TEST_LAST_LOGGED) {
+      const lastLogged = await lastLoggedCall();
+      expect(lastLogged?.errorMessage).toEqual(
+        "404 The model `gpt-3.5-turbo-blaster` does not exist",
+      );
+      expect(lastLogged?.statusCode).toEqual(404);
+    }
   }
 });
 
@@ -524,9 +580,14 @@ test("bad call", async () => {
     assert("openpipe" in e);
     // @ts-expect-error need to check for error type
     await e.openpipe.reportingFinished;
-    const lastLogged = await lastLoggedCall();
-    expect(lastLogged?.errorMessage).toEqual("404 The model `gpt-3.5-turbo-buster` does not exist");
-    expect(lastLogged?.statusCode).toEqual(404);
+
+    if (TEST_LAST_LOGGED) {
+      const lastLogged = await lastLoggedCall();
+      expect(lastLogged?.errorMessage).toEqual(
+        "404 The model `gpt-3.5-turbo-buster` does not exist",
+      );
+      expect(lastLogged?.statusCode).toEqual(404);
+    }
   }
 });
 
@@ -541,11 +602,14 @@ test("bad call ft", async () => {
     assert(e instanceof APIError);
     // @ts-expect-error need to check for error type
     expect(e.error.message).toEqual("The model `openpipe:gpt-3.5-turbo-buster` does not exist");
-    const lastLogged = await lastLoggedCall();
-    expect(lastLogged?.errorMessage).toEqual(
-      "The model `openpipe:gpt-3.5-turbo-buster` does not exist",
-    );
-    expect(lastLogged?.statusCode).toEqual(404);
+
+    if (TEST_LAST_LOGGED) {
+      const lastLogged = await lastLoggedCall();
+      expect(lastLogged?.errorMessage).toEqual(
+        "The model `openpipe:gpt-3.5-turbo-buster` does not exist",
+      );
+      expect(lastLogged?.statusCode).toEqual(404);
+    }
   }
 });
 
@@ -569,18 +633,20 @@ test("openai content call unusual tags", async () => {
 
   await completion.openpipe?.reportingFinished;
 
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.reqPayload).toMatchObject(payload);
-  expect(completion).toMatchObject(lastLogged?.respPayload);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload).toMatchObject(payload);
+    expect(completion).toMatchObject(lastLogged?.respPayload);
 
-  const { nullTag, ...expectedTags } = {
-    ...getTags(openpipeOptions),
-    numberTag: "1",
-    booleanTag: "true",
-    nullTag: undefined,
-  };
+    const { nullTag, ...expectedTags } = {
+      ...getTags(openpipeOptions),
+      numberTag: "1",
+      booleanTag: "true",
+      nullTag: undefined,
+    };
 
-  expect(lastLogged?.tags).toMatchObject(expectedTags);
+    expect(lastLogged?.tags).toMatchObject(expectedTags);
+  }
 }, 10000);
 
 test("ft content call unusual tags", async () => {
@@ -603,16 +669,19 @@ test("ft content call unusual tags", async () => {
 
   await sleep(100);
   await completion.openpipe?.reportingFinished;
-  const lastLogged = await lastLoggedCall();
-  expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
-  expect(completion).toMatchObject(lastLogged?.respPayload);
 
-  const { nullTag, ...expectedTags } = {
-    ...getTags(openpipeOptions),
-    numberTag: "1",
-    booleanTag: "true",
-    nullTag: undefined,
-  };
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+    expect(completion).toMatchObject(lastLogged?.respPayload);
 
-  expect(lastLogged?.tags).toMatchObject(expectedTags);
+    const { nullTag, ...expectedTags } = {
+      ...getTags(openpipeOptions),
+      numberTag: "1",
+      booleanTag: "true",
+      nullTag: undefined,
+    };
+
+    expect(lastLogged?.tags).toMatchObject(expectedTags);
+  }
 }, 100000);

--- a/client-libs/typescript/src/openai/report.test.ts
+++ b/client-libs/typescript/src/openai/report.test.ts
@@ -1,22 +1,20 @@
-import dotenv from "dotenv";
 import { test } from "vitest";
 import OpenAI from "../openai";
 import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
 import { OPClient } from "../codegen";
-
-dotenv.config();
+import { OPENPIPE_API_KEY, OPENPIPE_API_URL } from "./setup";
 
 const oaiClient = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
   openpipe: {
-    apiKey: process.env.OPENPIPE_API_KEY,
-    baseUrl: "http://localhost:3000/api/v1",
+    apiKey: OPENPIPE_API_KEY,
+    baseUrl: OPENPIPE_API_URL,
   },
 });
 
 const opClient = new OPClient({
-  BASE: "http://localhost:3000/api/v1",
-  TOKEN: process.env.OPENPIPE_API_KEY,
+  BASE: OPENPIPE_API_URL,
+  TOKEN: OPENPIPE_API_KEY,
 });
 
 test("reports null response payload", async () => {

--- a/client-libs/typescript/src/openai/setup.ts
+++ b/client-libs/typescript/src/openai/setup.ts
@@ -1,0 +1,27 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+if (
+  !process.env.OPENPIPE_BASE_URL_PROD ||
+  !process.env.OPENPIPE_BASE_URL_LOCAL ||
+  !process.env.OPENPIPE_API_KEY_PROD ||
+  !process.env.OPENPIPE_API_KEY_LOCAL
+) {
+  throw new Error("Environment variables for production are not set");
+}
+
+let OPENPIPE_API_URL: string;
+let OPENPIPE_API_KEY: string;
+
+if (process.env.ENVIRONMENT === "production") {
+  OPENPIPE_API_URL = process.env.OPENPIPE_BASE_URL_PROD;
+  OPENPIPE_API_KEY = process.env.OPENPIPE_API_KEY_PROD;
+} else {
+  OPENPIPE_API_URL = process.env.OPENPIPE_BASE_URL_LOCAL;
+  OPENPIPE_API_KEY = process.env.OPENPIPE_API_KEY_LOCAL;
+}
+
+const TEST_LAST_LOGGED = process.env.ENVIRONMENT === "local" ? true : false;
+
+export { OPENPIPE_API_URL, OPENPIPE_API_KEY, TEST_LAST_LOGGED };

--- a/client-libs/typescript/src/openai/updateLogTags.test.ts
+++ b/client-libs/typescript/src/openai/updateLogTags.test.ts
@@ -1,14 +1,12 @@
-import dotenv from "dotenv";
+// import dotenv from "dotenv";
 import { expect, test } from "vitest";
-import OpenAI from "../openai";
 import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
 import { OPClient } from "../codegen";
-
-dotenv.config();
+import { OPENPIPE_API_KEY, OPENPIPE_API_URL, TEST_LAST_LOGGED } from "./setup";
 
 const opClient = new OPClient({
-  BASE: "http://localhost:3000/api/v1",
-  TOKEN: process.env.OPENPIPE_API_KEY,
+  BASE: OPENPIPE_API_URL,
+  TOKEN: OPENPIPE_API_KEY,
 });
 
 const respPayload = {
@@ -66,11 +64,13 @@ test("adds tags", async () => {
 
   expect(resp.matchedLogs).toEqual(1);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(originalPromptId);
-  expect(lastLogged?.tags.any_key).toEqual(newTags.any_key);
-  expect(lastLogged?.tags.otherId).toEqual(newTags.otherId);
+    expect(lastLogged?.tags.prompt_id).toEqual(originalPromptId);
+    expect(lastLogged?.tags.any_key).toEqual(newTags.any_key);
+    expect(lastLogged?.tags.otherId).toEqual(newTags.otherId);
+  }
 });
 
 test("updates tags", async () => {
@@ -117,11 +117,13 @@ test("updates tags", async () => {
 
   expect(resp.matchedLogs).toEqual(2);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
-  expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
-  expect(lastLogged?.tags.any_key).toEqual("any value");
+    expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
+    expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
+    expect(lastLogged?.tags.any_key).toEqual("any value");
+  }
 });
 
 test("updates tag by completionId", async () => {
@@ -175,11 +177,13 @@ test("updates tag by completionId", async () => {
 
   expect(resp.matchedLogs).toEqual(1);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
-  expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
-  expect(lastLogged?.tags.any_key).toEqual("any value");
+    expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
+    expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
+    expect(lastLogged?.tags.any_key).toEqual("any value");
+  }
 });
 
 test("updates tag by model", async () => {
@@ -215,11 +219,13 @@ test("updates tag by model", async () => {
 
   expect(resp.matchedLogs).toEqual(1);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
-  expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
-  expect(lastLogged?.tags.any_key).toEqual("any value");
+    expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
+    expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
+    expect(lastLogged?.tags.any_key).toEqual("any value");
+  }
 });
 
 test("updates by combination of filters", async () => {
@@ -258,11 +264,13 @@ test("updates by combination of filters", async () => {
 
   expect(resp.matchedLogs).toEqual(1);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
-  expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
-  expect(lastLogged?.tags.any_key).toEqual("any value");
+    expect(lastLogged?.tags.prompt_id).toEqual(updatedTags.prompt_id);
+    expect(lastLogged?.tags.otherId).toEqual(updatedTags.otherId);
+    expect(lastLogged?.tags.any_key).toEqual("any value");
+  }
 });
 
 test("updates some tags by combination of filters", async () => {
@@ -329,11 +337,13 @@ test("updates some tags by combination of filters", async () => {
 
   expect(resp.matchedLogs).toEqual(2);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(originalPromptId);
-  expect(lastLogged?.tags.otherId).toEqual("value 1");
-  expect(lastLogged?.tags.any_key).toEqual("any value");
+    expect(lastLogged?.tags.prompt_id).toEqual(originalPromptId);
+    expect(lastLogged?.tags.otherId).toEqual("value 1");
+    expect(lastLogged?.tags.any_key).toEqual("any value");
+  }
 });
 
 test("deletes tags", async () => {
@@ -364,8 +374,10 @@ test("deletes tags", async () => {
 
   expect(keepResp.matchedLogs).toEqual(0);
 
-  const keepLoggedCall = await lastLoggedCall();
-  expect(keepLoggedCall?.tags.prompt_id).toEqual(keepPromptId);
+  if (TEST_LAST_LOGGED) {
+    const keepLoggedCall = await lastLoggedCall();
+    expect(keepLoggedCall?.tags.prompt_id).toEqual(keepPromptId);
+  }
 
   await opClient.default.report({
     requestedAt: Date.now(),
@@ -386,9 +398,11 @@ test("deletes tags", async () => {
 
   expect(resp.matchedLogs).toEqual(1);
 
-  const lastLogged = await lastLoggedCall();
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
 
-  expect(lastLogged?.tags.prompt_id).toEqual(undefined);
+    expect(lastLogged?.tags.prompt_id).toEqual(undefined);
+  }
 });
 
 test("deletes nothing when no tags matched", async () => {
@@ -409,9 +423,10 @@ test("deletes nothing when no tags matched", async () => {
 
   expect(resp.matchedLogs).toEqual(0);
 
-  const lastLogged = await lastLoggedCall();
-
-  expect(lastLogged?.tags.prompt_id).toEqual(originalPromptId);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.tags.prompt_id).toEqual(originalPromptId);
+  }
 });
 
 test("deletes from all logged calls when no filters provided", async () => {
@@ -448,9 +463,11 @@ test("deletes from all logged calls when no filters provided", async () => {
 
   expect(resp.matchedLogs).toBeGreaterThanOrEqual(2);
 
-  const firstLogged = await lastLoggedCall();
-  expect(firstLogged?.tags.prompt_id).toEqual(undefined);
+  if (TEST_LAST_LOGGED) {
+    const firstLogged = await lastLoggedCall();
+    expect(firstLogged?.tags.prompt_id).toEqual(undefined);
 
-  const secondLogged = await lastLoggedCall();
-  expect(secondLogged?.tags.prompt_id).toEqual(undefined);
+    const secondLogged = await lastLoggedCall();
+    expect(secondLogged?.tags.prompt_id).toEqual(undefined);
+  }
 });


### PR DESCRIPTION
This commit makes it easier to run tests. You just need to change the environment variable inside the .env file:
ENVIRONMENT=production
or
ENVIRONMENT=local
It automatically sets OPENPIPE_API_KEY and OPENPIPE_BASE_URL.

Also, added a condition to skip lastLoggedCall() tests in production.