### PR TITLE
Database VPN access only

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -2,7 +2,7 @@ config:
   aws-native:region: us-west-2
   aws:region: us-west-2
   openpipe:ALLOWED_IP_LIST:
-    secure: AAABAD+vzw3ZeVmSKfVV59sxDVQ3u/FF+opCzoeEYyYyl5yLtte4JVmcUDK46mVqRg==
+    secure: AAABAKw5hqzBY3HqcuyLZ9w6HAkaM9pySePLdRZcU/E0oHoQjdrC2lk8bZM1E/trbqatrn/zFqZVFO31Mp0yHk22l/edPDtNVIta8b4Lm/TPPgUzFs0r9ON7OptKkf3rj/kx+Is0kwGQioA9pdyQyUFJ6KwIEtkZSv+DHnCrgAp7jfsW+XQda1v4braSK/qPatp3LNfSWUr71XSx0DHHhbH6we9RulmW3Om9vhMXpqLfyf7i7vX1JUlA4SwMrtQXYG+fiTby
   openpipe:ANYSCALE_ENABLE_A100: "true"
   openpipe:ANYSCALE_INFERENCE_API_KEY:
     secure: AAABAFPYf6OL5TLvPZUU+/jhzGYcIhxg3pwpmV+BQnegrMRYbQboxRi+Zb+on+KVGqLM/vDcvXeqs4zOesGbCCi4oAhIOgG2bR6T

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -1,6 +1,8 @@
 config:
   aws-native:region: us-west-2
   aws:region: us-west-2
+  openpipe:ALLOWED_IP_LIST:
+    secure: AAABAD+vzw3ZeVmSKfVV59sxDVQ3u/FF+opCzoeEYyYyl5yLtte4JVmcUDK46mVqRg==
   openpipe:ANYSCALE_ENABLE_A100: "true"
   openpipe:ANYSCALE_INFERENCE_API_KEY:
     secure: AAABAFPYf6OL5TLvPZUU+/jhzGYcIhxg3pwpmV+BQnegrMRYbQboxRi+Zb+on+KVGqLM/vDcvXeqs4zOesGbCCi4oAhIOgG2bR6T

--- a/infra/Pulumi.stage.yaml
+++ b/infra/Pulumi.stage.yaml
@@ -2,7 +2,7 @@ config:
   aws-native:region: us-west-2
   aws:region: us-west-2
   openpipe:ALLOWED_IP_LIST:
-    secure: AAABACCbWl8ASasm2juEsx3z/8oz72HtdWUteoHr4y3Oe274pCYntVaW1RecVDbPDg==
+    secure: AAABAGVz7ItXWBwDtP0kp0R0qyKvNUeuCZKE3AZcd5h4pswYxuCl1q4bTIaGcSqzg8oS1wolmBS5EoDHq4wgy/rWQCCRqgS681iqmAqP/VZyH9sQBj0a8angVk//lnEtbqEkbpO6w4tmVsvUkUCJDDsglKA25yhCPEXAEdPyXwW06xvImGr8X6pjg4C13heZihwlP/BglAiwe7hH64py8gitAarugQZewZ4J1qxSR4x9nOmauBNvB3guVdMWCBUojce0Y608
   openpipe:ANYSCALE_INFERENCE_API_KEY:
     secure: AAABAEkqA8a0Jud/Z2yjQXsRXwvmh54DwFWbDJarnNS3ZlhLpZdFO6pTwCW1EDlpY8nVSooHlmJZSZi5Y8tzwqpudYSt6lYYc8a4
   openpipe:ANYSCALE_INFERENCE_BASE_URL: https://inference-stage-c6qyl.cld-tskg84t9kb3cr8ud.s.anyscaleuserdata.com/v1

--- a/infra/Pulumi.stage.yaml
+++ b/infra/Pulumi.stage.yaml
@@ -1,6 +1,8 @@
 config:
   aws-native:region: us-west-2
   aws:region: us-west-2
+  openpipe:ALLOWED_IP_LIST:
+    secure: AAABACCbWl8ASasm2juEsx3z/8oz72HtdWUteoHr4y3Oe274pCYntVaW1RecVDbPDg==
   openpipe:ANYSCALE_INFERENCE_API_KEY:
     secure: AAABAEkqA8a0Jud/Z2yjQXsRXwvmh54DwFWbDJarnNS3ZlhLpZdFO6pTwCW1EDlpY8nVSooHlmJZSZi5Y8tzwqpudYSt6lYYc8a4
   openpipe:ANYSCALE_INFERENCE_BASE_URL: https://inference-stage-c6qyl.cld-tskg84t9kb3cr8ud.s.anyscaleuserdata.com/v1

