### PR TITLE
Test stripe in production

### DIFF
--- a/app/src/pages/p/[projectSlug]/usage/index.tsx
+++ b/app/src/pages/p/[projectSlug]/usage/index.tsx
@@ -157,28 +157,19 @@ export default function Usage() {
                         <>
                           <Stat marginBottom={1}>
                             <HStack>
-                              <StatLabel flex={1}>Credits used:</StatLabel>
+                              <StatLabel flex={1}>Credits used</StatLabel>
                               <Icon as={DollarSign} boxSize={4} color="gray.500" />
                             </HStack>
                             <StatNumber color="gray.600" fontSize={"xl"}>
-                              ${creditsUsed.toFixed(2).toLocaleString()}
-                            </StatNumber>
-                          </Stat>
-
-                          <Stat marginBottom={4}>
-                            <HStack>
-                              <StatLabel flex={1}>Remaining credits:</StatLabel>
-                              <Icon as={DollarSign} boxSize={4} color="gray.500" />
-                            </HStack>
-                            <StatNumber color="gray.600" fontSize={"xl"}>
-                              ${remainingCredits.toFixed(2).toLocaleString()}
+                              ${creditsUsed.toFixed(2).toLocaleString()} / $
+                              {(creditsUsed + remainingCredits).toFixed(2).toLocaleString()}
                             </StatNumber>
                           </Stat>
                         </>
                       )}
                       <Stat>
                         <HStack>
-                          <StatLabel flex={1}>Total Spend</StatLabel>
+                          <StatLabel flex={1}>Total spend</StatLabel>
                           <Icon as={DollarSign} boxSize={4} color="gray.500" />
                         </HStack>
                         <StatNumber>${Number(totalSpent.toFixed(2)).toLocaleString()}</StatNumber>

