### PR TITLE
Order by role before createdAt

### DIFF
--- a/app/src/server/api/routers/projects.router.ts
+++ b/app/src/server/api/routers/projects.router.ts
@@ -109,9 +109,9 @@ export const projectsRouter = createTRPCRouter({
               .innerJoin("User as u", "u.id", "pu.userId")
               .select(["pu.createdAt", "pu.role", "u.id as userId", "u.name", "u.email"])
               .whereRef("pu.projectId", "=", "p.id")
-              .orderBy("pu.createdAt", "asc")
               // Take advantage of fact that ADMIN is alphabetically before MEMBER and VIEWER
-              .orderBy("pu.role", "asc"),
+              .orderBy("pu.role", "asc")
+              .orderBy("pu.createdAt", "asc"),
           ).as("projectUsers"),
           jsonArrayFrom(
             eb


### PR DESCRIPTION
Project membership level is more important than when someone joined a project, so we should give it greater cardinality.