### PR TITLE
Use Anyscale responses

### DIFF
--- a/app/src/modelProviders/fine-tuned/benchmark.ts
+++ b/app/src/modelProviders/fine-tuned/benchmark.ts
@@ -77,6 +77,6 @@ export function benchmarkCompletions(
       });
     });
 
-  return modalCompletion;
-  // return firstSuccessful([modalCompletion, anyscaleCompletion]);
+  // return modalCompletion;
+  return firstSuccessful([modalCompletion, anyscaleCompletion]);
 }


### PR DESCRIPTION
We'll now be dual-homing all requests to Anyscale and Modal, and returning to the user whichever one gets back first.