### PR TITLE
export weights 7 days fix

### DIFF
--- a/app/src/server/api/routers/fineTunes/exportWeights.ts
+++ b/app/src/server/api/routers/fineTunes/exportWeights.ts
@@ -43,6 +43,8 @@ export const requestExportWeights = protectedProcedure
       where: {
         fineTuneId: input.fineTuneId,
         userId: ctx.session.user.id,
+        // only in the last 7 days
+        createdAt: { gte: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7) },
       },
     });
 


### PR DESCRIPTION
Allow export again in 7 days after the file link has expired.