### PR TITLE
Tool call and content streaming

### DIFF
--- a/app/src/modelProviders/fine-tuned/getAnyscaleCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getAnyscaleCompletion.ts
@@ -12,7 +12,10 @@ import OpenAI from "openai";
 import { type TypedFineTune } from "~/types/dbColumns.types";
 import { deserializeChatOutput, serializeChatInput } from "./serializers";
 import { env } from "~/env.mjs";
-import { Transform } from "stream";
+import {
+  generateOpenAiFunctionCallId,
+  transformStreamToolCallToOpenAIFormat,
+} from "./streamTransformerToOpenAIFormat";
 
 const deployments = ["a100", "a10"] as const;
 
@@ -64,12 +67,6 @@ export async function getAnyscaleCompletion(
     );
   }
 
-  // if ((input.functions || input.tools) && input.stream) {
-  //   throw new Error(
-  //     `We don't currently support streaming for function calls. Please open an issue if you need this functionality! https://github.com/openpipe/openpipe`,
-  //   );
-  // }
-
   const serializedInput = serializeChatInput(input, fineTune);
   const templatedPrompt = `### Instruction:\n${serializedInput}\n\n### Response:\n`;
 
@@ -86,13 +83,8 @@ export async function getAnyscaleCompletion(
     // for await (const chunk of resp) {
     //   console.log(chunk.choices);
     // }
-    // return resp;
-    // return transformStream(resp, input.model);
-    if (input.tools?.length ?? 0 > 0) {
-      return transformStreamToolCall(resp, input.model);
-    } else {
-      return transformStream(resp, input.model);
-    }
+
+    return transformStreamToolCallToOpenAIFormat(resp, input);
   }
 
   const convertToFunctions = (input.functions?.length ?? 0) > 0;
@@ -114,124 +106,4 @@ export async function getAnyscaleCompletion(
     choices,
     usage: resp.usage,
   };
-}
-
-function transformStream(
-  originalStream: Stream<ChatCompletionChunk>,
-  model: string,
-): Stream<ChatCompletionChunk> {
-  const controller = new AbortController();
-
-  async function* iterator() {
-    for await (const chunk of originalStream) {
-      console.log(chunk.choices[0].delta);
-      yield transformChunk(chunk, model);
-    }
-  }
-
-  return new Stream(iterator, controller);
-}
-
-function transformChunk(chunk: any, model: string) {
-  return {
-    id: chunk.id,
-    object: "chat.completion.chunk",
-    created: chunk.created,
-    model,
-    choices: chunk.choices,
-    usage: chunk.usage,
-  } as ChatCompletionChunk;
-}
-
-function transformStreamToolCall(
-  originalStream: Stream<any>,
-  model: string,
-): Stream<ChatCompletionChunk> {
-  const controller = new AbortController();
-
-  async function* iterator() {
-    let buffer = "";
-    let inArguments = false;
-
-    for await (const chunk of originalStream) {
-      console.log(chunk.choices[0]);
-
-      const transformedChunk = transformChunkToolCall(chunk, buffer, inArguments);
-
-      buffer = transformedChunk.buffer;
-      inArguments = transformedChunk.inArguments;
-
-      if (transformedChunk.toolCall || chunk.usage) {
-        yield {
-          id: chunk.id,
-          object: "chat.completion.chunk",
-          created: chunk.created,
-          model,
-          choices: [
-            {
-              delta: { tool_calls: [transformedChunk.toolCall] },
-              index: 0,
-              finish_reason: chunk.usage ? "tool_calls" : null,
-              logprobs: null,
-            },
-          ],
-          usage: chunk.usage ?? null,
-        } as ChatCompletionChunk;
-      }
-    }
-  }
-
-  return new Stream(iterator, controller);
-}
-
-const FUNCTION_CALL_TAG = "<function>";
-const FUNCTION_ARGS_TAG = "<arguments>";
-
-function transformChunkToolCall(chunk: any, buffer: string, inArguments: boolean) {
-  buffer += chunk.choices[0]?.delta.content ?? "";
-  let functionNameToYield: string = "";
-  let argumentsToYeld: string = "";
-
-  if (!inArguments && buffer.includes(FUNCTION_CALL_TAG)) {
-    // Getting a function name by waits untill the buffer has a values like: <function>get_current_weather<arguments>
-    const startIndex = buffer.lastIndexOf(FUNCTION_CALL_TAG) + FUNCTION_CALL_TAG.length;
-    const endIndex = buffer.indexOf(FUNCTION_ARGS_TAG, startIndex);
-    if (endIndex !== -1) {
-      functionNameToYield = buffer.substring(startIndex, endIndex).trim();
-      buffer = buffer.substring(endIndex + FUNCTION_ARGS_TAG.length);
-      inArguments = true; // The next iteration will not check for function names, just yield the arguments
-    }
-  } else if (inArguments) {
-    if (buffer.startsWith("<")) {
-      // New function call detected, reset
-      inArguments = false;
-    } else {
-      argumentsToYeld = buffer;
-      buffer = "";
-    }
-  }
-
-  let toolCall;
-  if (functionNameToYield) {
-    toolCall = {
-      index: 0,
-      id: "",
-      type: "function",
-      function: {
-        name: functionNameToYield,
-        arguments: argumentsToYeld,
-      },
-    };
-
-    functionNameToYield = "";
-  } else if (argumentsToYeld) {
-    toolCall = {
-      index: 0,
-      function: {
-        arguments: argumentsToYeld,
-      },
-    };
-  }
-
-  return { buffer, inArguments, toolCall };
 }

