### PR TITLE
Owner role added

### DIFF
--- a/app/prisma/migrations/20240213192728_added_project_owner/migration.sql
+++ b/app/prisma/migrations/20240213192728_added_project_owner/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ProjectUserRole" ADD VALUE 'OWNER';

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -199,6 +199,7 @@ enum ProjectUserRole {
     ADMIN
     MEMBER
     VIEWER
+    OWNER
 }
 
 model ProjectUser {

--- a/app/src/components/projectSettings/InviteProjectUserModal.tsx
+++ b/app/src/components/projectSettings/InviteProjectUserModal.tsx
@@ -36,7 +36,7 @@ export const InviteProjectUserModal = ({
   const utils = api.useContext();
 
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<ProjectUserRole>("MEMBER");
+  const [role, setRole] = useState<Exclude<ProjectUserRole, "OWNER">>("MEMBER");
 
   useEffect(() => {
     setEmail("");
@@ -77,7 +77,7 @@ export const InviteProjectUserModal = ({
 
             <RadioGroup
               value={role}
-              onChange={(e) => setRole(e as ProjectUserRole)}
+              onChange={(e) => setRole(e as Exclude<ProjectUserRole, "OWNER">)}
               colorScheme="orange"
             >
               <VStack w="full" alignItems="flex-start">

--- a/app/src/components/projectSettings/ProjectUserTable.tsx
+++ b/app/src/components/projectSettings/ProjectUserTable.tsx
@@ -17,10 +17,6 @@ const ProjectUserTable = () => {
   const owner = selectedProject?.projectUsers.find((u) => u.role === "OWNER");
   const utils = api.useContext();
 
-  const canLeaveProject =
-    !isAdmin ||
-    !selectedProject ||
-    selectedProject.projectUsers.filter((u) => u.role === "ADMIN" || u.role === "OWNER").length > 1;
   const [projectUserToRemove, setProjectUserToRemove] = useState<ProjectUser | null>(null);
 
   const cancelInvitationMutation = api.users.cancelProjectInvitation.useMutation();
@@ -76,14 +72,10 @@ const ProjectUserTable = () => {
                   <Td fontSize={{ base: "xs", md: "sm" }}>{member.role}</Td>
                   <Td textAlign="end">
                     {(member.userId === session?.user?.id || isAdmin) &&
-                      member.userId !== owner?.userId &&
                       member.userId !== selectedProject.personalProjectUserId && (
                         <ConditionallyEnable
                           checks={[
-                            [
-                              member.userId !== session?.user?.id || canLeaveProject,
-                              "You are the last remaining admin. If you wish to leave, appoint another admin or delete the project.",
-                            ],
+                            [member.userId !== owner?.userId, "You are an owner of this project."],
                           ]}
                         >
                           <IconButton

--- a/app/src/components/projectSettings/ProjectUserTable.tsx
+++ b/app/src/components/projectSettings/ProjectUserTable.tsx
@@ -14,13 +14,13 @@ const ProjectUserTable = () => {
   const session = useSession().data;
 
   const isAdmin = useAccessCheck("requireIsProjectAdmin").access;
-
+  const owner = selectedProject?.projectUsers.find((u) => u.role === "OWNER");
   const utils = api.useContext();
 
   const canLeaveProject =
     !isAdmin ||
     !selectedProject ||
-    selectedProject.projectUsers.filter((u) => u.role === "ADMIN").length > 1;
+    selectedProject.projectUsers.filter((u) => u.role === "ADMIN" || u.role === "OWNER").length > 1;
   const [projectUserToRemove, setProjectUserToRemove] = useState<ProjectUser | null>(null);
 
   const cancelInvitationMutation = api.users.cancelProjectInvitation.useMutation();
@@ -76,6 +76,7 @@ const ProjectUserTable = () => {
                   <Td fontSize={{ base: "xs", md: "sm" }}>{member.role}</Td>
                   <Td textAlign="end">
                     {(member.userId === session?.user?.id || isAdmin) &&
+                      member.userId !== owner?.userId &&
                       member.userId !== selectedProject.personalProjectUserId && (
                         <ConditionallyEnable
                           checks={[

--- a/app/src/pages/api/stripe/webhook.ts
+++ b/app/src/pages/api/stripe/webhook.ts
@@ -58,7 +58,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         },
       });
 
-      await notifyAdminsAboutPayment(invoiceId, "SUCCESS");
+      await sendPaymentNotification(invoiceId, "SUCCESS");
 
       break;
 
@@ -75,7 +75,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         },
       });
 
-      await notifyAdminsAboutPayment(invoiceId, "FAILURE");
+      await sendPaymentNotification(invoiceId, "FAILURE");
 
       break;
 
@@ -92,7 +92,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         },
       });
 
-      await notifyAdminsAboutPayment(invoiceId, "FAILURE");
+      await sendPaymentNotification(invoiceId, "FAILURE");
 
       break;
     case "payment_intent.succeeded":
@@ -108,7 +108,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         },
       });
 
-      await notifyAdminsAboutPayment(invoiceId, "SUCCESS");
+      await sendPaymentNotification(invoiceId, "SUCCESS");
 
       break;
   }
@@ -118,7 +118,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
 export default handler;
 
-async function notifyAdminsAboutPayment(
+async function sendPaymentNotification(
   invoiceId: string | undefined,
   result: "SUCCESS" | "FAILURE",
 ) {

--- a/app/src/pages/api/stripe/webhook.ts
+++ b/app/src/pages/api/stripe/webhook.ts
@@ -3,9 +3,9 @@ import Stripe from "stripe";
 import { prisma } from "~/server/db";
 import { env } from "~/env.mjs";
 import { captureException } from "@sentry/node";
-import { sendToAdmins } from "~/server/emails/sendToAdmins";
 import { sendPaymentSuccessful } from "~/server/emails/sendPaymentSuccessful";
 import { sendPaymentFailed } from "~/server/emails/sendPaymentFailed";
+import { sendToOwner } from "~/server/emails/sendToOwner";
 
 const stripe = new Stripe(env.STRIPE_SECRET_KEY ?? "");
 const endpointSecret = env.STRIPE_WEBHOOK_SECRET ?? "";
@@ -136,7 +136,7 @@ async function notifyAdminsAboutPayment(
     });
 
     if (result === "SUCCESS") {
-      await sendToAdmins(invoice.projectId, (email: string) =>
+      await sendToOwner(invoice.projectId, (email: string) =>
         sendPaymentSuccessful(
           invoice.id,
           Number(invoice.amount),
@@ -150,7 +150,7 @@ async function notifyAdminsAboutPayment(
     }
 
     if (result === "FAILURE") {
-      await sendToAdmins(invoice.projectId, (email: string) =>
+      await sendToOwner(invoice.projectId, (email: string) =>
         sendPaymentFailed(
           invoice.id,
           Number(invoice.amount),

--- a/app/src/pages/p/[projectSlug]/settings/index.tsx
+++ b/app/src/pages/p/[projectSlug]/settings/index.tsx
@@ -122,7 +122,7 @@ export default function Settings() {
               </Box>
               <ConditionallyEnable
                 accessRequired="requireIsProjectAdmin"
-                accessDeniedText="Only admins can invite new members"
+                accessDeniedText="Only owners and admins can invite new members"
                 w="fit-content"
               >
                 <Button
@@ -151,7 +151,7 @@ export default function Settings() {
             <VStack alignItems="flex-start" w="full">
               <HStack>
                 <Subtitle fontSize="sm">Read/Write</Subtitle>
-                <InfoCircle tooltipText="Only available to project admins and members. Use this key to query models and record request logs." />
+                <InfoCircle tooltipText="Only available to project owners, admins and members. Use this key to query models and record request logs." />
               </HStack>
               <CopiableCode
                 code={

--- a/app/src/server/api/routers/projects.router.ts
+++ b/app/src/server/api/routers/projects.router.ts
@@ -241,7 +241,7 @@ export const projectsRouter = createTRPCRouter({
           data: {
             userId: ctx.session.user.id,
             projectId: newProjectId,
-            role: "ADMIN",
+            role: "OWNER",
           },
         }),
         prisma.apiKey.create({

--- a/app/src/server/api/routers/users.router.ts
+++ b/app/src/server/api/routers/users.router.ts
@@ -266,6 +266,20 @@ export const usersRouter = createTRPCRouter({
         await requireIsProjectAdmin(input.projectId, ctx);
       }
 
+      const owner = await prisma.projectUser.findFirst({
+        where: {
+          projectId: input.projectId,
+          role: "OWNER",
+        },
+      });
+
+      if (input.userId === owner?.userId) {
+        throw new TRPCError({
+          message: "You can't remove the owner of the project",
+          code: "FORBIDDEN",
+        });
+      }
+
       await prisma.projectUser.delete({
         where: {
           projectId_userId: {

--- a/app/src/server/emails/sendToOwner.ts
+++ b/app/src/server/emails/sendToOwner.ts
@@ -1,0 +1,21 @@
+import { prisma } from "../db";
+
+export async function sendToOwner(projectId: string, callback: (...args: any[]) => Promise<void>) {
+  const owner = await prisma.projectUser.findFirst({
+    where: {
+      projectId: projectId,
+      role: "OWNER",
+    },
+    select: {
+      user: {
+        select: {
+          email: true,
+        },
+      },
+    },
+  });
+
+  if (owner?.user.email) {
+    await callback(owner.user.email);
+  }
+}

--- a/app/src/server/scripts/backfillProjectOwners.ts
+++ b/app/src/server/scripts/backfillProjectOwners.ts
@@ -1,0 +1,28 @@
+import { prisma } from "../db";
+
+const projects = await prisma.project.findMany({});
+
+for (const project of projects) {
+  const owner = await prisma.projectUser.findFirst({
+    where: {
+      projectId: project.id,
+      role: "ADMIN",
+    },
+    orderBy: {
+      createdAt: "asc",
+    },
+  });
+  if (owner) {
+    await prisma.projectUser.update({
+      where: {
+        projectId_userId: {
+          projectId: project.id,
+          userId: owner.userId,
+        },
+      },
+      data: {
+        role: "OWNER",
+      },
+    });
+  }
+}

--- a/app/src/server/scripts/sendInvoiceEmailToExistingClients.ts
+++ b/app/src/server/scripts/sendInvoiceEmailToExistingClients.ts
@@ -1,6 +1,6 @@
 import { prisma } from "../db";
 import { sendInvoiceNotificationWithoutRequiredPayment } from "../emails/sendInvoiceNotificationWithoutRequiredPayment";
-import { sendToAdmins } from "../emails/sendToAdmins";
+import { sendToOwner } from "../emails/sendToOwner";
 
 console.log("Doing: sending emiails");
 
@@ -28,7 +28,7 @@ for (const creditAdjustment of creditAdjustments) {
     invoice &&
     (invoice.status === "PENDING" || Number(creditAdjustment.amount) > -100)
   ) {
-    await sendToAdmins(invoice.projectId, (email: string) =>
+    await sendToOwner(invoice.projectId, (email: string) =>
       sendInvoiceNotificationWithoutRequiredPayment(
         invoice.id,
         Number(invoice.amount),

--- a/app/src/server/tasks/generateInvoices.task.ts
+++ b/app/src/server/tasks/generateInvoices.task.ts
@@ -10,8 +10,8 @@ import { sql } from "kysely";
 import { calculateSpendingsWithCredits } from "~/utils/billing";
 import { getStats } from "../api/routers/usage.router";
 import { chargeInvoice } from "./chargeInvoices.task";
-import { sendToAdmins } from "../emails/sendToAdmins";
 import { sendInvoiceNotificationWithoutRequiredPayment } from "../emails/sendInvoiceNotificationWithoutRequiredPayment";
+import { sendToOwner } from "../emails/sendToOwner";
 
 export const generateInvoices = defineTask({
   id: "generateInvoices",
@@ -29,7 +29,7 @@ export const generateInvoices = defineTask({
 
       //Send success email if a user spent credits but does not have to pay.
       if (data && data.creditsUsed > 0 && Number(data.invoice.amount) <= 1) {
-        await sendToAdmins(data.invoice.projectId, (email: string) =>
+        await sendToOwner(data.invoice.projectId, (email: string) =>
           sendInvoiceNotificationWithoutRequiredPayment(
             data.invoice.id,
             Number(data.invoice.amount),

--- a/app/src/server/utils/userProject.ts
+++ b/app/src/server/utils/userProject.ts
@@ -12,7 +12,7 @@ export default async function userProject(userId: string) {
       projectUsers: {
         create: {
           userId: userId,
-          role: "ADMIN",
+          role: "OWNER",
         },
       },
       apiKeys: {

--- a/app/src/types/kysely-codegen.types.ts
+++ b/app/src/types/kysely-codegen.types.ts
@@ -335,7 +335,7 @@ export interface Project {
 
 export interface ProjectUser {
   id: string;
-  role: "ADMIN" | "MEMBER" | "VIEWER";
+  role: "ADMIN" | "MEMBER" | "OWNER" | "VIEWER";
   projectId: string;
   userId: string;
   createdAt: Generated<Timestamp>;
@@ -408,7 +408,7 @@ export interface UserInvitation {
   id: string;
   projectId: string;
   email: string;
-  role: "ADMIN" | "MEMBER" | "VIEWER";
+  role: "ADMIN" | "MEMBER" | "OWNER" | "VIEWER";
   invitationToken: string;
   senderId: string;
   createdAt: Generated<Timestamp>;


### PR DESCRIPTION
Added a migration that adds the `OWNER` ProjectUserRole.
Added a script to backfill project owners: `pnpm tsx src/server/scripts/backfillProjectOwners.ts`
Ownership cannot be transferred to another user. The owner cannot be removed from a project. The owner has the same permission as an admin and shares the same access control function `requireIsProjectAdmin`.

+Added permission for superadmins to view all projects.