### PR TITLE
Delete fine-tune results from eval when fine-tune deleted

### DIFF
--- a/app/src/server/api/routers/fineTunes.router.ts
+++ b/app/src/server/api/routers/fineTunes.router.ts
@@ -301,6 +301,13 @@ export const fineTunesRouter = createTRPCRouter({
           id: input.id,
         },
       });
+
+      await prisma.datasetEvalOutputSource.deleteMany({
+        where: {
+          modelId: input.id,
+        },
+      });
+
       return success("Fine tune deleted");
     }),
   listTrainingEntries: protectedProcedure


### PR DESCRIPTION
Results themselves should delete by cascade when output sources are deleted.