### PR TITLE
Evaluate view changed

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -165,12 +165,6 @@ const FormattedInputGridItem = ({
         bottom={expandable && !isExpanded ? `${VERTICAL_PADDING}px` : "auto"}
       >
         <FormattedDatasetEntryInput messages={entry.messages} />
-        <Text color="gray.500">
-          <Text as="span" fontWeight="bold">
-            ID:
-          </Text>{" "}
-          {entry.id}
-        </Text>
       </VStack>
       {expandable && (
         <VStack position="absolute" top={0} w="full" spacing={0}>


### PR DESCRIPTION
Task:
Current behavior:
In the evaluation table, we make each row as tall as the tallest output. To condense long inputs into this shorter space, we show the beginning of the input log, along with a button to expand it.

Changes:
Instead of showing the beginning of long inputs by default, we should show the end of them. The last message in an input is more likely to be different and relevant to the final output than the first one, which is often a system message.

We should continue collapsing and expanding inputs, but we should cap the max height to some reasonable amount, perhaps max(600px, height_of_tallest_output). If an input is taller than our max height, it should be scrollable.

Inputs that are not expanded should not be scrollable.

Previous UI:
![prev](https://github.com/OpenPipe/OpenPipe/assets/28661894/26709296-8c99-43f3-a2c9-0e81c71402c8)

Current UI:
![1](https://github.com/OpenPipe/OpenPipe/assets/28661894/f9fc9b79-57be-4fba-8345-d22ff4b8957b)
![2](https://github.com/OpenPipe/OpenPipe/assets/28661894/dc34fd77-8282-4c77-b6ee-3873ed797f17)
![3](https://github.com/OpenPipe/OpenPipe/assets/28661894/45665722-e256-4af9-a09d-18c47b2b6e46)