### PR TITLE
Index LoggedCallTags by value

### DIFF
--- a/app/prisma/migrations/20240208012802_add_index_on_logged_call_tags_values/migration.sql
+++ b/app/prisma/migrations/20240208012802_add_index_on_logged_call_tags_values/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "LoggedCallTag_value_name_projectId_idx" ON "LoggedCallTag"("value", "name", "projectId");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -286,6 +286,7 @@ model LoggedCallTag {
     @@index([name, projectId])
     @@index([projectId, name])
     @@index([projectId, name, value])
+    @@index([value, name, projectId])
 }
 
 enum ApiKeyProvider {

--- a/infra/src/database.ts
+++ b/infra/src/database.ts
@@ -27,7 +27,7 @@ const dbInstance = new aws.rds.Instance(nm("app"), {
   password: password.result,
   dbName,
   instanceClass: "db.m7g.2xlarge",
-  allocatedStorage: 400,
+  allocatedStorage: 750,
   maxAllocatedStorage: 1000,
   storageType: "io1",
   iops: 12000,
@@ -42,7 +42,7 @@ const dbInstance = new aws.rds.Instance(nm("app"), {
   performanceInsightsEnabled: true,
   multiAz: isProd,
   skipFinalSnapshot: !isProd,
-  snapshotIdentifier: isProd ? undefined : "rds:app-pl-prod2de906e-2024-01-16-08-43",
+  snapshotIdentifier: isProd ? undefined : "rds:app-pl-prod2de906e-2024-02-06-08-43",
   finalSnapshotIdentifier: nm("app-db-final-snapshot"),
 });
 


### PR DESCRIPTION
Since `projectId` and `name` have very low cardinality, adding an index that starts by `value` helps Postgres get this query faster.

For my test query this dropped query time from 1500ms (with caches already hot) to 1ms.