### PR TITLE
Disable the fine-tune button correctly

### DIFF
--- a/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/General/FineTuneButton.tsx
@@ -425,6 +425,7 @@ Controls the magnitude of updates to the model's parameters during training."
                   [!needsMissingBetaAccess, "Training this model requires beta access"],
                   [!needsMoreTrainingData, "At least 10 training entries are required"],
                   [!!modelSlug, "Add a Model ID"],
+                  [price.data?.cost !== undefined, "Price is being calculated"],
                 ]}
               >
                 <Button
@@ -432,7 +433,6 @@ Controls the magnitude of updates to the model's parameters during training."
                   onClick={createFineTune}
                   isLoading={creationInProgress}
                   minW={24}
-                  isDisabled={price.isLoading || price.data?.calculating}
                 >
                   Start Training
                 </Button>


### PR DESCRIPTION
Because we were setting the `isDisabled` prop explicitly, the checks in `ConditionallyEnable` were being bypassed, and users could attempt (and fail) to create fine-tunes in bad states like eg. trying to fine-tune GPT-3.5 without an API key.