### PR TITLE
Invalidate logged call count on refresh

### DIFF
--- a/app/src/pages/p/[projectSlug]/request-logs/index.tsx
+++ b/app/src/pages/p/[projectSlug]/request-logs/index.tsx
@@ -47,7 +47,10 @@ export default function LoggedCalls() {
                 />
               }
               isDisabled={isFetching || isLoading}
-              onClick={() => void utils.loggedCalls.list.invalidate()}
+              onClick={() => {
+                void utils.loggedCalls.list.invalidate();
+                void utils.loggedCalls.getMatchingCount.invalidate();
+              }}
             />
           </HStack>
           <HStack w="full" justifyContent="space-between">

--- a/app/src/utils/api.ts
+++ b/app/src/utils/api.ts
@@ -4,7 +4,7 @@
  *
  * We also create a few inference helpers for input and output types.
  */
-import { httpBatchLink, httpLink, splitLink, loggerLink } from "@trpc/client";
+import { httpBatchLink, splitLink, loggerLink } from "@trpc/client";
 import { createTRPCNext } from "@trpc/next";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import superjson from "superjson";
@@ -40,9 +40,10 @@ export const api = createTRPCNext<AppRouter>({
         }),
         splitLink({
           condition(op) {
-            return op.context.skipBatch === true;
+            return op.context.slowBatch === true;
           },
-          true: httpLink({
+          // separate batching for slow requests
+          true: httpBatchLink({
             url: `${getBaseUrl()}/api/trpc`,
           }),
           false: httpBatchLink({

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -304,7 +304,7 @@ export const useLoggedCallsCount = () => {
       refetchOnWindowFocus: false,
       trpc: {
         context: {
-          skipBatch: true,
+          slowBatch: true,
         },
       },
     },


### PR DESCRIPTION
Both the calls themselves and the number of calls should be invalidated when we refresh.