### PR TITLE
Rename Fireworks Mixtral model

### DIFF
--- a/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/InferenceCodeTabs/InferenceCodeTabs.tsx
@@ -3,13 +3,14 @@ import { useMemo } from "react";
 import { type RouterOutputs } from "~/utils/api";
 import { useFineTune, useSelectedProject, useTrainingEntries } from "~/utils/hooks";
 import CopiableCodeTabs, { type CodeTab } from "./CopiableCodeTabs";
+import { env } from "~/env.mjs";
 
 const baseTabs: CodeTab[] = [
   {
     title: "cURL",
     language: "bash",
     code: `curl --request POST \\
---url https://app.openpipe.ai/api/v1/chat/completions \\
+--url ${env.NEXT_PUBLIC_HOST}/api/v1/chat/completions \\
 --header 'Authorization: Bearer {{TEMPLATED_OPENPIPE_API_KEY}}' \\
 --header 'Content-Type: application/json' \\
 --header 'op-log-request: true' \\

--- a/app/src/server/api/internal/v1Api.router.ts
+++ b/app/src/server/api/internal/v1Api.router.ts
@@ -46,7 +46,7 @@ export const v1ApiRouter = createOpenApiRouter({
 
       const fireworksBaseModel =
         fineTune.baseModel === "mistralai/Mixtral-8x7B-Instruct-v0.1"
-          ? "accounts/fireworks/models/mixtral-8x7b-instruct"
+          ? "accounts/fireworks/models/mixtral-8x7b-instruct-hf"
           : undefined;
 
       return {


### PR DESCRIPTION
They renamed their base Mixtral model without telling us, causing Mixtral training to fail. This fixes that.