### PR TITLE
Fireworks rate limiting

### DIFF
--- a/app/prisma/migrations/20240221070339_add_rate_limiting/migration.sql
+++ b/app/prisma/migrations/20240221070339_add_rate_limiting/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "RateLimit" (
+    "key" TEXT NOT NULL,
+    "tokens" INTEGER NOT NULL,
+    "allowed" BOOLEAN NOT NULL,
+    "lastUpdated" TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT "RateLimit_pkey" PRIMARY KEY ("key")
+);

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -723,3 +723,11 @@ model ExportWeightsRequest {
 
     createdAt DateTime @default(now())
 }
+
+model RateLimit {
+    key         String   @id
+    tokens      Int
+    // Whether the current request is allowed. Has to be a separate variable to track state.
+    allowed     Boolean
+    lastUpdated DateTime @db.Timestamptz
+}

--- a/app/scripts/repl.ts
+++ b/app/scripts/repl.ts
@@ -7,5 +7,19 @@ import { generateBlobDownloadUrl } from "~/utils/azure/server";
 import { trainFineTune } from "~/server/tasks/fineTuning/trainFineTune.task";
 
 import crypto from "crypto";
+import { startTestJobs } from "~/server/utils/startTestJobs";
+import { fireworksTestSetLimit } from "~/utils/rateLimits";
 
-console.log(crypto.randomBytes(48).toString("base64url"));
+const model = await prisma.fineTune.findUniqueOrThrow({
+  where: {
+    id: "b501e7c7-b4d6-49a8-9c93-f4d57e607345",
+  },
+});
+
+await prisma.fineTuneTestingEntry.deleteMany({
+  where: {
+    modelId: model.id,
+  },
+});
+
+await startTestJobs(model.datasetId, model.id);

