### PR TITLE
Remove docs on relabeling tags

### DIFF
--- a/docs/features/updating-tags.mdx
+++ b/docs/features/updating-tags.mdx
@@ -34,7 +34,6 @@ resp = op_client.update_log_tags(
     ],
     tags={
         "relabel": "true",
-        "add_to_dataset": "original_model_dataset",
         "tag_to_remove": None # this will remove the tag_to_remove tag from the request log we just created
     },
 )
@@ -74,7 +73,6 @@ const resp = await opClient.updateLogTags({
   ],
   tags: {
     relabel: "true",
-    add_to_dataset: "original_model_dataset",
     tag_to_remove: null, // this will remove the tag_to_remove tag from the request log we just created
   },
 });


### PR DESCRIPTION
Until we have better docs on relabeling, it's better to avoid documenting it altogether.