### PR TITLE
Add policy actions to deploy user

### DIFF
--- a/infra/src/deployUser.ts
+++ b/infra/src/deployUser.ts
@@ -46,6 +46,17 @@ const deployUserPolicy = new aws.iam.Policy(
           Effect: "Allow",
           Resource: "*",
         },
+        {
+          Action: [
+            // "iam:CreatePolicy",
+            "iam:GetPolicy",
+            // "iam:CreatePolicyVersion",
+            // "iam:ListPolicyVersions",
+            // "iam:DeletePolicyVersion",
+          ],
+          Effect: "Allow",
+          Resource: "*",
+        },
       ],
     }),
   },

--- a/infra/src/deployUser.ts
+++ b/infra/src/deployUser.ts
@@ -41,6 +41,11 @@ const deployUserPolicy = new aws.iam.Policy(
           Effect: "Allow",
           Resource: "*",
         },
+        {
+          Action: ["dms:DescribeReplicationTasks"],
+          Effect: "Allow",
+          Resource: "*",
+        },
       ],
     }),
   },


### PR DESCRIPTION
Addressing a new deployment error:
`creating IAM Policy (deploy-pl-prod): AccessDenied: User: deploy-pl-prod is not authorized to perform: iam:CreatePolicy  because no identity-based policy allows the iam:CreatePolicy action`