### PR TITLE
Remove unnecessary importlib-resources package

### DIFF
--- a/client-libs/python/poetry.lock
+++ b/client-libs/python/poetry.lock
@@ -324,24 +324,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-resources"
-version = "6.1.1"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.1.1-py3-none-any.whl", hash = "sha256:e8bf90d8213b486f428c9c39714b920041cb02c184686a3dee24905aaa8105d6"},
-    {file = "importlib_resources-6.1.1.tar.gz", hash = "sha256:3893a00122eafde6894c59914446a512f728a0c1a45f9bb9b63721b6bacf0b4a"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff", "zipp (>=3.17)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -804,22 +786,7 @@ files = [
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
 
-[[package]]
-name = "zipp"
-version = "3.17.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
-    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
-]
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "fcad8f5c84ce829ce54d29499279f0783376c4819a4d533fd867f680a80ab7f6"
+content-hash = "e3f79ec0ab7665e2a560669ea5a52dc1d55aac6fb4f9503d5effbdb3aa59b936"

--- a/client-libs/python/pyproject.toml
+++ b/client-libs/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openpipe"
-version = "4.4.0"
+version = "4.4.1"
 description = "Python client library for the OpenPipe service"
 authors = ["Kyle Corbitt <kyle@openpipe.ai>"]
 license = "Apache-2.0"
@@ -14,7 +14,6 @@ httpx = "^0.24.1"
 attrs = "^23.1.0"
 python-dateutil = "^2.8.2"
 openai = "~1.7.0"
-importlib-resources = "^6.1.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/docs/features/updating-tags.mdx
+++ b/docs/features/updating-tags.mdx
@@ -98,7 +98,7 @@ Keep in mind that filters are cumulative, so only request logs that match all of
 
 ### Tags
 
-Provide one or more tags in a json object to be updated. The key should be the name of the tag you'd like to add, update, or delete. The value should be the new value of the tag.
+Provide one or more tags in a json object. The key should be the name of the tag you'd like to add, update, or delete. The value should be the new value of the tag.
 If you'd like to delete a tag, provide a value of `None` or `null`.
 
 Updated tags will be searchable in the [Request Logs](/features/request-logs) panel.


### PR DESCRIPTION
It turns out importlib.metadata was built in to python 3.8, so we don't need an extra package to determine which version of the SDK we're using.