### PR TITLE
Account for non-round numbers of imported logs

### DIFF
--- a/app/src/components/requestLogs/AddToDatasetButton.tsx
+++ b/app/src/components/requestLogs/AddToDatasetButton.tsx
@@ -35,6 +35,7 @@ import { useRouter } from "next/router";
 import { useFilters, constructFiltersQueryParams } from "../Filters/useFilters";
 import { DATASET_GENERAL_TAB_KEY } from "../datasets/DatasetContentTabs/DatasetContentTabs";
 import { GeneralFiltersDefaultFields } from "~/types/shared.types";
+import { useDateFilter } from "../Filters/useDateFilter";
 
 const AddToDatasetButton = () => {
   const totalNumLogsSelected = useTotalNumLogsSelected();
@@ -62,6 +63,7 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
   const deselectedLogIds = useAppStore((s) => s.selectedLogs.deselectedLogIds);
   const defaultToSelected = useAppStore((s) => s.selectedLogs.defaultToSelected);
   const resetLogSelection = useAppStore((s) => s.selectedLogs.resetLogSelection);
+  const dateFilters = useDateFilter().filters;
   const filters = useFilters().filters;
 
   const totalNumLogsSelected = useTotalNumLogsSelected();
@@ -110,7 +112,7 @@ const AddToDatasetModal = ({ disclosure }: { disclosure: UseDisclosureReturn }) 
       deselectedLogIds: Array.from(deselectedLogIds),
       defaultToSelected,
       sampleSize,
-      filters,
+      filters: [...dateFilters, ...filters],
       ...datasetParams,
     });
 

--- a/app/src/server/api/routers/nodeEntries.router.ts
+++ b/app/src/server/api/routers/nodeEntries.router.ts
@@ -274,8 +274,7 @@ export const nodeEntriesRouter = createTRPCRouter({
       })
         .select(["lc.id", "lc.reqPayload", "lc.respPayload", "lc.inputTokens", "lc.outputTokens"])
         .orderBy(sql`random()`)
-        // Account for 1% incorrectly formatted logs
-        .limit(Math.ceil(input.sampleSize * 1.01))
+        .limit(input.sampleSize)
         .execute();
 
       if (!loggedCalls.length) {
@@ -315,7 +314,7 @@ export const nodeEntriesRouter = createTRPCRouter({
         await prepareDatasetEntriesForImport({
           projectId,
           dataChannelId: preparedArchiveCreation.archiveInputChannelId,
-          entriesToImport: rowsToConvert.slice(0, input.sampleSize),
+          entriesToImport: rowsToConvert,
         });
 
       // Ensure dataset and dataset entries are created atomically

--- a/app/src/server/api/routers/nodeEntries.router.ts
+++ b/app/src/server/api/routers/nodeEntries.router.ts
@@ -275,7 +275,7 @@ export const nodeEntriesRouter = createTRPCRouter({
         .select(["lc.id", "lc.reqPayload", "lc.respPayload", "lc.inputTokens", "lc.outputTokens"])
         .orderBy(sql`random()`)
         // Account for 1% incorrectly formatted logs
-        .limit(input.sampleSize * 1.01)
+        .limit(Math.ceil(input.sampleSize * 1.01))
         .execute();
 
       if (!loggedCalls.length) {


### PR DESCRIPTION
This fixes a bug caused by increasing the number of request logs to analyze before importing by 1%. When tested with numbers of logged calls that are not multiples of 100, multiplying the number of calls to retrieve from the database by 1.01 results in a non-integer number, which sql doesn't know how to handle.

I'm okay with removing the logic for processing spare logs until we validate that non-testing projects contain invalid logs.