--- a/app/src/modelProviders/fine-tuned/getAnyscaleCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getAnyscaleCompletion.ts
@@ -12,6 +12,7 @@ import OpenAI from "openai";
 import { type TypedFineTune } from "~/types/dbColumns.types";
 import { deserializeChatOutput, serializeChatInput } from "./serializers";
 import { env } from "~/env.mjs";
+import { Transform } from "stream";
 
 const deployments = ["a100", "a10"] as const;
 
@@ -63,11 +64,11 @@ export async function getAnyscaleCompletion(
     );
   }
 
-  if ((input.functions || input.tools) && input.stream) {
-    throw new Error(
-      `We don't currently support streaming for function calls. Please open an issue if you need this functionality! https://github.com/openpipe/openpipe`,
-    );
-  }
+  // if ((input.functions || input.tools) && input.stream) {
+  //   throw new Error(
+  //     `We don't currently support streaming for function calls. Please open an issue if you need this functionality! https://github.com/openpipe/openpipe`,
+  //   );
+  // }
 
   const serializedInput = serializeChatInput(input, fineTune);
   const templatedPrompt = `### Instruction:\n${serializedInput}\n\n### Response:\n`;
@@ -82,7 +83,16 @@ export async function getAnyscaleCompletion(
   });
 
   if (resp instanceof Stream) {
-    return transformStream(resp, input.model);
+    // for await (const chunk of resp) {
+    //   console.log(chunk.choices);
+    // }
+    // return resp;
+    // return transformStream(resp, input.model);
+    if (input.tools?.length ?? 0 > 0) {
+      return transformStreamToolCall(resp, input.model);
+    } else {
+      return transformStream(resp, input.model);
+    }
   }
 
   const convertToFunctions = (input.functions?.length ?? 0) > 0;
@@ -130,4 +140,96 @@ function transformChunk(chunk: any, model: string) {
     choices: chunk.choices,
     usage: chunk.usage,
   } as ChatCompletionChunk;
