### PR TITLE
Properly count model test entries

### DIFF
--- a/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
+++ b/app/src/components/fineTunes/FineTuneContentTabs/General/General.tsx
@@ -59,7 +59,7 @@ const General = () => {
             </HStack>
             <HStack>
               <Text w={180}>Test Set Size</Text>
-              <Text color="gray.500">{fineTune.numTestingEntries.toLocaleString()}</Text>
+              <Text color="gray.500">{fineTune.numTestEntries?.toLocaleString()}</Text>
             </HStack>
             <HStack>
               <Text w={180}>Test Set Performance</Text>


### PR DESCRIPTION
This is a holdover from when NodeEntry rows had `nodeId` values.