### PR TITLE
Retry relabel task up to 30 times

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntriesTable.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/DatasetEntriesTable.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { Card, Table, Tbody } from "@chakra-ui/react";
-import { RelabelRequestStatus } from "@prisma/client";
 
 import { useDatasetEntries } from "~/utils/hooks";
+import { useFilters } from "~/components/Filters/useFilters";
 import { TableHeader, TableRow, EmptyTableRow } from "./TableRow";
 import DatasetEntryDrawer from "./DatasetEntryDrawer/DatasetEntryDrawer";
+import { GeneralFiltersDefaultFields } from "~/types/shared.types";
 
 export default function DatasetEntriesTable() {
   const [expandedDatasetEntryPersistentId, setExpandedDatasetEntryPersistentId] = useState<
@@ -13,14 +14,11 @@ export default function DatasetEntriesTable() {
   const [refetchInterval, setRefetchInterval] = useState(0);
   const datasetEntries = useDatasetEntries(refetchInterval).data?.entries;
 
+  const filters = useFilters().filters;
+
   const relabelingVisible = useMemo(
-    () =>
-      !!datasetEntries?.some(
-        (entry) =>
-          entry.relabelStatuses?.[0] &&
-          entry.relabelStatuses[0].status !== RelabelRequestStatus.COMPLETE,
-      ),
-    [datasetEntries],
+    () => filters.some((filter) => filter.field === GeneralFiltersDefaultFields.RelabelBatchId),
+    [filters],
   );
 
   const countingIncomplete = useMemo(

--- a/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/TableRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/DatasetEntriesTable/TableRow.tsx
@@ -173,6 +173,10 @@ const RelabelingStatus = ({ status }: { status?: RelabelRequestStatus }) => {
       color = "gray.500";
       text = "Pending";
       break;
+    case RelabelRequestStatus.COMPLETE:
+      color = "green.500";
+      text = "Complete";
+      break;
     default:
       return null;
   }

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -37,7 +37,7 @@ export function calculateQueryDelay(
   numPreviousTries: number,
   maxDelay = DEFAULT_MAX_DELAY,
 ): number {
-  const baseDelay = Math.min(maxDelay, MIN_DELAY * Math.pow(2, numPreviousTries));
+  const baseDelay = Math.min(maxDelay, MIN_DELAY * Math.pow(1.7, numPreviousTries));
   const jitter = Math.random() * baseDelay;
   return baseDelay + jitter;
 }

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -31,10 +31,13 @@ export type GenerateTestSetEntryJob = {
 const MAX_TRIES = 25;
 
 const MIN_DELAY = 1000; // 1 second
-const MAX_DELAY = 6 * 60 * 60 * 1000; // 6 hours
+const DEFAULT_MAX_DELAY = 6 * 60 * 60 * 1000; // 6 hours
 
-export function calculateQueryDelay(numPreviousTries: number): number {
-  const baseDelay = Math.min(MAX_DELAY, MIN_DELAY * Math.pow(2, numPreviousTries));
+export function calculateQueryDelay(
+  numPreviousTries: number,
+  maxDelay = DEFAULT_MAX_DELAY,
+): number {
+  const baseDelay = Math.min(maxDelay, MIN_DELAY * Math.pow(2, numPreviousTries));
   const jitter = Math.random() * baseDelay;
   return baseDelay + jitter;
 }

--- a/app/src/server/tasks/relabelDatasetEntry.task.ts
+++ b/app/src/server/tasks/relabelDatasetEntry.task.ts
@@ -15,7 +15,7 @@ export type RelabelDatasetEntryJob = {
   numPreviousTries: number;
 };
 
-const MAX_TRIES = 25;
+const MAX_TRIES = 30;
 
 export const relabelDatasetEntry = defineTask<RelabelDatasetEntryJob>({
   id: "relabelDatasetEntry",
@@ -95,7 +95,7 @@ export const relabelDatasetEntry = defineTask<RelabelDatasetEntryJob>({
             numPreviousTries: numPreviousTries + 1,
           },
           {
-            runAt: new Date(Date.now() + calculateQueryDelay(numPreviousTries, 60 * 60 * 1000)),
+            runAt: new Date(Date.now() + calculateQueryDelay(numPreviousTries)),
             priority: 3,
           },
         );

--- a/app/src/server/tasks/relabelDatasetEntry.task.ts
+++ b/app/src/server/tasks/relabelDatasetEntry.task.ts
@@ -95,7 +95,7 @@ export const relabelDatasetEntry = defineTask<RelabelDatasetEntryJob>({
             numPreviousTries: numPreviousTries + 1,
           },
           {
-            runAt: new Date(Date.now() + calculateQueryDelay(numPreviousTries, 30000)),
+            runAt: new Date(Date.now() + calculateQueryDelay(numPreviousTries, 60 * 60 * 1000)),
             priority: 3,
           },
         );


### PR DESCRIPTION
Previously, we didn't retry relabeling tasks after they ran into an error. Now we retry up to 25 times with exponential backoff.