### PR TITLE
PK added to dataset entries

### DIFF
--- a/app/prisma/migrations/20240311202822_pk_added_to_dataset_entries/migration.sql
+++ b/app/prisma/migrations/20240311202822_pk_added_to_dataset_entries/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "DatasetEntryInput" ADD CONSTRAINT "DatasetEntryInput_pkey" PRIMARY KEY ("hash");
+
+-- AlterTable
+ALTER TABLE "DatasetEntryOutput" ADD CONSTRAINT "DatasetEntryOutput_pkey" PRIMARY KEY ("hash");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -807,7 +807,7 @@ model DatasetEntryInput {
     messages        Json   @default("[]")
     response_format Json?
     inputTokens     Int?
-    hash            String
+    hash            String @id
 
     projectId String  @db.Uuid
     project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
@@ -820,7 +820,7 @@ model DatasetEntryInput {
 
 model DatasetEntryOutput {
     output       Json
-    hash         String
+    hash         String @id
     outputTokens Int?
 
     projectId String  @db.Uuid


### PR DESCRIPTION
Amazon database migration tool uses primary keys to track records.