### PR TITLE
price fix, openai removed from usage 

### DIFF
--- a/app/src/server/scripts/regenerateInvoices.ts
+++ b/app/src/server/scripts/regenerateInvoices.ts
@@ -1,0 +1,11 @@
+import { prisma } from "../db";
+import { generateInvoices } from "../tasks/generateInvoices.task";
+
+//Delete all existing invoices
+await prisma.invoice.deleteMany({
+  where: { OR: [{ status: "PENDING" }, { status: "CANCELLED" }] }, //Keep paid invoices
+});
+
+console.log("Invoices deleted successfully. Generating new invoices.");
+
+await generateInvoices.enqueue({});

--- a/app/src/server/scripts/updateUsageLogBillable.ts
+++ b/app/src/server/scripts/updateUsageLogBillable.ts
@@ -1,0 +1,23 @@
+import { kysely } from "~/server/db";
+
+//Set usage log billable to false for openai fine tunes TESTING logs
+const usageLogIds = await kysely
+  .selectFrom("UsageLog")
+  .where("UsageLog.type", "=", "TESTING")
+  .innerJoin("FineTune", "FineTune.id", "UsageLog.fineTuneId")
+  .where("FineTune.provider", "=", "openai")
+  .select(["UsageLog.id"])
+  .execute();
+
+const idsToUpdate = usageLogIds.map((row: { id: string }) => row.id);
+
+if (idsToUpdate.length > 0) {
+  console.log(`updating ${idsToUpdate.length} usage logs`);
+  await kysely
+    .updateTable("UsageLog")
+    .set({ billable: false })
+    .where("id", "in", idsToUpdate)
+    .execute();
+} else {
+  console.log(`no usage logs to update`);
+}

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -175,6 +175,7 @@ export const generateTestSetEntry = defineTask<GenerateTestSetEntryJob>({
               inputTokens,
               outputTokens,
               ...calculateCost(fineTune, 0, inputTokens, outputTokens),
+              billable: fineTune.provider === "openpipe",
             },
           });
         }


### PR DESCRIPTION
**Fixed usage price calculation** by adding `billable: fineTune.provider === "openpipe",` to the generateTestSetEntry task.
Previously it calculated OpenAI TESTING usage logs.

**Updated usage page** to display only tokens and requests associated with OpenPipe models.

**Created 2 scripts**:
`pnpm tsx src/server/scripts/updateUsageLogBillable.ts` - searches for all the previous usage logs and updates billable to false if it is associated with an OpenAI model.

`pnpm tsx src/server/scripts/regenerateInvoices.ts` - deletes old (not paid) invoices and starts a task that creates new ones.

Since the price may be slightly different, we might need to remove some credit adjustments manually and rerun this script: zeroCheckedToZeroInvoice.ts