### PR TITLE
Explicitly specify role order

### DIFF
--- a/app/src/server/api/routers/projects.router.ts
+++ b/app/src/server/api/routers/projects.router.ts
@@ -118,8 +118,16 @@ export const projectsRouter = createTRPCRouter({
               .innerJoin("User as u", "u.id", "pu.userId")
               .select(["pu.createdAt", "pu.role", "u.id as userId", "u.name", "u.email"])
               .whereRef("pu.projectId", "=", "p.id")
-              // Take advantage of fact that ADMIN is alphabetically before MEMBER and VIEWER
-              .orderBy("pu.role", "asc")
+              .orderBy(
+                sql`CASE pu.role
+              WHEN 'OWNER' THEN 1
+              WHEN 'ADMIN' THEN 2
+              WHEN 'MEMBER' THEN 3
+              WHEN 'VIEWER' THEN 4
+              ELSE 5
+            END`,
+                "asc",
+              )
               .orderBy("pu.createdAt", "asc"),
           ).as("projectUsers"),
           jsonArrayFrom(


### PR DESCRIPTION
With the addition of project owners, we can no longer rely on alphabetical ordering to properly sort project roles.