### PR TITLE
Don't try to update the launch config unnecessarily

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -3,7 +3,7 @@ import { vpc } from "./src/vpc";
 import "./src/app-service";
 import "./src/app-worker";
 import "./src/dns";
-export * from "./src/metrics";
+// export * from "./src/metrics";
 export { dbConnectionString } from "./src/database";
 export { deployAccessKeyId, deployAccessKeySecret } from "./src/deployUser";
 export * from "./src/vanta";

--- a/infra/src/cluster.ts
+++ b/infra/src/cluster.ts
@@ -9,53 +9,55 @@ import { deployUser } from "./deployUser";
 const cfg = new pulumi.Config();
 const numk8sNodes = cfg.getNumber("numK8sNodes") ?? 1;
 
-export const cluster = new eks.Cluster(nm("main"), {
-  vpcId: vpc.vpcId,
-  // Public subnets will be used for load balancers
-  publicSubnetIds: vpc.publicSubnetIds,
-  // Private subnets will be used for cluster nodes
-  privateSubnetIds: vpc.privateSubnetIds,
-  instanceType: "m5.4xlarge",
-  nodeRootVolumeSize: 100,
-  desiredCapacity: numk8sNodes,
-  minSize: 1,
-  maxSize: 6,
-  nodeAssociatePublicIpAddress: false,
-  endpointPrivateAccess: false,
-  endpointPublicAccess: true,
-  userMappings: [
-    {
-      userArn: deployUser.arn,
-      username: deployUser.name,
-      groups: ["system:masters"],
-    },
-    {
-      userArn: "arn:aws:iam::844303249414:user/kyle",
-      username: "kyle",
-      groups: ["system:masters"],
-    },
-    {
-      userArn: "arn:aws:iam::844303249414:user/david",
-      username: "david",
-      groups: ["system:masters"],
-    },
-  ],
-});
+export const cluster = new eks.Cluster(
+  nm("main"),
+  {
+    vpcId: vpc.vpcId,
+    // Public subnets will be used for load balancers
+    publicSubnetIds: vpc.publicSubnetIds,
+    // Private subnets will be used for cluster nodes
+    privateSubnetIds: vpc.privateSubnetIds,
+    instanceType: "m5.4xlarge",
+    nodeRootVolumeSize: 100,
+    desiredCapacity: numk8sNodes,
+    minSize: 1,
+    maxSize: 6,
+    nodeAssociatePublicIpAddress: false,
+    endpointPrivateAccess: false,
+    endpointPublicAccess: true,
+    userMappings: [
+      {
+        userArn: deployUser.arn,
+        username: deployUser.name,
+        groups: ["system:masters"],
+      },
+      {
+        userArn: "arn:aws:iam::844303249414:user/kyle",
+        username: "kyle",
+        groups: ["system:masters"],
+      },
+      {
+        userArn: "arn:aws:iam::844303249414:user/david",
+        username: "david",
+        groups: ["system:masters"],
+      },
+    ],
+  },
+  {
+    transformations: [
+      (args) => {
+        if (args.type === "aws:ec2/launchConfiguration:LaunchConfiguration") {
+          return {
+            ...args,
+            opts: pulumi.mergeOptions(args.opts, { ignoreChanges: ["imageId"] }),
+          };
+        }
+        return undefined;
+      },
+    ],
+  },
+);
 
 export const eksProvider = new k8s.Provider(nm("eks"), {
   kubeconfig: cluster.kubeconfigJson,
 });
-
-// new eks.NodeGroupV2(nm("main"), {
-//   cluster: cluster,
-//   instanceType: "m5.4xlarge",
-//   desiredCapacity: 1,
-//   // desiredCapacity: numk8sNodes,
-//   minSize: 1,
-//   maxSize: 6,
-//   nodeRootVolumeSize: 100,
-//   nodeAssociatePublicIpAddress: false,
-//   labels: {
-//     nodegroup: "main",
-//   },
-// });


### PR DESCRIPTION
Every time we deploy Pulumi wants to update our k8s cluster to the latest version of the AMI base image. This is unnecessary and leads to downtime because for some reason Pulumi's rollout strategy doesn't bring up the new nodes until after the old ones are gone. There's no reason to always be on the latest AMI, so let's just leave it at a version we know works.

Also removes graphana/prometheus from the cluster for now because we aren't using it for anything atm anyway.