### PR TITLE
Record updated tag names on project

### DIFF
--- a/app/src/server/api/external/v1Api.router.ts
+++ b/app/src/server/api/external/v1Api.router.ts
@@ -28,6 +28,7 @@ import {
   recordLoggedCall,
   recordUsage,
   reqValidator,
+  recordTagNames,
 } from "~/utils/recordRequest";
 import { getOpenaiCompletion } from "~/server/utils/openai";
 import { parseTags } from "~/server/utils/parseTags";
@@ -540,6 +541,11 @@ export const v1ApiRouter = createOpenApiRouter({
             })),
           )
           .execute();
+
+        await recordTagNames(
+          ctx.key.projectId,
+          tagsToUpsert.map(([name]) => name),
+        );
       }
 
       if (tags["relabel"] === "true" && tags["add_to_dataset"] === "original_model_dataset") {

--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -236,7 +236,7 @@ async function createTags(projectId: string, loggedCallId: string, tags: Record<
 
   const tagNames = tagsToCreate.map((tag) => tag.name);
 
-  await recordTagNames(projectId, tagNames);
+  void recordTagNames(projectId, tagNames).catch((e) => captureException(e));
 }
 
 export async function recordTagNames(projectId: string, tagNames: string[]) {

--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -234,6 +234,12 @@ async function createTags(projectId: string, loggedCallId: string, tags: Record<
 
   await kysely.insertInto("LoggedCallTag").values(tagsToCreate).execute();
 
+  const tagNames = tagsToCreate.map((tag) => tag.name);
+
+  await recordTagNames(projectId, tagNames);
+}
+
+export async function recordTagNames(projectId: string, tagNames: string[]) {
   const project = await kysely
     .selectFrom("Project")
     .where("id", "=", projectId)
@@ -242,11 +248,9 @@ async function createTags(projectId: string, loggedCallId: string, tags: Record<
 
   if (!project) return;
 
-  const tagNames = project.tagNames ?? [];
+  const existingTagNames = project.tagNames ?? [];
 
-  const tagsNamesToAdd = tagsToCreate
-    .filter((tag) => !tagNames.includes(tag.name))
-    .map((tag) => tag.name);
+  const tagsNamesToAdd = tagNames.filter((tagName) => !existingTagNames.includes(tagName));
 
   // optimistically assume that no two requests will simultaneously add different tags
   // this avoids row level locks
@@ -254,7 +258,7 @@ async function createTags(projectId: string, loggedCallId: string, tags: Record<
     await kysely
       .updateTable("Project")
       .set({
-        tagNames: [...tagNames, ...tagsNamesToAdd],
+        tagNames: [...existingTagNames, ...tagsNamesToAdd],
       })
       .where("id", "=", projectId)
       .execute();


### PR DESCRIPTION
Fixes https://github.com/OpenPipe/OpenPipe/issues/570

We should also cache tag names that come in via the updateLogTags endpoint.