+}
+
+function transformStreamToolCall(
+  originalStream: Stream<any>,
+  model: string,
+): Stream<ChatCompletionChunk> {
+  const controller = new AbortController();
+
+  async function* iterator() {
+    let buffer = "";
+    let inArguments = false;
+
+    for await (const chunk of originalStream) {
+      const transformedChunk = transformChunkToolCall(chunk, buffer, inArguments);
+
+      buffer = transformedChunk.buffer;
+      inArguments = transformedChunk.inArguments;
+
+      if (transformedChunk.toolCall || chunk.usage) {
+        yield {
+          id: "chunk.id",
+          object: "chat.completion.chunk",
+          created: chunk.created,
+          model,
+          choices: [
+            {
+              delta: { tool_calls: [transformedChunk.toolCall] },
+              index: 0,
+              finish_reason: "stop",
+              logprobs: null,
+            },
+          ],
+          usage: chunk.usage ?? null,
+        } as ChatCompletionChunk;
+      }
+    }
+  }
+
+  return new Stream(iterator, controller);
+}
+
+const FUNCTION_CALL_TAG = "<function>";
+const FUNCTION_ARGS_TAG = "<arguments>";
+
+function transformChunkToolCall(chunk: any, buffer: string, inArguments: boolean) {
+  buffer += chunk.choices[0]?.delta.content ?? "";
+  console.log(buffer);
+  let functionNameToYield: string = "";
+  let argumentsToYeld: string = "";
+
+  if (!inArguments && buffer.includes(FUNCTION_CALL_TAG)) {
+    // Getting a function name by waits untill the buffer has a values like: <function>get_current_weather<arguments>
+    const startIndex = buffer.lastIndexOf(FUNCTION_CALL_TAG) + FUNCTION_CALL_TAG.length;
+    const endIndex = buffer.indexOf(FUNCTION_ARGS_TAG, startIndex);
+    if (endIndex !== -1) {
+      functionNameToYield = buffer.substring(startIndex, endIndex).trim();
+      buffer = buffer.substring(endIndex + FUNCTION_ARGS_TAG.length);
+      inArguments = true; // The next iteration will not check for function names, just yield the arguments
+    }
+  } else if (inArguments) {
+    if (buffer.startsWith("<")) {
+      // New function call detected, reset
+      inArguments = false;
+    } else {
+      argumentsToYeld = buffer;
+      buffer = "";
+    }
+  }
+
+  let toolCall;
+  if (functionNameToYield) {
+    toolCall = {
+      index: 0,
+      id: "",
+      type: "function",
+      function: {
+        name: functionNameToYield,
+        arguments: argumentsToYeld,
+      },
+    };
+
+    functionNameToYield = "";
+  } else if (argumentsToYeld) {
+    toolCall = {
+      index: 0,
+      function: {
+        arguments: argumentsToYeld,
+      },
+    };
+  }
+
+  return { buffer, inArguments, toolCall };
 }

--- a/app/src/modelProviders/fine-tuned/getAnyscaleCompletion.ts
+++ b/app/src/modelProviders/fine-tuned/getAnyscaleCompletion.ts
@@ -14,7 +14,7 @@ import { deserializeChatOutput, serializeChatInput } from "./serializers";
 import { env } from "~/env.mjs";
 import {
   constructOpenAIChunk,
-  transformStreamToOpenAIFormat,
+  transformToolCallStreamToOpenAIFormat,
 } from "./streamTransformerToOpenAIFormat";
 
 const deployments = ["a100", "a10"] as const;
