### PR TITLE
Retry unreliable Fireworks uploads

### DIFF
--- a/trainer/src/inference_server/main.py
+++ b/trainer/src/inference_server/main.py
@@ -41,7 +41,7 @@ stub = modal.Stub(APP_NAME)
 stub.volume = volume
 stub.vllm_image = vllm_image
 
-with vllm_image.run_inside():
+with vllm_image.imports():
     from vllm import SamplingParams
     from vllm.utils import random_uuid
     from vllm.outputs import RequestOutput


### PR DESCRIPTION
Fireworks LoRA uploads unfortunately sometimes hang. This change automatically times them out after 5 minutes and retries up to 3 times.