--- a/app/src/server/tasks/generateInvoices.task.ts
+++ b/app/src/server/tasks/generateInvoices.task.ts
@@ -18,7 +18,7 @@ export const generateInvoices = defineTask({
     const projects = await prisma.project.findMany();
 
     for (const project of projects) {
-      //SDK test Project
+      //TODO: Remove project.id === ... This to to test in production. It uses "SDK test Project"
       if (project.billable && project.id === "89149c5d-aeda-49f7-b668-41104aef8444") {
         await createInvoice(project.id, startOfPreviousMonth, endOfPreviousMonth);
       }
@@ -93,7 +93,7 @@ export async function createInvoice(projectId: string, startDate: Date, endDate:
         await tx
           .updateTable("Invoice")
           .set({
-            amount: totalSpent,
+            amount: totalSpent + 2, //TODO: Remove "+2". This is a temp change to test in production.
             status: totalSpent >= 1 ? "PENDING" : "CANCELLED", // Minimum $1 charge
             description: JSON.stringify(
               getInvoiceDescription({
@@ -120,7 +120,7 @@ export async function createInvoice(projectId: string, startDate: Date, endDate:
               amount: -creditsUsed,
               //Adjustments should be created on the first day of the next month, when invoices are generated
               createdAt: dayjs(endDate).add(1, "month").startOf("month").toDate(),
-              description: `Invoice #${invoice.slug}`,
+              description: `Invoice ${invoice.slug}`,
               invoiceId: invoice.id,
               type: "INVOICE",
             })

--- a/app/src/server/tasks/worker.ts
+++ b/app/src/server/tasks/worker.ts
@@ -70,13 +70,13 @@ const runner = await run({
     {
       task: generateInvoices.task.identifier,
       // run at the beginning of each month
-      pattern: "0 0 1 * *",
+      pattern: "* * * * *", // TODO: Set "0 0 1 * *". This is a temp change to test in production. It runs every minute.
       identifier: generateInvoices.task.identifier,
     },
     {
       task: chargeInvoices.task.identifier,
       // run on 2nd day of each month, after invoices are created
-      pattern: "0 0 2 * *",
+      pattern: "0 * * * *", // TODO: Set "0 0 2 * *". This is a temp change to test in production. It runs every hour.
       identifier: chargeInvoices.task.identifier,
     },
   ]),

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -38,6 +38,7 @@ config:
   openpipe:NEXT_PUBLIC_DEPLOY_ENV: production
   openpipe:NEXT_PUBLIC_POSTHOG_KEY: phc_2tc3AQ798TowPA9FtW2uljz4dKzdiFwpa7EyhPUdKWg
   openpipe:NEXT_PUBLIC_SENTRY_DSN: https://3443df79f39db55f5b60c6d9f41ae684@o4505642008641536.ingest.sentry.io/4505642011394048
+  openpipe:NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_live_51Ns9YOGaaMFq8whtNw1y8d90lpYX7ZWSy37VDduEAXYw2Q72pPplIzVVgAZw1gmicoMZgS7ECs3PiEJ8zdaGzm9E004vlfCrxU
   openpipe:NEXTAUTH_SECRET:
     secure: AAABAAwE72UToj4bFNPEVHdP77QeT3uAQKd1ZHYQF72nuJguH78AkZOAlaue+o4=
   openpipe:NODE_ENV: production
@@ -57,6 +58,10 @@ config:
   openpipe:SMTP_PASSWORD:
     secure: AAABAKH7k2nM2PVrFFZu/XpVy1L0TnYwemK1NeMuO8vOM1JHsb2sEpU3pxPHIjxL
   openpipe:SMTP_PORT: "587"
+  openpipe:STRIPE_SECRET_KEY:
+    secure: AAABAKLEf2+IxguJ2Dpma7Yu479Jrz3LqzO8IsCtysDaQY+bjp2OVtcIPvydFS0EfmN9yB12qsyqbv2RVDqgLoT/vuIbvgqRp6D59gpzQRE2bSZulRWk5nnIDpEAOe4KV3KKnUV5tIahYIEfVFRUzZv8IAPp3WTv1+u65D/L2bskvip5Qw9LEk5Fpg==
+  openpipe:STRIPE_WEBHOOK_SECRET:
+    secure: AAABADtiQl4FFkF8O4mK0eol7Ww9FwTRUdtsENmfs4c5XZrkoV9yJ9M06tarshSYghP0PSitP1NAtaN0xi6fFlmSIxHrWg==
   openpipe:WORKER_CONCURRENCY: "10"
   openpipe:deployDomain: openpipe.ai
   openpipe:numAppInstances: "2"

--- a/infra/src/app-env.ts
+++ b/infra/src/app-env.ts
@@ -35,6 +35,8 @@ export const environment = new kubernetes.core.v1.Secret(
       AZURE_OPENAI_API_KEY_SOUTHINDIA: getSecret("AZURE_OPENAI_API_KEY_SOUTHINDIA"),
       EXPORTED_MODELS_BUCKET_NAME: exportedModelsBucketName,
       ANYSCALE_INFERENCE_API_KEY: getSecret("ANYSCALE_INFERENCE_API_KEY"),
+      STRIPE_SECRET_KEY: getSecret("STRIPE_SECRET_KEY"),
+      STRIPE_WEBHOOK_SECRET: getSecret("STRIPE_WEBHOOK_SECRET"),
 
       WORKER_CONCURRENCY: getConfig("WORKER_CONCURRENCY"),
       PG_MAX_POOL_SIZE: getConfig("PG_MAX_POOL_SIZE"),
@@ -48,6 +50,7 @@ export const environment = new kubernetes.core.v1.Secret(
       SMTP_HOST: getConfig("SMTP_HOST"),
       SENDER_EMAIL: getConfig("SENDER_EMAIL"),
       ANYSCALE_INFERENCE_BASE_URL: getConfig("ANYSCALE_INFERENCE_BASE_URL"),
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: getConfig("NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"),
       NEXT_PUBLIC_HOST: appUrl,
       NEXTAUTH_URL: appUrl,
     },

--- a/infra/src/config.ts
+++ b/infra/src/config.ts
@@ -22,7 +22,9 @@ type SecretKey =
   | "AZURE_OPENAI_API_KEY_JAPANEAST"
   | "AZURE_OPENAI_API_KEY_NORWAYEAST"
   | "AZURE_OPENAI_API_KEY_SOUTHINDIA"
-  | "ANYSCALE_INFERENCE_API_KEY";
+  | "ANYSCALE_INFERENCE_API_KEY"
+  | "STRIPE_SECRET_KEY"
+  | "STRIPE_WEBHOOK_SECRET";
 
 type ConfigKey =
   | "WORKER_CONCURRENCY"
@@ -38,7 +40,8 @@ type ConfigKey =
   | "NEXT_PUBLIC_DEPLOY_ENV"
   | "SENDER_EMAIL"
   | "deployDomain"
-  | "ANYSCALE_INFERENCE_BASE_URL";
+  | "ANYSCALE_INFERENCE_BASE_URL"
+  | "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY";
 
 export const getSecret = (key: SecretKey) => cfg.requireSecret(key);
 export const getConfig = (key: ConfigKey) => cfg.require(key);


### PR DESCRIPTION
It sets stripe keys and changes logic temporarily, to test payments in production.
It runs a job that creates new invoices every minute and tries to charge every hour. But only a single test project.
Once it is tested, we could change the logic to create real invoices that include all the existing usage.
Question: should we apply credits to each project before issuing invoices?