### PR TITLE
Convert non-breaking spaces into regular spaces

### DIFF
--- a/app/src/components/FormattedJson.tsx
+++ b/app/src/components/FormattedJson.tsx
@@ -28,7 +28,8 @@ const FormattedJson = ({ json }: { json: any }) => {
         }}
         wrapLines
       >
-        {jsonString}
+        {/* convert non-breaking spaces into regular spaces */}
+        {jsonString.replace(/[\u00A0]+/g, " ")}
       </SyntaxHighlighter>
       <IconButton
         aria-label="Copy"


### PR DESCRIPTION
When the contents of a SyntaxHighlighter contains nonbreaking spaces (e.g. &nbsp; aka \u00A0), we should display them as breaking spaces to prevent our highlighted json blocks from expanding too widely.