### PR TITLE
Skip creating pruning rule matches a second time

### DIFF
--- a/app/src/server/utils/updatePruningRuleMatches.ts
+++ b/app/src/server/utils/updatePruningRuleMatches.ts
@@ -73,6 +73,7 @@ export const updateDatasetPruningRuleMatches = async (
             "DatasetEntry.id as datasetEntryId",
           ]),
       )
+      .onConflict((oc) => oc.columns(["pruningRuleId", "datasetEntryId"]).doNothing())
       .execute();
   }
 };


### PR DESCRIPTION
When a dataset has an enormous number of entries, pruning rule matches can take some time to calculate. If, due to the high latency, the user triggers a second update to a rule before the first one's matches are fully calculated, we might try to create duplicate matches. Let's avoid this by ignoring conflicting unique keys.

Sentry error: https://openpipe.sentry.io/issues/4907046810/?alert_rule_id=14584639&alert_timestamp=1705990095077&alert_type=email&environment=production&notification_uuid=ae5441b7-98cb-4ac2-a2b4-fa6fdb203ab5&project=4505642011394048&referrer=alert_email