### PR TITLE
[WIP] Setup new Auth0 provider for easy local development login

### DIFF
--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -114,7 +114,11 @@ const NavSidebar = () => {
               as={ChakraLink}
               justifyContent="start"
               onClick={() => {
-                signIn("github").catch(console.error);
+                if (process.env.NODE_ENV === "development") {
+                  signIn("auth0").catch(console.error);
+                } else {
+                  signIn("github").catch(console.error);
+                }
               }}
             >
               <Icon as={BsPersonCircle} boxSize={6} mr={2} />
@@ -196,7 +200,11 @@ export default function AppShell({
 
   useEffect(() => {
     if (requireAuth && user === null && !authLoading) {
-      signIn("github").catch(console.error);
+      if (process.env.NODE_ENV === "development") {
+        signIn("auth0").catch(console.error);
+      } else {
+        signIn("github").catch(console.error);
+      }
     }
   }, [requireAuth, user, authLoading]);
 

--- a/app/src/env.mjs
+++ b/app/src/env.mjs
@@ -62,6 +62,11 @@ export const env = createEnv({
     STRIPE_WEBHOOK_SECRET: z.string().optional(),
     AWS_ACCESS_KEY_ID: z.string().optional(),
     AWS_SECRET_ACCESS_KEY: z.string().optional(),
+    AUTH0_SECRET: z.string().default("placeholder"),
+    AUTH0_BASE_URL: z.string().default("placeholder"),
+    AUTH0_ISSUER_BASE_URL: z.string().default("placeholder"),
+    AUTH0_CLIENT_ID: z.string().default("placeholder"),
+    AUTH0_CLIENT_SECRET: z.string().default("placeholder"),
   },
 
   /**
@@ -127,6 +132,11 @@ export const env = createEnv({
     STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
     AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    AUTH0_SECRET: process.env.AUTH0_SECRET,
+    AUTH0_BASE_URL: process.env.AUTH0_BASE_URL,
+    AUTH0_ISSUER_BASE_URL: process.env.AUTH0_ISSUER_BASE_URL,
+    AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
+    AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.

--- a/app/src/pages/account/signin.tsx
+++ b/app/src/pages/account/signin.tsx
@@ -11,7 +11,11 @@ export default function SignIn() {
     if (session) {
       router.push("/").catch(console.error);
     } else if (session === null) {
-      signIn("github").catch(console.error);
+      if (process.env.NODE_ENV === "development") {
+        signIn("auth0").catch(console.error);
+      } else {
+        signIn("github").catch(console.error);
+      }
     }
   }, [session, router]);
 


### PR DESCRIPTION
This PR sets up a simple Auth0 provider with a free dev instance of an Auth0 app. Users can locally login with Auth0 by entering the credentials

email : dev@example.com
password : Test#1234

Alternatively a user can also Sign Up as a new user and that flow would also work out of the box.

Note : I still have to update the Readme and the `.env` file with the credentials for Auth0 when we create a new Auth0 application for this. 