--- a/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
+++ b/app/src/components/datasets/DatasetContentTabs/Evaluation/EvaluationTable/EvaluationRow.tsx
@@ -255,6 +255,9 @@ const FormattedOutputGridItem = ({
 
 export const FormattedOutput = ({ entry, preferJson }: { entry: FTEntry; preferJson: boolean }) => {
   if (entry.errorMessage) {
+    if (entry.errorMessage === "Pending") {
+      return <Text color="gray.500">Pending</Text>;
+    }
     return <Text color="red.500">{entry.errorMessage}</Text>;
   }
 

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -212,8 +212,7 @@ export const generateTestSetEntry = defineTask<GenerateTestSetEntryJob>({
           await prisma.fineTuneTestingEntry.update({
             where: { modelId_datasetEntryId: { modelId, datasetEntryId } },
             data: {
-              errorMessage:
-                "Pausing completion processing to avoid rate limiting, will retry soon.",
+              errorMessage: "Pending",
             },
           });
         } else {

--- a/app/src/server/tasks/generateTestSetEntry.task.ts
+++ b/app/src/server/tasks/generateTestSetEntry.task.ts
@@ -20,6 +20,8 @@ import {
 import { getOpenaiCompletion } from "../utils/openai";
 import defineTask from "./defineTask";
 import { queueHeadToHeadEvalJobsForTestingEntry } from "./evaluateTestSetEntries.task";
+import { RateLimitError } from "openai";
+import { fireworksTestSetLimit } from "~/utils/rateLimits";
 
 export type GenerateTestSetEntryJob = {
   modelId: string;
@@ -147,12 +149,18 @@ export const generateTestSetEntry = defineTask<GenerateTestSetEntryJob>({
         if (isComparisonModel(modelId)) {
           completion = await getOpenaiCompletion(rawDatasetEntry.dataset.projectId, input);
         } else if (fineTune) {
-          // Need to add more rate limiting for Fireworks
-          if (fineTune.baseModel === "mistralai/Mixtral-8x7B-Instruct-v0.1") {
-            throw new Error(
-              "Test set completions for Mixtral-8x7B-Instruct-v0.1 are temporarily paused and will be restored soon (Feb 20, 2024).",
+          if (
+            fineTune.baseModel === "mistralai/Mixtral-8x7B-Instruct-v0.1" &&
+            !(await fireworksTestSetLimit())
+          ) {
+            throw new RateLimitError(
+              429,
+              { error: "Completion rate limit exceeded" },
+              "Completion rate limit exceeded",
+              {},
             );
           }
+
           completion = await getCompletion(fineTune, input);
         } else {
           await prisma.fineTuneTestingEntry.update({
@@ -200,14 +208,24 @@ export const generateTestSetEntry = defineTask<GenerateTestSetEntryJob>({
 
         await triggerEvals(datasetEntry, updatedFineTuneTestingEntry);
       } catch (e: unknown) {
-        const typedError = e as { message?: string; error?: { message: string } };
-        await prisma.fineTuneTestingEntry.update({
-          where: { modelId_datasetEntryId: { modelId, datasetEntryId } },
-          data: {
-            errorMessage:
-              typedError.message ?? typedError.error?.message ?? "Error retrieving completion",
-          },
-        });
+        if (e instanceof RateLimitError) {
+          await prisma.fineTuneTestingEntry.update({
+            where: { modelId_datasetEntryId: { modelId, datasetEntryId } },
+            data: {
+              errorMessage:
+                "Pausing completion processing to avoid rate limiting, will retry soon.",
+            },
+          });
+        } else {
+          const typedError = e as { message?: string; error?: { message: string } };
+          await prisma.fineTuneTestingEntry.update({
+            where: { modelId_datasetEntryId: { modelId, datasetEntryId } },
+            data: {
+              errorMessage:
+                typedError.message ?? typedError.error?.message ?? "Error retrieving completion",
+            },
+          });
+        }
         throw e;
       }
     } catch (e) {

--- a/app/src/types/kysely-codegen.types.ts
+++ b/app/src/types/kysely-codegen.types.ts
@@ -358,6 +358,12 @@ export interface PruningRuleMatch {
   datasetEntryId: string;
 }
 
+export interface RateLimit {
+  key: string;
+  tokens: number;
+  lastUpdated: Timestamp;
+}
+
 export interface RelabelRequest {
   id: string;
   batchId: string;
@@ -450,6 +456,7 @@ export interface DB {
   ProjectUser: ProjectUser;
   PruningRule: PruningRule;
   PruningRuleMatch: PruningRuleMatch;
+  RateLimit: RateLimit;
   RelabelRequest: RelabelRequest;
   Session: Session;
   UsageLog: UsageLog;

--- a/app/src/utils/errorHandling/standardResponses.ts
+++ b/app/src/utils/errorHandling/standardResponses.ts
@@ -1,4 +1,4 @@
-import { z, ZodTypeAny } from "zod";
+import { z, type ZodTypeAny } from "zod";
 
 export function error(message: string): { status: "error"; message: string } {
   return {

--- a/app/src/utils/rateLimits.test.ts
+++ b/app/src/utils/rateLimits.test.ts
@@ -47,7 +47,7 @@ describe("rateLimit", () => {
     expect(result).toBe(true);
   });
 
-  it.only("calls the fireworksTestSetLimit function", async () => {
+  it("calls the fireworksTestSetLimit function", async () => {
     const result = await fireworksTestSetLimit();
     expect(result).toBe(true);
   });

--- a/app/src/utils/rateLimits.test.ts
+++ b/app/src/utils/rateLimits.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { fireworksTestSetLimit, rateLimit } from "./rateLimits";
+import { sleep } from "~/server/utils/sleep";
+
+const rateLimitConfig = {
+  capacity: 5, // Allow 5 requests
+  fillRate: 1, // 1 token added per second
+};
+
+describe("rateLimit", () => {
+  it("allows requests under capacity", async () => {
+    const key = Math.random().toString();
+    let result = true;
+    // Perform 4 requests, which should all be allowed
+    for (let i = 0; i < 4; i++) {
+      result = result && (await rateLimit(key, rateLimitConfig));
+    }
+    expect(result).toBe(true);
+  });
+
+  it("blocks requests over capacity", async () => {
+    const key = Math.random().toString();
+    let result = true;
+    // Perform 6 requests, the last one should be blocked
+    for (let i = 0; i < 6; i++) {
+      result = await rateLimit(key, rateLimitConfig);
+    }
+    expect(result).toBe(false);
+  });
+
+  it("resets capacity after 1 second due to fill rate", async () => {
+    const key = Math.random().toString();
+    // Use up the capacity
+    for (let i = 0; i < 5; i++) {
+      expect(await rateLimit(key, rateLimitConfig)).toBe(true);
+    }
+
+    // Try one more request, which should be blocked
+    const blockedResult = await rateLimit(key, rateLimitConfig);
+    expect(blockedResult).toBe(false);
+
+    await rateLimit(key, rateLimitConfig);
+
+    // Wait for 1 second to allow the bucket to refill
+    await sleep(1000);
+    const result = await rateLimit(key, rateLimitConfig);
+    expect(result).toBe(true);
+  });
+
+  it.only("calls the fireworksTestSetLimit function", async () => {
+    const result = await fireworksTestSetLimit();
+    expect(result).toBe(true);
+  });
+});

--- a/app/src/utils/rateLimits.ts
+++ b/app/src/utils/rateLimits.ts
@@ -17,11 +17,10 @@ export const rateLimit = async (key: string, config: RateLimitConfig): Promise<b
     on conflict (key) do update set
       tokens = greatest(0, ${currentTokenCount} - 1),
       allowed = round(${currentTokenCount}) > 0,
-      "lastUpdated" = now()
+      "lastUpdated" = case when ${currentTokenCount} > 0 then now() else "RateLimit"."lastUpdated" end
     returning allowed, tokens as "tokensLeft";
   `;
   const result = await query.execute(kysely);
-  console.log(result.rows[0]);
 
   return result.rows[0]?.allowed ?? false;
 };

--- a/app/src/utils/rateLimits.ts
+++ b/app/src/utils/rateLimits.ts
@@ -1,0 +1,32 @@
+import { sql } from "kysely";
+import { kysely } from "~/server/db";
+
+type RateLimitConfig = {
+  capacity: number; // Maximum tokens in the bucket
+  fillRate: number; // Tokens added to the bucket per second
+};
+
+export const rateLimit = async (key: string, config: RateLimitConfig): Promise<boolean> => {
+  const tokensToAdd = sql`((extract(epoch from now()) - extract(epoch from "RateLimit"."lastUpdated")) * ${config.fillRate})`;
+
+  const currentTokenCount = sql`least(${config.capacity}, "RateLimit".tokens + ${tokensToAdd})`;
+
+  const query = sql<{ allowed: boolean; tokensLeft: number }>`
+    insert into "RateLimit"(key, tokens, allowed, "lastUpdated")
+    values (${key}, ${config.capacity} - 1, true, now())
+    on conflict (key) do update set
+      tokens = greatest(0, ${currentTokenCount} - 1),
+      allowed = round(${currentTokenCount}) > 0,
+      "lastUpdated" = now()
+    returning allowed, tokens as "tokensLeft";
+  `;
+  const result = await query.execute(kysely);
+  console.log(result.rows[0]);
+
+  return result.rows[0]?.allowed ?? false;
+};
+
+// Example usage with simplified rate limit configuration
+// Allow up to 50 bursty requests with a fill rate of 10 tokens per second
+export const fireworksTestSetLimit = () =>
+  rateLimit("fireworksTestSet", { capacity: 30, fillRate: 10 });


### PR DESCRIPTION
Ensure we never send more than 30 requests to Fireworks as part of evals at once, and that we send requests at a maximum rate of 10 rps.

Also adds a general `rateLimit` abstraction that we may be able to reuse for similar types of soft limits in the future. It uses the token bucket strategy -- leaky bucket would probably be a better fit semantically, but would require some pretty major changes to the way we queue/process background jobs so decided to just go with the simple approach instead.