@@ -87,7 +87,7 @@ export async function getAnyscaleCompletion(
 
   if (resp instanceof Stream) {
     if (input.tools) {
-      return transformStreamToOpenAIFormat(resp, input);
+      return transformToolCallStreamToOpenAIFormat(resp, input);
     } else {
       const controller = new AbortController();
 

--- a/app/src/modelProviders/fine-tuned/streamTransformerToOpenAIFormat.ts
+++ b/app/src/modelProviders/fine-tuned/streamTransformerToOpenAIFormat.ts
@@ -1,0 +1,204 @@
+import { v4 as uuidv4 } from "uuid";
+import type {
+  ChatCompletion,
+  ChatCompletionChunk,
+  ChatCompletionCreateParams,
+  ChatCompletionCreateParamsNonStreaming,
+  ChatCompletionCreateParamsStreaming,
+} from "openai/resources/chat";
+import { Stream } from "openai/streaming";
+import OpenAI from "openai";
+
+import { type TypedFineTune } from "~/types/dbColumns.types";
+import { deserializeChatOutput, serializeChatInput } from "./serializers";
+import { env } from "~/env.mjs";
+
+const FUNCTION_CALL_TAG = "<function>";
+const FUNCTION_ARGS_TAG = "<arguments>";
+
+export function transformChunk(chunk: any, input: ChatCompletionCreateParams) {
+  // console.log(chunk);
+  const transformedChunk = {
+    id: chunk.id,
+    object: "chat.completion.chunk",
+    created: chunk.created,
+    model: input.model,
+    choices: chunk.choices,
+    usage: chunk.usage,
+  } as ChatCompletionChunk;
+
+  // OpenAI returns a "tool_calls" finish_reason when we pass tools in the input, even if the response was a regular content.
+  if (transformedChunk.choices?.[0]?.finish_reason === "stop" && input.tools?.length) {
+    transformedChunk.choices[0].finish_reason = "tool_calls";
+  }
+
+  return transformedChunk;
+}
+
+export function transformStreamToolCallToOpenAIFormat(
+  originalStream: Stream<any>,
+  input: ChatCompletionCreateParams,
+): Stream<ChatCompletionChunk> {
+  const controller = new AbortController();
+
+  async function* iterator() {
+    let buffer = "";
+    let inArguments = false;
+    let functionIndex = 0; // The index of the function in the tool_calls array
+    let functionId = generateOpenAiFunctionCallId(); // The index of the function in the tool_calls array
+    let role: null | string = null;
+    let call: "CONTENT" | "TOOL" | "UNKNOWN" = "UNKNOWN";
+
+    for await (const chunk of originalStream) {
+      if (chunk.choices[0].delta.role) {
+        role = chunk.choices[0].delta.role;
+      }
+      // console.log(chunk.choices[0].delta.role);
+      if (call === "UNKNOWN") {
+        buffer += chunk.choices[0]?.delta.content ?? "";
+      }
+      // Wait for at least 5 characters in the buffer before deciding if it's a tool call stream
+      if (call === "UNKNOWN" && buffer.trim().length >= 5) {
+        call = buffer.trim().startsWith(FUNCTION_CALL_TAG.substring(0, 5)) ? "TOOL" : "CONTENT";
+        buffer = buffer.slice(0, -chunk.choices[0]?.delta.content.length) ?? ""; // Remove the last chunk from the buffer
+
+        if (call === "CONTENT") {
+          // Yield role as the first chunk
+          if (role) {
+            yield {
+              id: chunk.id,
+              object: "chat.completion.chunk",
+              created: chunk.created,
+              model: input.model,
+              choices: [
+                {
+                  delta: { role, content: "" },
+                  index: 0,
+                  finish_reason: null,
+                  logprobs: null,
+                },
+              ],
+              usage: null,
+            } as ChatCompletionChunk;
+            role = null;
+          }
+          // Yield the accumulated buffer as a first chunk after a role
+          yield transformChunk(
+            {
+              ...chunk,
+              choices: [
+                {
+                  ...chunk.choices[0],
+                  delta: { ...chunk.choices[0].delta, content: buffer },
+                },
+              ],
+            },
+            input,
+          );
+          buffer = "";
+        }
+      }
+
+      if (call === "TOOL") {
+        const transformedChunk = transformChunkToolCallToOpenAIFormat(
+          chunk,
+          buffer,
+          inArguments,
+          functionIndex,
+          functionId,
+        );
+        buffer = transformedChunk.buffer;
+        inArguments = transformedChunk.inArguments;
+        functionIndex = transformedChunk.functionIndex;
+        functionId = transformedChunk.functionId;
+
+        if (transformedChunk.toolCall || chunk.usage) {
+          yield {
+            id: chunk.id,
+            object: "chat.completion.chunk",
+            created: chunk.created,
+            model: input.model,
+            choices: [
+              {
+                delta: {
+                  ...(role && { role }),
+                  tool_calls: [transformedChunk.toolCall],
+                },
+                index: 0,
+                finish_reason: chunk.usage ? "tool_calls" : null,
+                logprobs: null,
+              },
+            ],
+            usage: chunk.usage ?? null,
+          } as ChatCompletionChunk;
+          role = null;
+        }
+      } else if (call === "CONTENT") {
+        yield transformChunk(chunk, input);
+      }
+    }
+  }
+
+  return new Stream(iterator, controller);
+}
+
+export function transformChunkToolCallToOpenAIFormat(
+  chunk: any,
+  buffer: string,
+  inArguments: boolean,
+  functionIndex: number,
+  functionId: string,
+) {
+  buffer += chunk.choices[0]?.delta.content ?? "";
+  let functionNameToYield: string = "";
+  let argumentsToYeld: string = "";
+
+  if (!inArguments && buffer.includes(FUNCTION_CALL_TAG)) {
+    // Getting a function name by waits untill the buffer has a values like: <function>get_current_weather<arguments>
+    const startIndex = buffer.lastIndexOf(FUNCTION_CALL_TAG) + FUNCTION_CALL_TAG.length;
+    const endIndex = buffer.indexOf(FUNCTION_ARGS_TAG, startIndex);
+    if (endIndex !== -1) {
+      functionNameToYield = buffer.substring(startIndex, endIndex).trim();
+      buffer = buffer.substring(endIndex + FUNCTION_ARGS_TAG.length);
+      inArguments = true; // The next iteration will not check for function names, just yield the arguments
+    }
+  } else if (inArguments) {
+    if (buffer.startsWith("<")) {
+      // New function call detected, reset
+      inArguments = false;
+      functionIndex++;
+      functionId = generateOpenAiFunctionCallId();
+    } else {
+      argumentsToYeld = buffer;
+      buffer = "";
+    }
+  }
+
+  let toolCall;
+  if (functionNameToYield) {
+    toolCall = {
+      index: functionIndex,
+      id: functionId,
+      type: "function",
+      function: {
+        name: functionNameToYield,
+        arguments: argumentsToYeld,
+      },
+    };
+
+    functionNameToYield = "";
+  } else if (argumentsToYeld) {
+    toolCall = {
+      index: 0,
+      function: {
+        arguments: argumentsToYeld,
+      },
+    };
+  }
+
+  return { buffer, inArguments, functionIndex, functionId, toolCall };
+}
+
+export function generateOpenAiFunctionCallId(): string {
+  return "call_" + Array.from({ length: 24 }, () => Math.random().toString(36)[2]).join("");
+}

--- a/app/src/modelProviders/fine-tuned/streamTransformerToOpenAIFormat.ts
+++ b/app/src/modelProviders/fine-tuned/streamTransformerToOpenAIFormat.ts
@@ -7,6 +7,11 @@ const FUNCTION_ARGS_TAG = "<arguments>";
 
 export type ChatCompletionChunkWithUsage = ChatCompletionChunk & { usage?: CompletionUsage };
 
+/**
+ * This function checks the stream, defines if it is a regular text response or tool call, and returns the correct OpenAI compatable stream.
+ * We need this custom logic because Fine-tuned models return tool calls as a regular text completion.
+ * In this case we need to deserialize the content transforming "<function>func_name<arguments>args" into a tool_calls object.
+ */
 export function transformStreamToOpenAIFormat(
   originalStream: Stream<any>,
   input: ChatCompletionCreateParams,
@@ -205,7 +210,7 @@ export function constructOpenAIChunk(chunk: any, input: ChatCompletionCreatePara
 }
 
 export function constructOpenAITollCallChoices(chunk: any, delta: any) {
-  return chunk.choices.map((choice: any) => ({
+  return chunk.choices.map(() => ({
     delta,
     index: 0,
     finish_reason: chunk.usage ? "tool_calls" : null,

--- a/client-libs/typescript/src/openai/http.test.ts
+++ b/client-libs/typescript/src/openai/http.test.ts
@@ -103,25 +103,3 @@ test("bad tags", async () => {
   const error = await response.json();
   expect(error.message).toMatch(/Failed to parse tags/);
 });
-
-function validateOpenAIChunkSignature(chunk: any) {
-  expect(chunk).toHaveProperty("id");
-  expect(chunk.object).toEqual("chat.completion.chunk");
-  expect(chunk).toHaveProperty("created");
-  expect(chunk).toHaveProperty("model");
-  expect(chunk).toHaveProperty("choices");
-  expect(Array.isArray(chunk.choices)).toBeTruthy();
-  chunk.choices.forEach((choice: Record<string, any>) => {
-    expect(choice).toHaveProperty("index");
-    expect(choice).toHaveProperty("delta");
-    expect(choice).toHaveProperty("logprobs");
-    expect([
-      "stop",
-      "length",
-      "tool_calls",
-      "content_filter",
-      "function_call",
-      null,
-    ]).toContainEqual(choice.finish_reason);
-  });
-}

--- a/client-libs/typescript/src/openai/http.test.ts
+++ b/client-libs/typescript/src/openai/http.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "vitest";
 import { OPENPIPE_BASE_URL, OPENPIPE_API_KEY, OPENAI_API_KEY } from "../testConfig";
 import OpenAI from "openai";
+import { validateOpenAIChunkSignature } from "./index.test";
 
 const openai = new OpenAI({
   apiKey: OPENAI_API_KEY,

--- a/client-libs/typescript/src/openai/index.test.ts
+++ b/client-libs/typescript/src/openai/index.test.ts
@@ -690,3 +690,107 @@ test("ft content call unusual tags", async () => {
     expect(lastLogged?.tags).toMatchObject(expectedTags);
   }
 }, 100000);
+
+test.only("ft tool call streaming", async () => {
+  const payload: ChatCompletionCreateParams = {
+    // model: "openpipe:test-tool-calls-mixtral-p3",
+    model: "openpipe:test-tool-calls-mistral-p3",
+    // model: "gpt-3.5-turbo",
+    messages: [{ role: "system", content: "What is the weather in Seattle?" }],
+    tools: [
+      {
+        type: "function",
+        function: functionBody,
+      },
+    ],
+    n: 1,
+    stream: true,
+  };
+  const completion = await oaiClient.chat.completions.create({
+    ...payload,
+    openpipe: {
+      tags: { promptId: "tool call streaming" },
+    },
+  });
+
+  let merged: ChatCompletion | null = null;
+  let isFirstChunk = true;
+  let isFirstFunctionChunk = true;
+
+  for await (const chunk of completion) {
+    console.log(chunk.choices[0]?.delta.tool_calls);
+    validateOpenAIChunkSignature(chunk);
+
+    if (isFirstChunk) {
+      validateOpenAIToolCallDeltaFirstChunkSignature(chunk.choices[0]?.delta);
+      isFirstChunk = false;
+    }
+
+    if (chunk.choices[0]?.delta?.tool_calls) {
+      validateOpenAIToolCallDeltaSignature(chunk.choices[0]?.delta, isFirstFunctionChunk);
+      isFirstFunctionChunk = false;
+    }
+
+    merged = mergeChunks(merged, chunk);
+  }
+
+  await completion.openpipe?.reportingFinished;
+
+  await sleep(100);
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+  }
+}, 200000);
+
+function validateOpenAIChunkSignature(chunk: any) {
+  expect(chunk).toHaveProperty("id");
+  expect(chunk.object).toEqual("chat.completion.chunk");
+  expect(chunk).toHaveProperty("created");
+  expect(chunk).toHaveProperty("model");
+  expect(chunk).toHaveProperty("choices");
+  expect(Array.isArray(chunk.choices)).toBeTruthy();
+  chunk.choices.forEach((choice: Record<string, any>) => {
+    expect(choice).toHaveProperty("index");
+    expect(choice).toHaveProperty("delta");
+    expect(choice).toHaveProperty("logprobs");
+    expect([
+      "stop",
+      "length",
+      "tool_calls",
+      "content_filter",
+      "function_call",
+      null,
+    ]).toContainEqual(choice.finish_reason);
+  });
+}
+
+function validateOpenAIToolCallDeltaFirstChunkSignature(chunk: any) {
+  expect(chunk).toHaveProperty("role");
+  expect(chunk).toHaveProperty("content");
+}
+
+function validateOpenAIToolCallDeltaSignature(chunk: any, isFirst: boolean) {
+  expect(chunk).toHaveProperty("tool_calls");
+  if (isFirst) {
+    expect(Array.isArray(chunk.tool_calls)).toBe(true);
+    chunk.tool_calls.forEach((call: any) => {
+      expect(call).toHaveProperty("index");
+      expect(call).toHaveProperty("id");
+      expect(typeof call.id).toBe("string");
+      expect(call).toHaveProperty("type");
+      expect(call.type).toBe("function");
+      expect(call).toHaveProperty("function");
+      expect(typeof call.function).toBe("object");
+    });
+  } else {
+    chunk.tool_calls.forEach((call: any) => {
+      expect(call).toHaveProperty("index");
+      expect(call).toHaveProperty("function");
+      expect(typeof call.function).toBe("object");
+      expect(call.function).toHaveProperty("arguments");
+      expect(typeof call.function.arguments).toBe("string");
+    });
+  }
+}

--- a/client-libs/typescript/src/openai/stream.test.ts
+++ b/client-libs/typescript/src/openai/stream.test.ts
@@ -1,0 +1,96 @@
+import dotenv from "dotenv";
+import { expect, test } from "vitest";
+import BaseOpenAI, { APIError } from "openai";
+import { sleep } from "openai/core";
+import type { ChatCompletion, ChatCompletionCreateParams } from "openai/resources/chat/completions";
+import assert from "assert";
+
+import OpenAI from "../openai";
+import { OPClient } from "../codegen";
+import mergeChunks from "./mergeChunks";
+import { getTags } from "../shared";
+import { OPENPIPE_API_KEY, OPENPIPE_BASE_URL, TEST_LAST_LOGGED } from "../testConfig";
+import { functionBody } from "../sharedTestInput";
+
+dotenv.config();
+
+const baseClient = new BaseOpenAI({
+  apiKey: OPENPIPE_API_KEY,
+  baseURL: OPENPIPE_BASE_URL,
+});
+
+const oaiClient = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  openpipe: {
+    apiKey: OPENPIPE_API_KEY,
+    baseUrl: OPENPIPE_BASE_URL,
+  },
+});
+
+const opClient = new OPClient({
+  BASE: OPENPIPE_BASE_URL,
+  TOKEN: OPENPIPE_API_KEY,
+});
+
+const lastLoggedCall = async () => opClient.default.localTestingOnlyGetLatestLoggedCall();
+
+const randomLetters = Math.random().toString(36).substring(7);
+
+test("simple ft tool call", async () => {
+  const payload: ChatCompletionCreateParams = {
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "system", content: "tell me the weather in SF and Orlando" }],
+    tools: [
+      {
+        type: "function",
+        function: functionBody,
+      },
+    ],
+  };
+  const completion = await oaiClient.chat.completions.create(payload);
+  console.log(completion.choices[0].message);
+  await sleep(100);
+  await completion.openpipe?.reportingFinished;
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+    expect(completion).toMatchObject(lastLogged?.respPayload);
+  }
+}, 100000);
+
+test.only("tool call streaming", async () => {
+  const payload: ChatCompletionCreateParams = {
+    model: "openpipe:test-tool-calls-mistral-p3",
+    // model: "gpt-3.5-turbo",
+    messages: [{ role: "system", content: "Tell me the weather in SF and Orlando" }],
+    tools: [
+      {
+        type: "function",
+        function: functionBody,
+      },
+    ],
+    stream: true,
+  };
+  const completion = await oaiClient.chat.completions.create({
+    ...payload,
+    openpipe: {
+      tags: { promptId: "tool call streaming" },
+    },
+  });
+
+  let merged: ChatCompletion | null = null;
+  for await (const chunk of completion) {
+    console.log(chunk.choices[0].delta.tool_calls);
+
+    merged = mergeChunks(merged, chunk);
+  }
+
+  await completion.openpipe?.reportingFinished;
+
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
+  }
+});

--- a/client-libs/typescript/src/openai/stream.test.ts
+++ b/client-libs/typescript/src/openai/stream.test.ts
@@ -84,15 +84,17 @@ test("content streaming", async () => {
 
 test.only("tool call streaming", async () => {
   const payload: ChatCompletionCreateParams = {
-    model: "openpipe:test-tool-calls-mistral-p3-uni",
+    model: "openpipe:pink-mirrors-hang",
+    // model: "openpipe:test-tool-calls-mistral-p3-uni",
     // model: "gpt-3.5-turbo",
-    messages: [{ role: "system", content: "Weather in SF and NY." }],
+    messages: [{ role: "system", content: "Weather in Seattle" }],
     tools: [
       {
         type: "function",
         function: functionBody,
       },
     ],
+    n: 1,
     stream: true,
   };
   const completion = await oaiClient.chat.completions.create({
@@ -107,7 +109,7 @@ test.only("tool call streaming", async () => {
   let isFirstFunctionChunk = true;
 
   for await (const chunk of completion) {
-    console.log(chunk.choices[0]?.delta);
+    console.log(chunk.choices[0]?.delta.tool_calls);
     validateOpenAIChunkSignature(chunk);
 
     if (isFirstChunk) {
@@ -156,8 +158,8 @@ function validateOpenAIChunkSignature(chunk: any) {
 }
 
 function validateOpenAIToolCallDeltaFirstChunkSignature(chunk: any) {
-  expect(chunk).toHaveProperty("role");
-  expect(chunk).toHaveProperty("content");
+  //   expect(chunk).toHaveProperty("role");
+  //   expect(chunk).toHaveProperty("content");
 }
 
 function validateOpenAIToolCallDeltaSignature(chunk: any, isFirst: boolean) {

--- a/client-libs/typescript/src/openai/stream.test.ts
+++ b/client-libs/typescript/src/openai/stream.test.ts
@@ -59,11 +59,34 @@ test("simple ft tool call", async () => {
   }
 }, 100000);
 
+test("content streaming", async () => {
+  const completion = await oaiClient.chat.completions.create({
+    model: "openpipe:test-content-mistral-p3",
+    messages: [{ role: "system", content: "count to 3" }],
+    stream: true,
+  });
+
+  let merged: ChatCompletion | null = null;
+  for await (const chunk of completion) {
+    console.log(chunk.choices[0]?.delta);
+    merged = mergeChunks(merged, chunk);
+  }
+
+  await completion.openpipe?.reportingFinished;
+  if (TEST_LAST_LOGGED) {
+    const lastLogged = await lastLoggedCall();
+    expect(merged).toMatchObject(lastLogged?.respPayload);
+    expect(lastLogged?.reqPayload.messages).toMatchObject([
+      { role: "system", content: "count to 3" },
+    ]);
+  }
+});
+
 test.only("tool call streaming", async () => {
   const payload: ChatCompletionCreateParams = {
-    model: "openpipe:test-tool-calls-mistral-p3",
+    model: "openpipe:test-tool-calls-mistral-p3-uni",
     // model: "gpt-3.5-turbo",
-    messages: [{ role: "system", content: "Tell me the weather in SF and Orlando" }],
+    messages: [{ role: "system", content: "Weather in SF and NY." }],
     tools: [
       {
         type: "function",
@@ -80,17 +103,83 @@ test.only("tool call streaming", async () => {
   });
 
   let merged: ChatCompletion | null = null;
+  let isFirstChunk = true;
+  let isFirstFunctionChunk = true;
+
   for await (const chunk of completion) {
-    console.log(chunk.choices[0].delta.tool_calls);
+    console.log(chunk.choices[0]?.delta);
+    validateOpenAIChunkSignature(chunk);
+
+    if (isFirstChunk) {
+      validateOpenAIToolCallDeltaFirstChunkSignature(chunk.choices[0]?.delta);
+      isFirstChunk = false;
+    }
+
+    if (chunk.choices[0]?.delta?.tool_calls) {
+      validateOpenAIToolCallDeltaSignature(chunk.choices[0]?.delta, isFirstFunctionChunk);
+      isFirstFunctionChunk = false;
+    }
 
     merged = mergeChunks(merged, chunk);
   }
 
   await completion.openpipe?.reportingFinished;
 
+  await sleep(100);
   if (TEST_LAST_LOGGED) {
     const lastLogged = await lastLoggedCall();
     expect(merged).toMatchObject(lastLogged?.respPayload);
     expect(lastLogged?.reqPayload.messages).toMatchObject(payload.messages);
   }
-});
+}, 200000);
+
+function validateOpenAIChunkSignature(chunk: any) {
+  expect(chunk).toHaveProperty("id");
+  expect(chunk.object).toEqual("chat.completion.chunk");
+  expect(chunk).toHaveProperty("created");
+  expect(chunk).toHaveProperty("model");
+  expect(chunk).toHaveProperty("choices");
+  expect(Array.isArray(chunk.choices)).toBeTruthy();
+  chunk.choices.forEach((choice: Record<string, any>) => {
+    expect(choice).toHaveProperty("index");
+    expect(choice).toHaveProperty("delta");
+    expect(choice).toHaveProperty("logprobs");
+    expect([
+      "stop",
+      "length",
+      "tool_calls",
+      "content_filter",
+      "function_call",
+      null,
+    ]).toContainEqual(choice.finish_reason);
+  });
+}
+
+function validateOpenAIToolCallDeltaFirstChunkSignature(chunk: any) {
+  expect(chunk).toHaveProperty("role");
+  expect(chunk).toHaveProperty("content");
+}
+
+function validateOpenAIToolCallDeltaSignature(chunk: any, isFirst: boolean) {
+  expect(chunk).toHaveProperty("tool_calls");
+  if (isFirst) {
+    expect(Array.isArray(chunk.tool_calls)).toBe(true);
+    chunk.tool_calls.forEach((call: any) => {
+      expect(call).toHaveProperty("index");
+      expect(call).toHaveProperty("id");
+      expect(typeof call.id).toBe("string");
+      expect(call).toHaveProperty("type");
+      expect(call.type).toBe("function");
+      expect(call).toHaveProperty("function");
+      expect(typeof call.function).toBe("object");
+    });
+  } else {
+    chunk.tool_calls.forEach((call: any) => {
+      expect(call).toHaveProperty("index");
+      expect(call).toHaveProperty("function");
+      expect(typeof call.function).toBe("object");
+      expect(call.function).toHaveProperty("arguments");
+      expect(typeof call.function.arguments).toBe("string");
+    });
+  }
+}


### PR DESCRIPTION
It adds support for tool streaming for both providers.

It checks if a user used any `tools` in its input. If yes - a function determines if it is a tool call response or a regular text completion making the necessary deserialization and conversion to OpenAI format.

Test cases include a new `openpipe:test-tool-calls-mixtral-p3` model to test Fireworks.

The code is hard to read, it probably requires some refactoring, but it works.