### PR TITLE
Tags pg insertion fix

### DIFF
--- a/app/src/utils/recordRequest.ts
+++ b/app/src/utils/recordRequest.ts
@@ -220,7 +220,9 @@ export const recordLoggedCall = async ({
     throw new Error(`Failed to create logged call: ${(e as Error).message}`);
   }
 
-  await createTags(projectId, newLoggedCallId, tags);
+  if (Object.keys(tags).length > 0) {
+    await createTags(projectId, newLoggedCallId, tags);
+  }
 };
 
 async function createTags(projectId: string, loggedCallId: string, tags: Record<string, string>) {


### PR DESCRIPTION
We’re constantly getting syntax errors when inserting into the “LoggedCallTag” table.

Theory: a user sends incorrect `tags` json.

When a user sends a request with incorrect `tags`, for example, "headers: {"op-tags": '{"1"}'}", we catch this error and return it to a user. But still, we try to insert an empty tags array into a db, getting this error.