### PR TITLE
Add maintenance banner

### DIFF
--- a/app/src/components/MaintenanceBanner.tsx
+++ b/app/src/components/MaintenanceBanner.tsx
@@ -1,0 +1,25 @@
+import { HStack, Icon, Text } from "@chakra-ui/react";
+import { FaWrench } from "react-icons/fa";
+
+const MaintenanceBanner = () => (
+  <HStack
+    w="full"
+    bgColor="white"
+    px={8}
+    py={2}
+    borderBottomWidth={1}
+    borderColor="gray.300"
+    justifyContent="space-between"
+    position="sticky"
+    zIndex={10}
+  >
+    <Icon as={FaWrench} color="orange.400" />
+    <Text fontWeight="500">
+      Some features are currently disabled for scheduled maintenance. Inference requests to your
+      fine-tuned models will not be affected.
+    </Text>
+    <Icon as={FaWrench} color="orange.400" />
+  </HStack>
+);
+
+export default MaintenanceBanner;

--- a/app/src/components/nav/AppShell.tsx
+++ b/app/src/components/nav/AppShell.tsx
@@ -30,6 +30,8 @@ import { BetaModal } from "../BetaModal";
 import { useIsMissingBetaAccess, useSelectedProject } from "~/utils/hooks";
 import { useAppStore } from "~/state/store";
 import { useAccessCheck } from "../ConditionallyEnable";
+import { env } from "~/env.mjs";
+import MaintenanceBanner from "../MaintenanceBanner";
 
 const Divider = (props: BoxProps) => <Box h="1px" bgColor="gray.300" w="full" {...props} />;
 
@@ -223,8 +225,18 @@ export default function AppShell({
         <Head>
           <title>{title ? `${title} | OpenPipe` : "OpenPipe"}</title>
         </Head>
+
         <NavSidebar />
-        <Box h="100%" flex={1} overflowY="auto" bgColor="gray.50" {...containerProps}>
+        <Box
+          position="relative"
+          h="100%"
+          flex={1}
+          overflowY="auto"
+          bgColor="gray.50"
+          {...containerProps}
+        >
+          {env.NEXT_PUBLIC_MAINTENANCE_MODE && <MaintenanceBanner />}
+
           {children}
         </Box>
       </Flex>

--- a/app/src/env.mjs
+++ b/app/src/env.mjs
@@ -75,8 +75,10 @@ export const env = createEnv({
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
     NEXT_PUBLIC_DEPLOY_ENV: z.string().default("development"),
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
-    NEXT_PUBLIC_MAINTENANCE_MODE: z.string().optional()
-    .transform((val) => val?.toLowerCase() === "true"),
+    NEXT_PUBLIC_MAINTENANCE_MODE: z
+      .string()
+      .optional()
+      .transform((val) => val?.toLowerCase() === "true"),
   },
 
   /**

--- a/app/src/env.mjs
+++ b/app/src/env.mjs
@@ -75,6 +75,8 @@ export const env = createEnv({
     NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
     NEXT_PUBLIC_DEPLOY_ENV: z.string().default("development"),
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
+    NEXT_PUBLIC_MAINTENANCE_MODE: z.string().optional()
+    .transform((val) => val?.toLowerCase() === "true"),
   },
 
   /**
@@ -127,6 +129,7 @@ export const env = createEnv({
     STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET,
     AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    NEXT_PUBLIC_MAINTENANCE_MODE: process.env.NEXT_PUBLIC_MAINTENANCE_MODE,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.

--- a/app/src/pages/p/[projectSlug]/request-logs/index.tsx
+++ b/app/src/pages/p/[projectSlug]/request-logs/index.tsx
@@ -29,7 +29,7 @@ export default function LoggedCalls() {
 
   return (
     <AppShell title="Request Logs" requireAuth>
-      <Box h="100vh" overflowY="scroll">
+      <Box>
         <VStack px={8} py={8} alignItems="flex-start" spacing={4} w="full">
           <HStack>
             <Text fontSize="2xl" fontWeight="bold">


### PR DESCRIPTION
While running data migrations that disable some features, it's useful to show a banner to users so that they know the site is in maintenance mode.

Banner:
<img width="1510" alt="Screenshot 2024-02-27 at 12 46 42 PM" src="https://github.com/OpenPipe/OpenPipe/assets/41524992/d811be33-eee2-4cb1-b956-83b3d8f07e91">

