### PR TITLE
Bugfix where training cost shows as $0.00

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -125,7 +125,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
       setSelectedBaseModel(visibleModels[0]);
       setModelSlug(humanId({ separator: "-", capitalize: false }));
       setTrainingConfigOverrides(undefined);
-      utils.datasets.getTrainingCosts.invalidate();
+      void utils.datasets.getTrainingCosts.invalidate();
     }
   }, [disclosure.isOpen]);
 
@@ -395,7 +395,6 @@ Controls the magnitude of updates to the model's parameters during training."
         <ModalFooter>
           <VStack alignItems="end">
             <HStack fontSize="sm" spacing={1}>
-              {" "}
               <Text>Estimated training price:</Text>
               <Skeleton startColor="gray.100" endColor="gray.300" isLoaded={!stats.isLoading}>
                 <Text>

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -125,6 +125,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
       setSelectedBaseModel(visibleModels[0]);
       setModelSlug(humanId({ separator: "-", capitalize: false }));
       setTrainingConfigOverrides(undefined);
+      utils.datasets.getTrainingCosts.invalidate();
     }
   }, [disclosure.isOpen]);
 
@@ -394,9 +395,14 @@ Controls the magnitude of updates to the model's parameters during training."
         <ModalFooter>
           <VStack alignItems="end">
             <HStack fontSize="sm" spacing={1}>
+              {" "}
               <Text>Estimated training price:</Text>
               <Skeleton startColor="gray.100" endColor="gray.300" isLoaded={!stats.isLoading}>
-                <Text>${Number(stats.data?.cost ?? 0).toFixed(2)}</Text>
+                <Text>
+                  {stats.data?.calculating
+                    ? "calculating..."
+                    : "$" + Number(stats.data?.cost ?? 0).toFixed(2)}
+                </Text>
               </Skeleton>
             </HStack>
             <HStack>

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -164,7 +164,7 @@ const FineTuneModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) => {
       datasetId: dataset.id,
       filters,
       pruningRuleIds: appliedPruningRuleIds,
-      trainingConfigOverrides,
+      trainingConfigOverrides: advancedConfigEnabled ? trainingConfigOverrides : undefined,
     });
     if (maybeReportError(resp)) return;
 

--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -350,7 +350,7 @@ Controls the magnitude of updates to the model's parameters during training."
 
                       <NumberInput
                         step={0.0001}
-                        min={0.0001}
+                        min={0}
                         max={1000}
                         value={trainingConfigOverrides?.learning_rate}
                         backgroundColor="white"

--- a/app/src/server/api/routers/datasets.router.ts
+++ b/app/src/server/api/routers/datasets.router.ts
@@ -75,6 +75,15 @@ export const datasetsRouter = createTRPCRouter({
         .where("de.split", "=", "TRAIN")
         .where("de.output", "is not", null);
 
+      const datasetCalculationInProgress = await baseQuery
+        .where((eb) => eb.or([eb("de.inputTokens", "is", null), eb("de.outputTokens", "is", null)]))
+        .select("id")
+        .executeTakeFirst();
+
+      if (datasetCalculationInProgress) {
+        return { cost: 0, calculating: true };
+      }
+
       const datasetEntryStats = await baseQuery
         .select([
           sql<number>`count(de.id)::int`.as("numEntries"),
@@ -111,6 +120,7 @@ export const datasetsRouter = createTRPCRouter({
 
       return {
         cost: cost * numEpochs,
+        calculating: false,
       };
     }),
   list: protectedProcedure

--- a/app/src/utils/hooks.ts
+++ b/app/src/utils/hooks.ts
@@ -168,6 +168,7 @@ export const useDatasetTrainingCost = (
   selectedBaseModel: ProviderWithModel,
   pruningRuleIds: string[],
   selectedNumberOfEpochs: number | undefined,
+  refetchInterval?: number,
 ) => {
   const dataset = useDataset().data;
 
@@ -181,7 +182,7 @@ export const useDatasetTrainingCost = (
       pruningRuleIds,
       selectedNumberOfEpochs,
     },
-    { enabled: !!dataset },
+    { enabled: !!dataset, refetchInterval },
   );
 
   return stats;


### PR DESCRIPTION
The calculation issue arises because we recalculate tokens for each dataset entry as a background process in datasetEntries.createFromLoggedCalls function:
`countDatasetEntryTokens.enqueue()`

A simple solution is to check if any entries with `null` tokens exist.

If we consider adding more calculations to the dataset creation function, we could add a column to the dataset table that tracks if the dataset is processed.