### PR TITLE
Adds an exported OpenPipe client at "openpipe/client"

### DIFF
--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {
@@ -19,6 +19,10 @@
       ".": {
         "import": "./index.js",
         "require": "./index.cjs"
+      },
+      "./client": {
+        "import": "./client.js",
+        "require": "./client.cjs"
       },
       "./openai": {
         "import": "./openai.js",

--- a/client-libs/typescript/package.json
+++ b/client-libs/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpipe-dev",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "LLM metrics and inference",
   "scripts": {

--- a/client-libs/typescript/src/client.ts
+++ b/client-libs/typescript/src/client.ts
@@ -1,0 +1,26 @@
+import { readEnv } from "openai/core";
+
+import { OPClient } from "./codegen";
+import { OpenPipeConfig } from "./shared";
+
+export default class OpenPipe {
+  baseClient: OPClient;
+
+  constructor(config: OpenPipeConfig = {}) {
+    const openPipeApiKey = config?.apiKey ?? readEnv("OPENPIPE_API_KEY");
+    const openpipeBaseUrl = config?.baseUrl ?? readEnv("OPENPIPE_BASE_URL");
+
+    this.baseClient = new OPClient({
+      BASE: openpipeBaseUrl,
+      TOKEN: openPipeApiKey,
+    });
+  }
+
+  updateLogTags(...params: Parameters<OPClient["default"]["updateLogTags"]>) {
+    return this.baseClient.default.updateLogTags(...params);
+  }
+
+  report(...params: Parameters<OPClient["default"]["report"]>) {
+    return this.baseClient.default.report(...params);
+  }
+}

--- a/client-libs/typescript/src/openai/updateLogTags.test.ts
+++ b/client-libs/typescript/src/openai/updateLogTags.test.ts
@@ -1,12 +1,12 @@
 // import dotenv from "dotenv";
 import { expect, test } from "vitest";
 import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
-import { OPClient } from "../codegen";
+import OpenPipe from "../client";
 import { OPENPIPE_API_KEY, OPENPIPE_API_URL, TEST_LAST_LOGGED } from "./setup";
 
-const opClient = new OPClient({
-  BASE: OPENPIPE_API_URL,
-  TOKEN: OPENPIPE_API_KEY,
+const opClient = new OpenPipe({
+  baseUrl: OPENPIPE_API_URL,
+  apiKey: OPENPIPE_API_KEY,
 });
 
 const respPayload = {
@@ -32,7 +32,8 @@ const respPayload = {
 
 const generateRandomId = () => Math.random().toString(36).substring(7);
 
-const lastLoggedCall = async () => opClient.default.localTestingOnlyGetLatestLoggedCall();
+const lastLoggedCall = async () =>
+  opClient.baseClient.default.localTestingOnlyGetLatestLoggedCall();
 
 test("adds tags", async () => {
   const payload: ChatCompletionCreateParams = {
@@ -42,7 +43,7 @@ test("adds tags", async () => {
 
   const originalPromptId = "original prompt id " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -57,7 +58,7 @@ test("adds tags", async () => {
     otherId: "value 3",
   };
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [{ field: "tags.prompt_id", equals: originalPromptId }],
     tags: newTags,
   });
@@ -81,7 +82,7 @@ test("updates tags", async () => {
 
   const originalPromptId = "original prompt id " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -93,7 +94,7 @@ test("updates tags", async () => {
     },
   });
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -110,7 +111,7 @@ test("updates tags", async () => {
     otherId: "value 3",
   };
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [{ field: "tags.prompt_id", equals: originalPromptId }],
     tags: updatedTags,
   });
@@ -135,7 +136,7 @@ test("updates tag by completionId", async () => {
 
   const originalPromptId = "original prompt id " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -150,7 +151,7 @@ test("updates tag by completionId", async () => {
     },
   });
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -170,7 +171,7 @@ test("updates tag by completionId", async () => {
     otherId: "value 3",
   };
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [{ field: "completionId", equals: completionId }],
     tags: updatedTags,
   });
@@ -195,7 +196,7 @@ test("updates tag by model", async () => {
 
   const originalPromptId = "original prompt id " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -212,7 +213,7 @@ test("updates tag by model", async () => {
     otherId: "value 3",
   };
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [{ field: "model", equals: model }],
     tags: updatedTags,
   });
@@ -237,7 +238,7 @@ test("updates by combination of filters", async () => {
 
   const originalPromptId = "original prompt id " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -254,7 +255,7 @@ test("updates by combination of filters", async () => {
     otherId: "value 3",
   };
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [
       { field: "model", equals: model },
       { field: "tags.prompt_id", equals: originalPromptId },
@@ -283,7 +284,7 @@ test("updates some tags by combination of filters", async () => {
 
   const originalPromptId = "original prompt id " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -295,7 +296,7 @@ test("updates some tags by combination of filters", async () => {
     },
   });
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -307,7 +308,7 @@ test("updates some tags by combination of filters", async () => {
     },
   });
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: {
@@ -327,7 +328,7 @@ test("updates some tags by combination of filters", async () => {
     otherId: "value 3",
   };
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [
       { field: "model", equals: model },
       { field: "tags.prompt_id", equals: originalPromptId },
@@ -355,7 +356,7 @@ test("deletes tags", async () => {
   const keepPromptId = "prompt id for tag to keep " + generateRandomId();
   const deletePromptId = "prompt id for tag to delete " + generateRandomId();
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -367,7 +368,7 @@ test("deletes tags", async () => {
     },
   });
 
-  const keepResp = await opClient.default.updateLogTags({
+  const keepResp = await opClient.updateLogTags({
     filters: [{ field: "tags.prompt_id", equals: deletePromptId }],
     tags: { prompt_id: null },
   });
@@ -379,7 +380,7 @@ test("deletes tags", async () => {
     expect(keepLoggedCall?.tags.prompt_id).toEqual(keepPromptId);
   }
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -391,7 +392,7 @@ test("deletes tags", async () => {
     },
   });
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [{ field: "tags.prompt_id", equals: deletePromptId }],
     tags: { prompt_id: null },
   });
@@ -407,7 +408,7 @@ test("deletes tags", async () => {
 
 test("deletes nothing when no tags matched", async () => {
   const originalPromptId = "id 1";
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: null,
@@ -416,7 +417,7 @@ test("deletes nothing when no tags matched", async () => {
       prompt_id: originalPromptId,
     },
   });
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [{ field: "tags.prompt_id", equals: generateRandomId() }],
     tags: { prompt_id: null },
   });
@@ -436,7 +437,7 @@ test("deletes from all logged calls when no filters provided", async () => {
     messages: [{ role: "system", content: "count to 3" }],
   };
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -446,7 +447,7 @@ test("deletes from all logged calls when no filters provided", async () => {
     },
   });
 
-  await opClient.default.report({
+  await opClient.report({
     requestedAt: Date.now(),
     receivedAt: Date.now(),
     reqPayload: payload,
@@ -456,7 +457,7 @@ test("deletes from all logged calls when no filters provided", async () => {
     },
   });
 
-  const resp = await opClient.default.updateLogTags({
+  const resp = await opClient.updateLogTags({
     filters: [],
     tags: { promptId: null },
   });

--- a/client-libs/typescript/tsup.config.ts
+++ b/client-libs/typescript/tsup.config.ts
@@ -9,6 +9,7 @@ const config: Options = {
   // Define entry points
   entry: [
     "src/index.ts", // Main entry
+    "src/client.ts", // 'client' sub-module
     "src/openai.ts", // 'openai' sub-module
     "src/openai/mergeChunks.ts", // 'openai/mergeChunks' sub-module
     "src/openai/streaming.ts", // 'openai/streaming' sub-module

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,42 +446,6 @@ importers:
         specifier: ^0.33.0
         version: 0.33.0
 
-  inference:
-    dependencies:
-      '@types/lodash-es':
-        specifier: ^4.17.8
-        version: 4.17.8
-      '@types/node':
-        specifier: ^20.11.10
-        version: 20.11.10
-      '@types/yargs':
-        specifier: ^17.0.26
-        version: 17.0.26
-      dotenv:
-        specifier: ^16.3.1
-        version: 16.3.1
-      execa:
-        specifier: ^8.0.1
-        version: 8.0.1
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
-      tsx:
-        specifier: ^3.12.7
-        version: 3.12.7
-      type-fest:
-        specifier: ^4.0.0
-        version: 4.0.0
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
-      zod:
-        specifier: ^3.22.4
-        version: 3.22.4
-
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -3322,6 +3286,7 @@ packages:
     resolution: {integrity: sha512-euY3XQcZmIzSy7YH5+Unb3b2X12Wtk54YWINBvvGQ5SmMvwb11JQskGsfkH/5HXK77Kr8GF0wkVDIxzAisWtog==}
     dependencies:
       '@types/lodash': 4.14.197
+    dev: true
 
   /@types/lodash.clonedeep@4.5.7:
     resolution: {integrity: sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==}
@@ -3376,7 +3341,6 @@ packages:
     resolution: {integrity: sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==}
     dependencies:
       undici-types: 5.26.5
-    dev: false
 
   /@types/node@20.4.10:
     resolution: {integrity: sha512-vwzFiiy8Rn6E0MtA13/Cxxgpan/N6UeNYR9oUu6kuJWxu6zCk98trcDp8CBhbtaeuq9SykCmXkFr2lWLoPcvLg==}
@@ -3519,11 +3483,13 @@ packages:
 
   /@types/yargs-parser@21.0.1:
     resolution: {integrity: sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==}
+    dev: true
 
   /@types/yargs@17.0.26:
     resolution: {integrity: sha512-Y3vDy2X6zw/ZCumcwLpdhM5L7jmyGpmBCTYMHDLqT2IKVMYRRLdv6ZakA+wxhra6Z/3bwhNbNl9bDGXaFU+6rw==}
     dependencies:
       '@types/yargs-parser': 21.0.1
+    dev: true
 
   /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4):
     resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
@@ -6721,7 +6687,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.4.10
+      '@types/node': 20.11.10
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
Usage:

```typescript
import OpenPipe from 'openpipe/client'

const client = new OpenPipe({ apiKey: "" })

client.updateLogTags({
    filters: [{ field: "tags.prompt_id", equals: originalPromptId }],
    tags: updatedTags,
  })
```

No documentation yet.