### PR TITLE
Put benchmarks behind an env variable

### DIFF
--- a/app/src/modelProviders/fine-tuned/benchmarkMModels.ts
+++ b/app/src/modelProviders/fine-tuned/benchmarkMModels.ts
@@ -24,6 +24,8 @@ export async function benchmarkMModels(
   fineTune: TypedFineTune,
   input: ChatCompletionCreateParamsNonStreaming,
 ): Promise<ChatCompletion> {
+  if (process.env.ENABLE_BENCHMARKING !== "true") return getAnyscaleCompletion(fineTune, input);
+
   const comparisonModelId = comparisonModels[fineTune.id];
 
   const comparisonModel =


### PR DESCRIPTION
Give us the option to turn it on/off without code deploys.