--- a/infra/src/database.ts
+++ b/infra/src/database.ts
@@ -2,11 +2,20 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 import { nm } from "./helpers";
-import { vpc } from "./vpc";
+import { vpc, vpcCidrBlocks } from "./vpc";
+
+const cfg = new pulumi.Config();
 
 const dbSecurityGroup = new aws.ec2.SecurityGroup(nm("app-db"), {
   vpcId: vpc.vpcId,
-  ingress: [{ protocol: "tcp", fromPort: 5432, toPort: 5432, cidrBlocks: ["0.0.0.0/0"] }],
+  ingress: [
+    {
+      protocol: "tcp",
+      fromPort: 5432,
+      toPort: 5432,
+      cidrBlocks: [vpcCidrBlocks, cfg.require("ALLOWED_IP_LIST")],
+    },
+  ],
 });
 
 const dbSubnetGroup = new aws.rds.SubnetGroup(nm("app-db"), {
@@ -103,7 +112,7 @@ const dmsAssumeRole = aws.iam.getPolicyDocument({
 });
 const dms_access_for_endpoint = new aws.iam.Role(nm("dms-access-for-endpoint"), {
   assumeRolePolicy: dmsAssumeRole.then((dmsAssumeRole) => dmsAssumeRole.json),
-  name: nm("dms-access-for-endpoint"),
+  name: isProd ? "dms-access-for-endpoint" : nm("dms-access-for-endpoint"),
 });
 
 const dms_access_for_endpoint_AmazonDMSRedshiftS3Role = new aws.iam.RolePolicyAttachment(
@@ -116,7 +125,7 @@ const dms_access_for_endpoint_AmazonDMSRedshiftS3Role = new aws.iam.RolePolicyAt
 
 const dms_cloudwatch_logs_role = new aws.iam.Role(nm("dms-cloudwatch-logs-role"), {
   assumeRolePolicy: dmsAssumeRole.then((dmsAssumeRole) => dmsAssumeRole.json),
-  name: nm("dms-cloudwatch-logs-role"),
+  name: isProd ? "dms-cloudwatch-logs-role" : nm("dms-cloudwatch-logs-role"),
 });
 
 const dms_cloudwatch_logs_role_AmazonDMSCloudWatchLogsRole = new aws.iam.RolePolicyAttachment(

--- a/infra/src/database.ts
+++ b/infra/src/database.ts
@@ -5,6 +5,7 @@ import { nm } from "./helpers";
 import { vpc, vpcCidrBlocks } from "./vpc";
 
 const cfg = new pulumi.Config();
+const allowedListArray = cfg.require("ALLOWED_IP_LIST").split(",");
 
 const dbSecurityGroup = new aws.ec2.SecurityGroup(nm("app-db"), {
   vpcId: vpc.vpcId,
@@ -13,7 +14,7 @@ const dbSecurityGroup = new aws.ec2.SecurityGroup(nm("app-db"), {
       protocol: "tcp",
       fromPort: 5432,
       toPort: 5432,
-      cidrBlocks: [vpcCidrBlocks, cfg.require("ALLOWED_IP_LIST")],
+      cidrBlocks: [vpcCidrBlocks, ...allowedListArray],
     },
   ],
 });

--- a/infra/src/vpc.ts
+++ b/infra/src/vpc.ts
@@ -1,7 +1,9 @@
 import * as awsx from "@pulumi/awsx";
 import { nm } from "./helpers";
 
+export const vpcCidrBlocks = "10.0.0.0/16";
+
 export const vpc = new awsx.ec2.Vpc(nm("main"), {
   enableDnsHostnames: true,
-  cidrBlock: "10.0.0.0/16",
+  cidrBlock: vpcCidrBlocks,
 });


### PR DESCRIPTION
It allows inbound DB connection from the IPs of the:
- `cidrBlock: "10.0.0.0/16"` (internal VPC IPs)
- `ALLOWED_IP_LIST` secret string.

The ALLOWED_IP_LIST stores IPs as a string divided by a comma: `1.2.3.4/32,1.2.3.5/32`

Also changed some namings because it still failed to create the necessary roles.
