### PR TITLE
Save response format in imported row

### DIFF
--- a/app/src/server/utils/datasetEntryCreation/prepareDatasetEntriesForImport.ts
+++ b/app/src/server/utils/datasetEntryCreation/prepareDatasetEntriesForImport.ts
@@ -61,6 +61,7 @@ export const prepareDatasetEntriesForImport = async ({
       messages: messages as object[],
       tool_choice: tool_choice as object,
       tools: tools as object[],
+      response_format: row.input.response_format,
       hash: inputHash,
     });
 


### PR DESCRIPTION
Response format was previously being dropped in row imports (although included in the hash for a row).